### PR TITLE
fix(api): Update config service, add module

### DIFF
--- a/generators/api/src/config/files/src/index.ts__tmpl__
+++ b/generators/api/src/config/files/src/index.ts__tmpl__
@@ -1,3 +1,4 @@
+export * from './lib/config.module'
 export * from './lib/config.service'
 export * from './lib/configuration'
 export * from './lib/validation'

--- a/generators/api/src/config/files/src/lib/config.modules.ts__tmpl__
+++ b/generators/api/src/config/files/src/lib/config.modules.ts__tmpl__
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common'
+import { ConfigService } from './config.service'
+
+@Module({
+  providers: [ConfigService],
+  exports: [ConfigService],
+})
+export class ConfigModule {}

--- a/generators/api/src/config/files/src/lib/config.service.ts__tmpl__
+++ b/generators/api/src/config/files/src/lib/config.service.ts__tmpl__
@@ -1,10 +1,10 @@
 import { Injectable } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
+import { ConfigService as NestConfigService } from '@nestjs/config'
 import { CookieOptions } from 'express'
 
 @Injectable()
-export class ApiConfigService {
-  constructor(public readonly config: ConfigService) {}
+export class ConfigService {
+  constructor(public readonly config: NestConfigService) {}
 
   get apiUrl(): string {
     return this.config.getOrThrow<string>('apiUrl')


### PR DESCRIPTION
This pull request introduces a new `ConfigModule` and updates the `ConfigService` to align with NestJS conventions. The changes improve modularity and consistency within the configuration system.

### Modularization of configuration:

* [`generators/api/src/config/files/src/lib/config.modules.ts__tmpl__`](diffhunk://#diff-23fbb21f7ae0ab636f7cad67fd0241d95ca2905d97c18e47946fb0c3c1ec00a8R1-R8): Added a new `ConfigModule` that provides and exports the `ConfigService`, making it reusable across the application.

* [`generators/api/src/config/files/src/index.ts__tmpl__`](diffhunk://#diff-0cfbfbce459e14c1e359a19a139086f706c88ad36b548ff8b55eba8fa4c7c536R1): Exported the newly created `ConfigModule` along with other configuration-related modules to ensure they are accessible from the main entry point.

### Updates to `ConfigService`:

* [`generators/api/src/config/files/src/lib/config.service.ts__tmpl__`](diffhunk://#diff-19e23a0d46cb6b3ce68f117378153fe285e77ab8600722ba375939b3bded1e89L2-R7): Renamed `ApiConfigService` to `ConfigService` and updated its dependency to use `ConfigService` from `@nestjs/config` (aliased as `NestConfigService`) for better alignment with NestJS naming and conventions.