### PR TITLE
Remove duplicate generator path

### DIFF
--- a/generators/api/src/generate-crud/generator.ts
+++ b/generators/api/src/generate-crud/generator.ts
@@ -261,10 +261,9 @@ export async function generateCrudLogic(
   async function createLibraries(tree: Tree, name: string) {
     const dataAccessLibraryRoot = `libs/api/${name}/data-access`
     const featureLibraryRoot = `libs/api/${name}/feature`
-    const dataAccessTemplatePath = dependencies.joinPathFragments(__dirname, './files/data-access')
-    const featureTemplatePath = dependencies.joinPathFragments(__dirname, './files/feature')
-    await dependencies.apiLibraryGenerator(tree, { name }, dataAccessTemplatePath, 'data-access')
-    await dependencies.apiLibraryGenerator(tree, { name }, featureTemplatePath, 'feature')
+    const templatePath = dependencies.joinPathFragments(__dirname, './files')
+    await dependencies.apiLibraryGenerator(tree, { name }, templatePath, 'data-access')
+    await dependencies.apiLibraryGenerator(tree, { name }, templatePath, 'feature')
     return { dataAccessLibraryRoot, featureLibraryRoot }
   }
 


### PR DESCRIPTION
This pull request simplifies the logic for generating CRUD API libraries by consolidating template paths. The most important change is the unification of template paths used for generating `data-access` and `feature` libraries.

Code simplification:

* [`generators/api/src/generate-crud/generator.ts`](diffhunk://#diff-8a42808218d3bc2d1598ec19834184b6413e9e25501fa68053cb481fdd4ceb85L264-R266): Consolidated the `dataAccessTemplatePath` and `featureTemplatePath` into a single `templatePath`, reducing redundancy in the `createLibraries` function.