### PR TITLE
Jbh/generator service

### DIFF
--- a/generators/api/src/generate-crud/generator.ts
+++ b/generators/api/src/generate-crud/generator.ts
@@ -143,7 +143,7 @@ ${guardImports}
 
 @Resolver(() => ${model.modelName})
 export class Generated${model.modelName}Resolver {
-  constructor(private readonly service: ApiCrudDataAccessService) {}
+  constructor(private readonly generatedService: ApiCrudDataAccessService) {}
 
   @Query(() => [${model.modelName}], { nullable: true })
   ${readManyGuardDecorator ? `@UseGuards(${readManyGuardDecorator})` : ''}
@@ -153,7 +153,7 @@ export class Generated${model.modelName}Resolver {
     model.modelName
   }Input,
   ) {
-    return this.service.${readManyMethodName}(info, input)
+    return this.generatedService.${readManyMethodName}(info, input)
   }
 
   @Query(() => CorePaging, { nullable: true })
@@ -163,7 +163,7 @@ export class Generated${model.modelName}Resolver {
     model.modelName
   }Input,
   ) {
-    return this.service.${countMethodName}(input)
+    return this.generatedService.${countMethodName}(input)
   }
 
   @Query(() => ${model.modelName}, { nullable: true })
@@ -172,7 +172,7 @@ export class Generated${model.modelName}Resolver {
     @Info() info: GraphQLResolveInfo,
     @Args('${model.modelPropertyName}Id') ${model.modelPropertyName}Id: string
   ) {
-    return this.service.${readOneMethodName}(info, ${model.modelPropertyName}Id)
+    return this.generatedService.${readOneMethodName}(info, ${model.modelPropertyName}Id)
   }
 
   @Mutation(() => ${model.modelName}, { nullable: true })
@@ -181,7 +181,7 @@ export class Generated${model.modelName}Resolver {
     @Info() info: GraphQLResolveInfo,
     @Args('input') input: Create${model.modelName}Input,
   ) {
-    return this.service.create${model.modelName}(info, input)
+    return this.generatedService.create${model.modelName}(info, input)
   }
 
   @Mutation(() => ${model.modelName}, { nullable: true })
@@ -191,7 +191,7 @@ export class Generated${model.modelName}Resolver {
     @Args('${model.modelPropertyName}Id') ${model.modelPropertyName}Id: string,
     @Args('input') input: Update${model.modelName}Input,
   ) {
-    return this.service.update${model.modelName}(info, ${model.modelPropertyName}Id, input)
+    return this.generatedService.update${model.modelName}(info, ${model.modelPropertyName}Id, input)
   }
 
   @Mutation(() => ${model.modelName}, { nullable: true })
@@ -199,7 +199,7 @@ export class Generated${model.modelName}Resolver {
   delete${model.modelName}(
     @Args('${model.modelPropertyName}Id') ${model.modelPropertyName}Id: string,
   ) {
-    return this.service.delete${model.modelName}(${model.modelPropertyName}Id)
+    return this.generatedService.delete${model.modelName}(${model.modelPropertyName}Id)
   }
 }
 `


### PR DESCRIPTION
This pull request refactors the `Generated${model.modelName}Resolver` class. The changes focus on improving code consistency and reducing redundancy.

### Refactoring the `Generated${model.modelName}Resolver` class:

* Replaced all references to `this.service` with `this.generatedService` to align with the updated naming convention. This affects methods such as `${readManyMethodName}`, `${countMethodName}`, `${readOneMethodName}`, `create${model.modelName}`, `update${model.modelName}`, and `delete${model.modelName}`. [[1]](diffhunk://#diff-8a42808218d3bc2d1598ec19834184b6413e9e25501fa68053cb481fdd4ceb85L146-R146) [[2]](diffhunk://#diff-8a42808218d3bc2d1598ec19834184b6413e9e25501fa68053cb481fdd4ceb85L156-R156) [[3]](diffhunk://#diff-8a42808218d3bc2d1598ec19834184b6413e9e25501fa68053cb481fdd4ceb85L166-R166) [[4]](diffhunk://#diff-8a42808218d3bc2d1598ec19834184b6413e9e25501fa68053cb481fdd4ceb85L175-R175) [[5]](diffhunk://#diff-8a42808218d3bc2d1598ec19834184b6413e9e25501fa68053cb481fdd4ceb85L184-R184) [[6]](diffhunk://#diff-8a42808218d3bc2d1598ec19834184b6413e9e25501fa68053cb481fdd4ceb85L194-R202)
