### PR TITLE
fix(api): Fix crud generator to set relationships instead of connect …

### DIFF
--- a/generators/api/src/generate-crud/files/data-access/src/lib/api-crud-data-access.service.ts__tmpl__
+++ b/generators/api/src/generate-crud/files/data-access/src/lib/api-crud-data-access.service.ts__tmpl__
@@ -138,14 +138,14 @@ function generateRelationHandling(model, operation) {
     code += '        if (Array.isArray(ids)) {\n';
     code += `          data[key] = { ${operation === 'create' ? 'connect' : 'set'}: ids.map(id => ({ id })) };\n`;
     code += '        } else {\n';
-    code += '          data[key] = { connect: { id: ids } };\n';
+    code += `          data[key] = { ${operation === 'create' ? 'connect' : 'set'}: { id: ids } };\n`;
     code += '        }\n';
   } else if (hasListFields) {
     // Only list fields
     code += `        data[key] = { ${operation === 'create' ? 'connect' : 'set'}: ids.map(id => ({ id })) };\n`;
   } else {
     // Only single fields
-    code += '        data[key] = { connect: { id: ids } };\n';
+    code += `        data[key] = { ${operation === 'create' ? 'connect' : 'set'}: { id: ids } };\n`;
   }
   
   code += '      }\n';


### PR DESCRIPTION
This pull request updates the logic in the `generateRelationHandling` function to dynamically handle different CRUD operations (`create` and others) when setting relationships in the `data` object. The change ensures consistent behavior for both single and array-based fields.

Key changes:

* Updated the logic for single fields to use a dynamic operation (`connect` or `set`) based on the `operation` parameter, replacing the hardcoded `connect` operation. This ensures that the correct operation is applied for both `create` and other CRUD operations.…them on update