### PR TITLE
fix(forms): reverted to mutation actual form state, which is correct …

### DIFF
--- a/forms/src/lib/fields/select-field-multi-search-apollo.tsx
+++ b/forms/src/lib/fields/select-field-multi-search-apollo.tsx
@@ -74,9 +74,7 @@ export function SelectFieldMultiSearchApollo<TDataItem extends RequiredItemShape
   // Ensure the field has submit transformation for form submission
   // The Form component looks for field.options.submitTransform during submission
   // eslint-disable-next-line no-param-reassign
-  if (!field.options.submitTransform) {
-    field.options.submitTransform = multiSelectSubmitTransform
-  }
+  field.options.submitTransform ??= multiSelectSubmitTransform
   
   const { options, loading: apolloLoading, handleSearchChange } = useApolloSearch<TDataItem>(field.options)
 

--- a/forms/src/lib/fields/select-field-multi-search.tsx
+++ b/forms/src/lib/fields/select-field-multi-search.tsx
@@ -3,7 +3,6 @@ import { SearchSelectBase } from './search-select-base'
 import { SelectedItems, multiSelectDisplayValue } from './search-select-helpers'
 import { useFormTheme } from '../theme-context'
 import { multiSelectSubmitTransform } from './select-field-multi-search-apollo'
-import { useMemo } from 'react'
 
 export function SelectFieldMultiSearch({
   form,
@@ -20,9 +19,7 @@ export function SelectFieldMultiSearch({
   // Ensure the field has submit transformation for form submission
   // The Form component looks for field.options.submitTransform during submission
   // eslint-disable-next-line no-param-reassign
-  if (!field.options.submitTransform) {
-    field.options.submitTransform = multiSelectSubmitTransform
-  }
+  field.options.submitTransform ??= multiSelectSubmitTransform
   
   const value = form.getValues(field.key) ?? []
 

--- a/forms/src/lib/fields/select-field-multi.tsx
+++ b/forms/src/lib/fields/select-field-multi.tsx
@@ -3,7 +3,6 @@ import { SearchSelectBase } from './search-select-base'
 import { SelectedItems } from './search-select-helpers'
 import { useFormTheme } from '../theme-context'
 import { multiSelectSubmitTransform } from './select-field-multi-search-apollo'
-import { useMemo } from 'react'
 
 export function SelectFieldMulti({
   form,
@@ -20,9 +19,7 @@ export function SelectFieldMulti({
   // Ensure the field has submit transformation for form submission
   // The Form component looks for field.options.submitTransform during submission
   // eslint-disable-next-line no-param-reassign
-  if (!field.options.submitTransform) {
-    field.options.submitTransform = multiSelectSubmitTransform
-  }
+  field.options.submitTransform ??= multiSelectSubmitTransform
   
   const value = form.getValues(field.key) ?? []
 

--- a/forms/src/lib/fields/select-field-search-apollo.tsx
+++ b/forms/src/lib/fields/select-field-search-apollo.tsx
@@ -33,9 +33,7 @@ export function SelectFieldSearchApollo<
   // Ensure the field has submit transformation for form submission
   // The Form component looks for field.options.submitTransform during submission
   // eslint-disable-next-line no-param-reassign
-  if (!field.options.submitTransform) {
-    field.options.submitTransform = singleSelectSubmitTransform
-  }
+  field.options.submitTransform ??= singleSelectSubmitTransform
   
   const { options, loading: apolloLoading, handleSearchChange } = useApolloSearch<TDataItem>(field.options)
 


### PR DESCRIPTION
This pull request refactors several `SelectField` components to ensure that the `submitTransform` property is directly assigned to `field.options` if it is not already set. This change simplifies the logic by removing the creation of a separate `fieldOptions` object and ensures consistency across components. It also updates related references to use `field.options` directly.

### Refactoring of `SelectField` components:

* Updated `SelectFieldMultiSearchApollo` to directly assign `submitTransform` to `field.options` if missing, removing the `useMemo` logic for creating a separate `fieldOptions` object. Updated all references to use `field.options`. (`forms/src/lib/fields/select-field-multi-search-apollo.tsx`, [forms/src/lib/fields/select-field-multi-search-apollo.tsxL74-R81](diffhunk://#diff-42ca9cc82dc2c4b22870a9a34dbc3fbb4ad3e65eb729bd0af7589f7118af6128L74-R81))

* Refactored `SelectFieldMultiSearch` to assign `submitTransform` directly to `field.options` and removed the `fieldOptions` object. Updated the component's props to reference `field.options` directly. (`forms/src/lib/fields/select-field-multi-search.tsx`, [[1]](diffhunk://#diff-a2d6f0765d135370ab3d8ae651afa123c914f7be72464b497615329a69364c78L20-R25) [[2]](diffhunk://#diff-a2d6f0765d135370ab3d8ae651afa123c914f7be72464b497615329a69364c78L35-R39)

* Updated `SelectFieldMulti` to assign `submitTransform` directly to `field.options` and removed the `fieldOptions` object. Adjusted the transformation of `options` to reference `field.options` directly. (`forms/src/lib/fields/select-field-multi.tsx`, [forms/src/lib/fields/select-field-multi.tsxL20-R30](diffhunk://#diff-e7e155e8b97e7e683ea81fbf2754f7d9ac688bcec1d9eea9313c4d2d7235b7a8L20-R30))

* Refactored `SelectFieldSearchApollo` to directly assign `submitTransform` to `field.options` and removed the `fieldOptions` object. Updated references to use `field.options` for consistency. (`forms/src/lib/fields/select-field-search-apollo.tsx`, [forms/src/lib/fields/select-field-search-apollo.tsxL33-R40](diffhunk://#diff-1beac5e9c2dc6c1839901d95010eb39f44049b819b600692d1e30c936c92f653L33-R40))…in this case