### PR TITLE
fix(forms): export markdown props

### DIFF
--- a/forms/src/index.ts
+++ b/forms/src/index.ts
@@ -13,7 +13,7 @@ export { useFormTheme } from './lib/theme-context'
 export { createFinalTheme } from './lib/utils/resolve-theme'
 
 // Export key types for library consumers
-export type { FormField, FormFieldType, BaseFieldOptions } from './lib/form-types'
+export type { FormField, FormFieldType, BaseFieldOptions, MarkdownEditorOptions } from './lib/form-types'
 export type { FormConfig } from './lib/form-config-context'
 
 // Field Components


### PR DESCRIPTION
This pull request includes a small change to the `forms/src/index.ts` file. The change adds `MarkdownEditorOptions` to the list of exported types, making it available for library consumers.