### PR TITLE
Jbh/optional arrays

### DIFF
--- a/generators/api/src/generate-crud/files/data-access/src/lib/dto/index.ts__tmpl__
+++ b/generators/api/src/generate-crud/files/data-access/src/lib/dto/index.ts__tmpl__
@@ -125,8 +125,8 @@ export class Create<%= model.modelName %>Input {
         fieldDecoratorTypeArg = `() => ${baseGqlType}`;
       }
     }
-    // Always optional for id, createdAt, updatedAt, and virtual fields
-    if (alwaysOptionalFields.includes(field.name) || field.isVirtual) {
+    // Always optional for id, createdAt, updatedAt, virtual fields, and relation fields
+    if (alwaysOptionalFields.includes(field.name) || field.isVirtual || field.relationName) {
       isOptional = true;
     } else {
       isOptional = field.isOptional;


### PR DESCRIPTION
This pull request introduces a small but important improvement to the DTO generation logic for API CRUD operations. The change ensures that relation fields are always marked as optional in the generated input types, along with id, createdAt, updatedAt, and virtual fields.

* In `index.ts__tmpl__`, the conditional logic for marking fields as optional in the `Create<%= model.modelName %>Input` class now includes relation fields, making them always optional in generated DTOs.