### PR TITLE
fix(forms): Add fieldvalues type alias from react-hook-forms

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,7 +1,11 @@
 {
   "mcpServers": {
     "nx-mcp": {
-      "url": "http://localhost:9449/sse"
+      "command": "npx",
+      "args": [
+        "-y",
+        "nx-mcp@latest"
+      ]
     }
   }
 }

--- a/forms/src/index.ts
+++ b/forms/src/index.ts
@@ -22,8 +22,8 @@ export type {
   CheckboxGroupOptions 
 } from './lib/form-types'
 export type { FormConfig } from './lib/form-config-context'
-// Re-export a friendly alias for react-hook-form's FieldValues
-export type { FieldValues as FormValues, FieldValues } from 'react-hook-form'
+// Re-export react-hook-form's FieldValues for consumers
+export type { FieldValues } from 'react-hook-form'
 
 // Field Components
 export { TextField } from './lib/fields/text-field'

--- a/forms/src/index.ts
+++ b/forms/src/index.ts
@@ -22,6 +22,8 @@ export type {
   CheckboxGroupOptions 
 } from './lib/form-types'
 export type { FormConfig } from './lib/form-config-context'
+// Re-export a friendly alias for react-hook-form's FieldValues
+export type { FieldValues as FormValues, FieldValues } from 'react-hook-form'
 
 // Field Components
 export { TextField } from './lib/fields/text-field'

--- a/forms/src/lib/themes/tailwind.tsx
+++ b/forms/src/lib/themes/tailwind.tsx
@@ -134,7 +134,7 @@ export const tailwindTheme = FormThemeSchema.parse({
     currencySymbol: 'absolute left-3 z-10 text-gray-500 pointer-events-none select-none flex items-center',
     currencySymbolHidden: 'hidden',
     input: 'block w-full px-3 py-2 sm:text-sm min-h-[2.5rem]',
-    inputWithSymbol: 'pl-12', // Additional left padding when symbol is visible (increased for longer symbols)
+    inputWithSymbol: 'pl-12',
     focus: 'focus:ring-2 focus:ring-sky-300 focus:border-sky-300',
     error: '!border-red-600 !focus:border-red-600 !focus:ring-red-600',
     disabled: 'opacity-50 cursor-not-allowed bg-gray-100',


### PR DESCRIPTION
This pull request introduces a minor configuration update and a small type export enhancement for the forms package. The changes focus on improving developer experience and workflow integration, with no impact on runtime behavior or styling.

Configuration and tooling:

* Updated `.cursor/mcp.json` to use an `npx` command with arguments to run `nx-mcp@latest` instead of a hardcoded local URL, making the setup more portable and easier to use across environments.

Type exports and developer ergonomics:

* Re-exported `FieldValues` from `react-hook-form` as a friendlier alias `FormValues` in `forms/src/index.ts`, simplifying imports for consumers of the forms package.

There are no functional or visual changes to the Tailwind theme; a minor comment was removed for clarity.