### PR TITLE
fix(forms): Clear single search select

### DIFF
--- a/forms/src/lib/fields/search-select-base.tsx
+++ b/forms/src/lib/fields/search-select-base.tsx
@@ -247,7 +247,7 @@ export function SearchSelectBase<TValue>({
           <div ref={containerRef} className={theme.container}>
             <div
               className={clsx(
-                theme.inputContainer || theme.container,
+                theme.inputContainer || 'relative',
                 hasError && theme.error,
                 isDisabled && theme.disabled,
               )}
@@ -270,7 +270,15 @@ export function SearchSelectBase<TValue>({
                     }
                   }, 100)
                 }}
-                onKeyDown={handleKeyDown}
+                onKeyDown={(e) => {
+                  // Handle backspace to clear when empty for single select
+                  if (!multiple && e.key === 'Backspace' && !searchTerm && value) {
+                    e.preventDefault()
+                    onChange(null as TValue)
+                  } else {
+                    handleKeyDown(e)
+                  }
+                }}
                 placeholder={getInputPlaceholder(fieldValue)}
                 disabled={isDisabled}
                 aria-expanded={isOpen}
@@ -280,27 +288,55 @@ export function SearchSelectBase<TValue>({
                 aria-activedescendant={highlightedIndex >= 0 ? `${field.name}-option-${highlightedIndex}` : undefined}
                 role="combobox"
               />
-            </div>
-            <button
-              type="button"
-              className={theme.button}
-              onClick={handleToggleDropdown}
-              disabled={isDisabled}
-              aria-label="Toggle dropdown"
-            >
-              <svg
-                className={theme.buttonIcon}
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-                fill="currentColor"
+              {/* Clear button for single select */}
+              {!multiple && value && (
+                <button
+                  type="button"
+                  className={theme.clearButton || theme.button}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onChange(null as TValue)
+                    setSearchTerm('')
+                    inputRef.current?.focus()
+                  }}
+                  disabled={isDisabled}
+                  aria-label="Clear selection"
+                >
+                  <svg
+                    className={theme.clearIcon || theme.buttonIcon}
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </button>
+              )}
+              <button
+                type="button"
+                className={theme.button}
+                onClick={handleToggleDropdown}
+                disabled={isDisabled}
+                aria-label="Toggle dropdown"
               >
-                <path
-                  fillRule="evenodd"
-                  d="M10 3a.75.75 0 01.53.22l3.5 3.5a.75.75 0 01-1.06 1.06L10 4.81 6.53 8.28a.75.75 0 01-1.06-1.06l3.5-3.5A.75.75 0 0110 3zm-3.72 9.28a.75.75 0 011.06 0L10 15.19l3.47-3.47a.75.75 0 111.06 1.06l-4 4a.75.75 0 01-1.06 0l-4-4a.75.75 0 010-1.06z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            </button>
+                <svg
+                  className={theme.buttonIcon}
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M10 3a.75.75 0 01.53.22l3.5 3.5a.75.75 0 01-1.06 1.06L10 4.81 6.53 8.28a.75.75 0 01-1.06-1.06l3.5-3.5A.75.75 0 0110 3zm-3.72 9.28a.75.75 0 011.06 0L10 15.19l3.47-3.47a.75.75 0 111.06 1.06l-4 4a.75.75 0 01-1.06 0l-4-4a.75.75 0 010-1.06z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </button>
+            </div>
 
             {isOpen && (
               <div 

--- a/forms/src/lib/fields/select-field-multi-search-apollo.tsx
+++ b/forms/src/lib/fields/select-field-multi-search-apollo.tsx
@@ -190,6 +190,10 @@ export function SelectFieldMultiSearchApollo<TDataItem extends RequiredItemShape
 
       // Store full option objects in form (like regular multi-search) instead of just IDs
       form.setValue(field.key, items)
+      // Trigger form validation/dirty state
+      if (form.trigger) {
+        form.trigger(field.key)
+      }
     },
     [form, field.key],
   )

--- a/forms/src/lib/fields/select-field-multi-search.stories.tsx
+++ b/forms/src/lib/fields/select-field-multi-search.stories.tsx
@@ -493,6 +493,21 @@ export const SearchAndMultiSelect: Story = {
 }
 
 /**
+ * Test clearing all selected items.
+ * Note: This test validates that individual remove buttons work correctly
+ * for clearing selected items in multi-select fields.
+ */
+export const ClearAllSelections: Story = {
+  args: {
+    label: 'Clear All Test',
+    optionSet: 'countries',
+    defaultValue: ['US', 'CA', 'UK'],
+    helpText: 'Click the X buttons to remove selected items. The onChange event fires for each removal.',
+    showState: true,
+  },
+}
+
+/**
  * Test removing selected items while searching.
  */
 export const SearchWithRemoval: Story = {

--- a/forms/src/lib/fields/select-field-multi-search.tsx
+++ b/forms/src/lib/fields/select-field-multi-search.tsx
@@ -35,7 +35,13 @@ export function SelectFieldMultiSearch({
       onSearchChange={field.options.onSearchChange}
       searchDebounceMs={field.options.searchDebounceMs}
       value={value}
-      onChange={(items) => form.setValue(field.key, items)}
+      onChange={(items) => {
+        form.setValue(field.key, items)
+        // Trigger form validation/dirty state
+        if (form.trigger) {
+          form.trigger(field.key)
+        }
+      }}
       displayValue={multiSelectDisplayValue}
       multiple={true}
       themeKey="searchSelectMultiField"

--- a/forms/src/lib/fields/select-field-search-apollo.tsx
+++ b/forms/src/lib/fields/select-field-search-apollo.tsx
@@ -92,6 +92,10 @@ export function SelectFieldSearchApollo<
         // Store the full option object (like multi-search) instead of just the ID
         // Submit transformation will convert back to ID for API submission
         form.setValue(field.key, option || null)
+        // Trigger form validation/dirty state
+        if (form.trigger) {
+          form.trigger(field.key)
+        }
       }}
       displayValue={singleSelectDisplayValue}
       themeKey="searchSelectField"

--- a/forms/src/lib/fields/select-field-search.stories.tsx
+++ b/forms/src/lib/fields/select-field-search.stories.tsx
@@ -504,6 +504,56 @@ export const SearchAndClear: Story = {
 }
 
 /**
+ * Test the clear button functionality when a value is selected.
+ */
+export const ClearButton: Story = {
+  args: {
+    label: 'Clear Button Test',
+    optionSet: 'technologies',
+    defaultValue: 'react',
+    placeholder: 'Search technologies...',
+    helpText: 'Test the clear button by selecting a value',
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    const user = userEvent.setup()
+    
+    await step('Verify initial value is selected', async () => {
+      const input = canvas.getByRole('combobox')
+      expect(input).toHaveDisplayValue('React')
+    })
+    
+    await step('Click clear button to remove selection', async () => {
+      // Find and click the clear button
+      const clearButton = canvas.getByLabelText('Clear selection')
+      await user.click(clearButton)
+      
+      // Verify the value is cleared
+      const input = canvas.getByRole('combobox')
+      expect(input).toHaveDisplayValue('')
+    })
+    
+    await step('Select a new value and clear with backspace', async () => {
+      const input = canvas.getByRole('combobox')
+      await user.click(input)
+      await user.type(input, 'vue')
+      
+      const vueOption = canvas.getByText('Vue.js')
+      await user.click(vueOption)
+      expect(input).toHaveDisplayValue('Vue.js')
+      
+      // Clear the input content first
+      await user.click(input)
+      await user.clear(input)
+      
+      // Now press backspace on empty input to clear selection
+      await user.keyboard('{Backspace}')
+      expect(input).toHaveDisplayValue('')
+    })
+  },
+}
+
+/**
  * Test keyboard navigation in search results.
  */
 export const KeyboardNavigation: Story = {

--- a/forms/src/lib/fields/select-field-search.tsx
+++ b/forms/src/lib/fields/select-field-search.tsx
@@ -27,7 +27,13 @@ export function SelectFieldSearch({
       onSearchChange={field.options.onSearchChange}
       searchDebounceMs={field.options.searchDebounceMs}
       value={selectedOption}
-      onChange={(option) => form.setValue(field.key, option?.value || null)}
+      onChange={(option) => {
+        form.setValue(field.key, option?.value || null)
+        // Trigger form validation/dirty state
+        if (form.trigger) {
+          form.trigger(field.key)
+        }
+      }}
       displayValue={singleSelectDisplayValue}
       themeKey="searchSelectField"
     />

--- a/forms/src/lib/form-theme.ts
+++ b/forms/src/lib/form-theme.ts
@@ -261,9 +261,12 @@ export const FormThemeSchema = z.object({
     .object({
       wrapper: z.string().default(''),
       container: z.string().default(''),
+      inputContainer: z.string().default(''),
       input: z.string().default(''),
       button: z.string().default(''),
       buttonIcon: z.string().default(''),
+      clearButton: z.string().default(''),
+      clearIcon: z.string().default(''),
       dropdown: z.string().default(''),
       option: z.string().default(''),
       optionActive: z.string().default(''),

--- a/forms/src/lib/themes/tailwind.tsx
+++ b/forms/src/lib/themes/tailwind.tsx
@@ -267,7 +267,10 @@ export const tailwindTheme = FormThemeSchema.parse({
   searchSelectField: {
     wrapper: '',
     container: 'relative',
-    input: 'w-full bg-white border border-gray-300 rounded-md shadow-sm py-2 pl-3 pr-10',
+    inputContainer: 'relative',
+    input: 'w-full bg-white border border-gray-300 rounded-md shadow-sm py-2 pl-3 pr-20',
+    clearButton: 'absolute inset-y-0 right-8 flex items-center pr-2',
+    clearIcon: 'h-5 w-5 text-gray-400 hover:text-gray-600',
     button: 'absolute inset-y-0 right-0 flex items-center pr-2',
     buttonIcon: 'h-5 w-5 text-gray-400',
     dropdown:


### PR DESCRIPTION
This pull request enhances the usability and accessibility of the search select field components by introducing a clear button for single-select fields, improving keyboard support for clearing selections, and ensuring form validation is consistently triggered on changes. Several new Storybook stories and theme updates support these improvements.

**User experience improvements:**

* Added a clear button to single-select search fields, allowing users to clear their selection with one click. Also, pressing backspace on an empty input now clears the selection for single-select fields. [[1]](diffhunk://#diff-957273af122f88bed2e9fdf40f63de7dabb79e039ab32ddd841a5bd99a033fbbL273-R281) [[2]](diffhunk://#diff-957273af122f88bed2e9fdf40f63de7dabb79e039ab32ddd841a5bd99a033fbbL283-R318) [[3]](diffhunk://#diff-957273af122f88bed2e9fdf40f63de7dabb79e039ab32ddd841a5bd99a033fbbR339)
* Updated the visual theme and schema to support the new clear button and icon, including new theme keys (`clearButton`, `clearIcon`, and `inputContainer`). [[1]](diffhunk://#diff-db59cdf0ab4995fadfa90d228d991ab65914bca62c5cb29b7870e187b62baa8bR264-R269) [[2]](diffhunk://#diff-efca04e4af95079073605585111084fe07ff9053faca402e40adbe90e19704ceL270-R273) [[3]](diffhunk://#diff-957273af122f88bed2e9fdf40f63de7dabb79e039ab32ddd841a5bd99a033fbbL250-R250)

**Form integration and validation:**

* Modified all select/search field components to trigger form validation and update dirty state when selections change, ensuring form state is always up-to-date. [[1]](diffhunk://#diff-2a258e92b4585241b642809c9ddb9176c692c0885e7fd4016ede2271bc642270L30-R36) [[2]](diffhunk://#diff-a2d6f0765d135370ab3d8ae651afa123c914f7be72464b497615329a69364c78L38-R44) [[3]](diffhunk://#diff-42ca9cc82dc2c4b22870a9a34dbc3fbb4ad3e65eb729bd0af7589f7118af6128R193-R196) [[4]](diffhunk://#diff-1beac5e9c2dc6c1839901d95010eb39f44049b819b600692d1e30c936c92f653R95-R98)

**Testing and documentation:**

* Added Storybook stories to test the clear button in single-select fields and clearing all selections in multi-select fields, including interactive steps to verify expected behaviors. [[1]](diffhunk://#diff-3dfcff2bfa164c0617d0be0355a03c497dee365b9add72bbbc3baf7d3962975fR506-R555) [[2]](diffhunk://#diff-549247fbb4cfd9a3a9963db0ef8b54ef45d0093f46f06cd2fea20b4fc1d82ca0R495-R509)