### PR TITLE
Jbh/form clear 2

### DIFF
--- a/forms/package.json
+++ b/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestledjs/forms",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "exports": {
     ".": {
       "import": "./index.js",

--- a/forms/src/lib/fields/search-select-base.tsx
+++ b/forms/src/lib/fields/search-select-base.tsx
@@ -20,7 +20,7 @@ export interface SearchSelectBaseProps<TValue> {
 
   // Value handling
   value: TValue
-  onChange: (value: TValue) => void
+  onChange: (value: TValue | null) => void
   displayValue: (value: TValue) => string
 
   // Combobox configuration
@@ -212,7 +212,7 @@ export function SearchSelectBase<TValue>({
       // Handle backspace to clear when empty for single select
       if (!multiple && event.key === 'Backspace' && !searchTerm && value) {
         event.preventDefault()
-        onChange(null as TValue)
+        onChange(null)
       } else {
         handleKeyDown(event)
       }
@@ -288,7 +288,7 @@ export function SearchSelectBase<TValue>({
                       // Clear selection if input is empty when blurring (user cleared it)
                       const currentInputValue = (e.target as HTMLInputElement).value
                       if (!multiple && value && currentInputValue === '') {
-                        onChange(null as TValue)
+                        onChange(null)
                       }
                       
                       // Reset search term
@@ -314,7 +314,7 @@ export function SearchSelectBase<TValue>({
                   className={theme.clearButton || (theme.button ? `${theme.button} opacity-70` : 'absolute inset-y-0 right-10 flex items-center pr-2 opacity-70')}
                   onClick={(e) => {
                     e.stopPropagation()
-                    onChange(null as TValue)
+                    onChange(null)
                     setSearchTerm('')
                     inputRef.current?.focus()
                   }}

--- a/forms/src/lib/fields/search-select-base.tsx
+++ b/forms/src/lib/fields/search-select-base.tsx
@@ -232,6 +232,10 @@ export function SearchSelectBase<TValue>({
   // Handle input focus
   const handleInputFocus = () => {
     setIsOpen(true)
+    // Clear the search term when focusing to allow typing
+    if (!multiple && value) {
+      setSearchTerm('')
+    }
   }
 
   // Handle dropdown toggle
@@ -280,6 +284,15 @@ export function SearchSelectBase<TValue>({
                     if (!containerRef.current?.contains(document.activeElement)) {
                       setIsOpen(false)
                       setHighlightedIndex(-1)
+                      
+                      // Clear selection if input is empty when blurring (user cleared it)
+                      const currentInputValue = (e.target as HTMLInputElement).value
+                      if (!multiple && value && currentInputValue === '') {
+                        onChange(null as TValue)
+                      }
+                      
+                      // Reset search term
+                      setSearchTerm('')
                       onBlur()
                     }
                   }, 100)

--- a/forms/src/lib/fields/select-field-multi-search-apollo.tsx
+++ b/forms/src/lib/fields/select-field-multi-search-apollo.tsx
@@ -171,13 +171,16 @@ export function SelectFieldMultiSearchApollo<TDataItem extends RequiredItemShape
 
   // Custom onChange handler that updates the cache for newly selected items
   const handleChange = useCallback(
-    (items: SearchSelectOption[]) => {
+    (items: SearchSelectOption[] | null) => {
+      // Multi-select should use empty array instead of null
+      const itemsArray = items || []
+      
       // Update cache with any new selections
       setSelectedOptionsCache((prevCache) => {
         let hasChanges = false
         const newCache = new Map(prevCache)
 
-        items.forEach((item) => {
+        itemsArray.forEach((item) => {
           if (!newCache.has(item.value)) {
             newCache.set(item.value, item)
             hasChanges = true
@@ -189,7 +192,7 @@ export function SelectFieldMultiSearchApollo<TDataItem extends RequiredItemShape
       })
 
       // Store full option objects in form (like regular multi-search) instead of just IDs
-      form.setValue(field.key, items)
+      form.setValue(field.key, itemsArray)
       // Trigger form validation/dirty state
       if (form.trigger) {
         form.trigger(field.key)

--- a/forms/src/lib/fields/select-field-multi-search.tsx
+++ b/forms/src/lib/fields/select-field-multi-search.tsx
@@ -36,7 +36,8 @@ export function SelectFieldMultiSearch({
       searchDebounceMs={field.options.searchDebounceMs}
       value={value}
       onChange={(items) => {
-        form.setValue(field.key, items)
+        // Multi-select should use empty array instead of null
+        form.setValue(field.key, items || [])
         // Trigger form validation/dirty state
         if (form.trigger) {
           form.trigger(field.key)


### PR DESCRIPTION
This pull request introduces improvements to the single-select mode behavior of the `SearchSelectBase` component. The main focus is on enhancing the user experience when interacting with the input field, specifically around clearing the search term and selection.

Improvements to single-select user experience:

* When the input field is focused in single-select mode and a value is already selected, the search term is now cleared to allow the user to start typing immediately.
* When the input field loses focus in single-select mode, if the user has cleared the input, the selected value is also cleared, and the search term is reset.

Other:

* Bumped the package version in `package.json` from `0.4.14` to `0.4.15` to reflect these changes.