### PR TITLE
Jbh/apollo search fix

### DIFF
--- a/forms/package.json
+++ b/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestledjs/forms",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "exports": {
     ".": {
       "import": "./index.js",

--- a/forms/src/lib/fields/use-apollo-search.ts
+++ b/forms/src/lib/fields/use-apollo-search.ts
@@ -58,12 +58,16 @@ export function useApolloSearch<TDataItem extends RequiredItemShape>(
         return
       }
       
-      // When search is cleared, reset to initial Apollo data merged with initial options
-      if (data) {
-        setOptions(processData(data[dataType] ?? []))
+      // When search is cleared, refetch with empty search to get all results
+      const input: { search: string; searchFields?: string[] } = { search: '' }
+      if (searchFields && searchFields.length > 0) {
+        input.searchFields = searchFields
       }
+      refetch({ input }).then((res) => {
+        setOptions(processData(res.data?.[dataType] ?? []))
+      })
     },
-    [refetch, searchFields, dataType, processData, data],
+    [refetch, searchFields, dataType, processData],
   )
 
   return {


### PR DESCRIPTION
This pull request updates the `@nestledjs/forms` package version and improves the behavior of the `useApolloSearch` hook when clearing a search. The most significant change is that clearing the search now triggers a refetch to ensure the options list is up to date, rather than relying on potentially stale initial data.

**Version update:**

* Bumped the package version from `0.4.15` to `0.4.16` in `package.json`.

**Improvements to search behavior:**

* Updated the `useApolloSearch` hook in `use-apollo-search.ts` so that clearing the search input now triggers a refetch with an empty search string, ensuring the options list reflects the latest data from the server. Previously, it reset to the initial Apollo data, which could be outdated.