### PR TITLE
fix(helpers,forms,generators): Post deprecation

### DIFF
--- a/forms/package.json
+++ b/forms/package.json
@@ -49,7 +49,6 @@
     "zod": "^3.0.0",
     "@hookform/resolvers": "^3.0.0",
     "react-hook-form": "^7.58.1",
-    "react-phone-number-input": "^3.4.12",
-    "@nestledjs/helpers": "^0.1.4"
+    "react-phone-number-input": "^3.4.12"
   }
 }

--- a/forms/src/lib/types/deep-partial.ts
+++ b/forms/src/lib/types/deep-partial.ts
@@ -1,0 +1,53 @@
+/**
+ * A utility type that makes all properties of a type and its nested objects optional recursively.
+ * Useful for creating partial versions of complex nested objects.
+ *
+ * This version properly handles:
+ * - Arrays: Makes array elements deeply partial while preserving array structure
+ * - Functions: Leaves functions unchanged (they shouldn't be made partial)
+ * - Objects: Makes nested objects deeply partial
+ * - Primitives: Makes primitive values optional
+ *
+ * @template T - The type to make deeply partial
+ * @example
+ * ```typescript
+ * interface User {
+ *   name: string
+ *   hobbies: string[]
+ *   friends: User[]
+ *   onClick: () => void
+ *   profile: {
+ *     age: number
+ *     address: {
+ *       street: string
+ *       city: string
+ *     }
+ *   }
+ * }
+ *
+ * type PartialUser = DeepPartial<User>
+ * // Result:
+ * // {
+ * //   name?: string
+ * //   hobbies?: string[]
+ * //   friends?: DeepPartial<User>[]
+ * //   onClick?: () => void
+ * //   profile?: {
+ * //     age?: number
+ * //     address?: {
+ * //       street?: string
+ * //       city?: string
+ * //     }
+ * //   }
+ * // }
+ * ```
+ */
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends (infer U)[]
+    ? DeepPartial<U>[]
+    : T[P] extends (...args: any[]) => any
+    ? T[P]
+    : T[P] extends object
+    ? DeepPartial<T[P]>
+    : T[P]
+}

--- a/forms/src/lib/types/deep-partial.ts
+++ b/forms/src/lib/types/deep-partial.ts
@@ -43,7 +43,7 @@
  * ```
  */
 export type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends (infer U)[]
+  [P in keyof T]?: T[P] extends readonly (infer U)[]
     ? DeepPartial<U>[]
     : T[P] extends (...args: any[]) => any
     ? T[P]

--- a/forms/src/lib/utils/resolve-theme.ts
+++ b/forms/src/lib/utils/resolve-theme.ts
@@ -2,7 +2,7 @@ import { merge } from 'lodash-es'
 import clsx from 'clsx'
 import { FormTheme, FormThemeSchema } from '../form-theme'
 import { tailwindTheme } from '../themes/tailwind'
-import { DeepPartial } from '@nestledjs/helpers'
+import { DeepPartial } from '../types/deep-partial'
 
 /**
  * Creates the final, fully resolved theme for the entire form. This is the

--- a/generators/utils/src/lib/generator-utils.ts
+++ b/generators/utils/src/lib/generator-utils.ts
@@ -726,10 +726,66 @@ export async function apiLibraryGenerator<T extends { name: string; overwrite?: 
   }
 }
 
+/**
+ * List of uncountable nouns that the pluralize library incorrectly pluralizes.
+ * These words should remain the same in plural form, so we append "List" instead.
+ */
+const UNCOUNTABLE_OVERRIDES = new Set([
+  'luggage',
+  'furniture',
+  'advice',
+  'research',
+  'progress',
+  'homework',
+  'housework',
+  'software',
+  'hardware',
+  'traffic',
+  'weather',
+  'news',
+  'evidence',
+  'feedback',
+  'knowledge',
+  'music',
+  'art',
+  'love',
+  'happiness',
+  'anger',
+  'beauty',
+  'courage',
+  'wisdom'
+])
+
+/**
+ * Pluralizes a word using the pluralize library, with special handling for words
+ * where the singular and plural forms are the same (like "data", "sheep").
+ * In those cases, appends "List" to make it clear it's a collection.
+ * Also includes overrides for known uncountable nouns that the pluralize library
+ * incorrectly pluralizes.
+ *
+ * @param name - The word to pluralize
+ * @returns The pluralized form, or the word + "List" if singular equals plural or is uncountable
+ *
+ * @example
+ * ```typescript
+ * getPluralName('user')     // 'users'
+ * getPluralName('category') // 'categories'
+ * getPluralName('data')     // 'dataList' (because 'data' plural is also 'data')
+ * getPluralName('sheep')    // 'sheepList' (because 'sheep' plural is also 'sheep')
+ * getPluralName('luggage')  // 'luggageList' (override: pluralize incorrectly returns 'luggages')
+ * getPluralName('furniture') // 'furnitureList' (override: pluralize incorrectly returns 'furnitures')
+ * ```
+ */
 export function getPluralName(name: string): string {
   if (!name || typeof name !== 'string') {
     throw new Error('getPluralName: name must be a non-empty string')
   }
+
+  // Check if this is a known uncountable noun that pluralize incorrectly handles
+  if (UNCOUNTABLE_OVERRIDES.has(name.toLowerCase())) {
+    return name + 'List'
+  }
+
   const plural = pluralize(name)
   return plural === name ? name + 'List' : plural
 }

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -1,11 +1,29 @@
-# helpers
+# @nestledjs/helpers - DEPRECATED
 
-This library was generated with [Nx](https://nx.dev).
+> ⚠️ **This package has been deprecated and is no longer maintained.**
 
-## Building
+## Migration Guide
 
-Run `nx build helpers` to build the library.
+The functionality from this package has been moved to other packages:
 
-## Running unit tests
+### DeepPartial Type
+- **Previously:** `import { DeepPartial } from '@nestledjs/helpers'`
+- **Now:** Available directly in `@nestledjs/forms` (if you're using the forms library)
 
-Run `nx test helpers` to execute the unit tests via [Vitest](https://vitest.dev/).
+### getPluralName Function
+- **Previously:** `import { getPluralName } from '@nestledjs/helpers'`
+- **Now:** `import { getPluralName } from '@nestledjs/utils'`
+
+## For Forms Users
+Simply update to the latest version of `@nestledjs/forms` (v0.4.17+) and remove the `@nestledjs/helpers` dependency:
+
+```bash
+npm uninstall @nestledjs/helpers
+npm install @nestledjs/forms@latest
+```
+
+## For Generator Users
+The `getPluralName` function is available in `@nestledjs/utils` which is already a dependency of the generator packages.
+
+## Questions?
+Please open an issue in the [main Nestled repository](https://github.com/nestledjs/nestled).


### PR DESCRIPTION
This pull request focuses on removing the deprecated `@nestledjs/helpers` package from the forms package and migrating its utilities internally. It introduces a local implementation of the `DeepPartial` type, updates imports, and clarifies migration steps for users. Additionally, it improves the pluralization utility to handle uncountable nouns more accurately.

**Helpers package deprecation and migration:**

* Updated `helpers/README.md` to announce deprecation, provide migration instructions, and clarify where to find `DeepPartial` and `getPluralName` utilities now.
* Removed `@nestledjs/helpers` from `forms/package.json` dependencies.

**Internalizing and improving utilities:**

* Added a robust local `DeepPartial` utility type in `forms/src/lib/types/deep-partial.ts`, with documentation and improved handling of arrays, functions, and nested objects.
* Updated imports in `forms/src/lib/utils/resolve-theme.ts` to use the new local `DeepPartial` instead of the one from `@nestledjs/helpers`.

**Pluralization improvements:**

* Enhanced the `getPluralName` function in `generators/utils/src/lib/generator-utils.ts` to handle uncountable nouns and edge cases, ensuring correct pluralization for generator output.