### PR TITLE
fix(forms): resolve SSR issues with multi-select field and MDX Editor

### DIFF
--- a/forms/package.json
+++ b/forms/package.json
@@ -5,6 +5,10 @@
     ".": {
       "import": "./index.js",
       "types": "./index.d.ts"
+    },
+    "./markdown": {
+      "import": "./markdown.js",
+      "types": "./markdown.d.ts"
     }
   },
   "main": "./index.js",

--- a/forms/src/index.ts
+++ b/forms/src/index.ts
@@ -39,7 +39,8 @@ export type { FieldValues } from 'react-hook-form'
 // Field Components
 export { TextField } from './lib/fields/text-field'
 export { TextAreaField } from './lib/fields/textarea-field'
-export { MarkdownEditor } from './lib/fields/markdown-editor'
+// MarkdownEditor removed from main exports to avoid SSR issues
+// Import from '@nestledjs/forms/markdown' when needed
 export { EmailField } from './lib/fields/email-field'
 export { PasswordField } from './lib/fields/password-field'
 export { UrlField } from './lib/fields/url-field'

--- a/forms/src/lib/fields/search-select-helpers.tsx
+++ b/forms/src/lib/fields/search-select-helpers.tsx
@@ -11,7 +11,7 @@ export function SelectedItems({
   theme: any
 }) {
   // Defensive check for undefined or null values
-  const items = value || []
+  const items = value ?? []
 
   return (
     <>

--- a/forms/src/lib/fields/search-select-helpers.tsx
+++ b/forms/src/lib/fields/search-select-helpers.tsx
@@ -10,15 +10,18 @@ export function SelectedItems({
   onChange: (items: SearchSelectOption[]) => void
   theme: any
 }) {
+  // Defensive check for undefined or null values
+  const items = value || []
+
   return (
     <>
-      {value.map((item: SearchSelectOption) => (
+      {items.map((item: SearchSelectOption) => (
         <span key={item.value} className={theme.selectedItem}>
           <span className={theme.selectedItemLabel}>{item.label}</span>
           <button
             type="button"
             className={theme.selectedItemRemoveButton}
-            onClick={() => onChange(value.filter((v: SearchSelectOption) => v.value !== item.value))}
+            onClick={() => onChange(items.filter((v: SearchSelectOption) => v.value !== item.value))}
           >
             <svg
               className={theme.selectedItemRemoveIcon}

--- a/forms/src/lib/render-form-field.tsx
+++ b/forms/src/lib/render-form-field.tsx
@@ -6,7 +6,10 @@ import { useFormConfig } from './form-config-context'
 
 import { TextField } from './fields/text-field'
 import { TextAreaField } from './fields/textarea-field'
-import { MarkdownEditor } from './fields/markdown-editor'
+// Lazy load MarkdownEditor to avoid SSR issues with MDX Editor dependencies
+const MarkdownEditor = React.lazy(() =>
+  import('./fields/markdown-editor').then(m => ({ default: m.MarkdownEditor }))
+)
 import { EmailField } from './fields/email-field'
 import { PasswordField } from './fields/password-field'
 import { UrlField } from './fields/url-field'
@@ -64,13 +67,15 @@ function renderComponent(
       )
     case FormFieldType.MarkdownEditor:
       return (
-        <MarkdownEditor
-          form={form}
-          field={field}
-          hasError={hasError}
-          formReadOnly={formReadOnly}
-          formReadOnlyStyle={formReadOnlyStyle}
-        />
+        <React.Suspense fallback={<div>Loading editor...</div>}>
+          <MarkdownEditor
+            form={form}
+            field={field}
+            hasError={hasError}
+            formReadOnly={formReadOnly}
+            formReadOnlyStyle={formReadOnlyStyle}
+          />
+        </React.Suspense>
       )
     case FormFieldType.Email:
       return (

--- a/forms/src/lib/render-form-field.tsx
+++ b/forms/src/lib/render-form-field.tsx
@@ -67,7 +67,7 @@ function renderComponent(
       )
     case FormFieldType.MarkdownEditor:
       return (
-        <React.Suspense fallback={<div>Loading editor...</div>}>
+        <React.Suspense fallback={<div aria-live="polite">Loading markdown editor...</div>}>
           <MarkdownEditor
             form={form}
             field={field}

--- a/forms/src/markdown.ts
+++ b/forms/src/markdown.ts
@@ -1,0 +1,15 @@
+/**
+ * Separate export for MarkdownEditor to avoid SSR issues.
+ * Import this only when you need the MarkdownEditor component.
+ *
+ * @example
+ * ```tsx
+ * // Only import when needed, preferably with dynamic imports in Next.js
+ * import dynamic from 'next/dynamic'
+ * const MarkdownEditor = dynamic(
+ *   () => import('@nestledjs/forms/markdown').then(m => m.MarkdownEditor),
+ *   { ssr: false }
+ * )
+ * ```
+ */
+export { MarkdownEditor } from './lib/fields/markdown-editor'


### PR DESCRIPTION
## Summary
- Fixed runtime error "Cannot read properties of undefined (reading 'map')" in multi-select fields
- Resolved SSR/hydration issues caused by MDX Editor being loaded for all form imports
- Improved code splitting by creating separate export path for MarkdownEditor

## Problem
The multi-select field was throwing a runtime error when used in applications. Investigation revealed two issues:
1. The MDX Editor dependency was being loaded for all form imports, even when only using simple fields
2. The SelectedItems component lacked defensive checks for undefined values

## Solution
1. **Lazy load MarkdownEditor**: Changed from static import to React.lazy() to only load when needed
2. **Add defensive checks**: Added null/undefined checks in SelectedItems component
3. **Separate export path**: Created `@nestledjs/forms/markdown` export for users who need the MarkdownEditor

## Technical Details
- MDX Editor has browser-specific code that doesn't work during SSR
- The multi-select's SelectedItems component was calling `.map()` on potentially undefined values
- Other fields weren't affected as severely because they either had defensive checks or simpler implementations

## Breaking Changes
⚠️ **Minor breaking change**: MarkdownEditor is no longer exported from the main `@nestledjs/forms` package.

Users who need MarkdownEditor should now import it from:
```tsx
// Before
import { MarkdownEditor } from '@nestledjs/forms'

// After (for SSR environments like Next.js)
import dynamic from 'next/dynamic'
const MarkdownEditor = dynamic(
  () => import('@nestledjs/forms/markdown').then(m => m.MarkdownEditor),
  { ssr: false }
)

// Or direct import (client-side only)
import { MarkdownEditor } from '@nestledjs/forms/markdown'
```

## Test Plan
- [x] Multi-select field renders without errors
- [x] Multi-select field handles undefined/null values gracefully
- [x] Forms package builds successfully
- [x] MarkdownEditor still works when imported from separate path
- [ ] Test in SSR environment (Next.js)
- [ ] Verify other form fields still work correctly

🤖 Generated with Claude Code