### PR TITLE
refactor(sdk): rename admin SDK to __admin to avoid naming conflicts

### DIFF
--- a/generators/shared/src/sdk/files/codegen.yml__tmpl__
+++ b/generators/shared/src/sdk/files/codegen.yml__tmpl__
@@ -2,7 +2,7 @@ overwrite: true
 schema: './api-schema.graphql'
 documents:
   - 'libs/shared/sdk/src/graphql/**/*.graphql'
-  - 'libs/shared/sdk/src/admin-graphql/**/*.graphql'
+  - 'libs/shared/sdk/src/__admin/**/*.graphql'
 generates:
   libs/shared/sdk/src/generated/graphql.ts:
     config:

--- a/generators/shared/src/sdk/generator.spec.ts
+++ b/generators/shared/src/sdk/generator.spec.ts
@@ -72,7 +72,7 @@ describe('sdk generator', () => {
       typeof modelDir === 'string' && modelDir.includes('graphql') && !modelDir.includes('__admin')
     );
     const adminCall = calls.find(([_, __, modelDir, context]) =>
-      typeof modelDir === 'string' && modelDir.includes('__admin') && context && context.adminPrefix === '__Admin'
+      typeof modelDir === 'string' && modelDir.includes('__admin') && context?.adminPrefix === '__Admin'
     );
     expect(userCall).toBeTruthy();
     expect(adminCall).toBeTruthy();

--- a/generators/shared/src/sdk/generator.spec.ts
+++ b/generators/shared/src/sdk/generator.spec.ts
@@ -69,15 +69,15 @@ describe('sdk generator', () => {
     const calls = vi.mocked(mockDependencies.generateFiles).mock.calls;
     // There should be at least one call for user and one for admin
     const userCall = calls.find(([_, __, modelDir, context]) =>
-      typeof modelDir === 'string' && modelDir.includes('graphql') && !modelDir.includes('admin-graphql')
+      typeof modelDir === 'string' && modelDir.includes('graphql') && !modelDir.includes('__admin')
     );
     const adminCall = calls.find(([_, __, modelDir, context]) =>
-      typeof modelDir === 'string' && modelDir.includes('admin-graphql') && context && context.adminPrefix === 'Admin'
+      typeof modelDir === 'string' && modelDir.includes('__admin') && context && context.adminPrefix === '__Admin'
     );
     expect(userCall).toBeTruthy();
     expect(adminCall).toBeTruthy();
-    // Check that adminPrefix is empty string for user SDK and 'Admin' for admin SDK
+    // Check that adminPrefix is empty string for user SDK and '__Admin' for admin SDK
     expect(userCall[3].adminPrefix).toBe('');
-    expect(adminCall[3].adminPrefix).toBe('Admin');
+    expect(adminCall[3].adminPrefix).toBe('__Admin');
   });
 }); 

--- a/generators/shared/src/sdk/generator.ts
+++ b/generators/shared/src/sdk/generator.ts
@@ -182,20 +182,20 @@ export async function sdkGeneratorLogic(
   }
 
   // 6. For each model, generate admin files (always overwrite)
-  // Clean up the admin-graphql directory before generating new files
-  deleteDirectory(tree, 'libs/shared/sdk/src/admin-graphql');
+  // Clean up the __admin directory before generating new files
+  deleteDirectory(tree, 'libs/shared/sdk/src/__admin');
   console.log('Generating admin files for models:', allModels.map((m: any) => m.name));
   for (const model of allModels) {
     const modelName = model.name
     const kebabName = kebabCase(modelName)
-    const modelDir = `libs/shared/sdk/src/admin-graphql/${kebabName}`
+    const modelDir = `libs/shared/sdk/src/__admin/${kebabName}`
     // Always overwrite admin files
     const className = modelName
     const propertyName = modelName.charAt(0).toLowerCase() + modelName.slice(1)
     const pluralClassName = dependencies.getPluralName(className)
     const pluralPropertyName = dependencies.getPluralName(propertyName)
     const fragmentFields = getAdminFragmentFields(model, allModels)
-    const adminPrefix = 'Admin'
+    const adminPrefix = '__Admin'
 
     console.log('Generating admin files for', modelName, 'at', modelDir);
 


### PR DESCRIPTION
## Summary
- Changes auto-generated admin SDK folder from `admin-graphql/` to `__admin/`
- Changes operation prefix from `Admin` to `__Admin` (e.g., `AdminUser` → `__AdminUser`)
- Updates codegen.yml to reference the new folder path

## Motivation
This frees up the `admin` namespace for custom endpoints while making it clear with the `__` prefix that these are generated internal operations that shouldn't be manually edited. Previously, AI code generation would sometimes try to use "admin" naming, causing conflicts with the generated SDK.

## Test plan
- [ ] Run the SDK generator and verify files are created in `__admin/` folder
- [ ] Verify generated operations are prefixed with `__Admin`
- [ ] Verify codegen picks up the new path correctly
- [ ] Confirm custom endpoints can now use `admin` naming without conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)