### PR TITLE
fix(generators): add idFieldType to DatabaseModel interface

### DIFF
--- a/generators/api/package.json
+++ b/generators/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestledjs/api",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "generators": "./generators.json",
   "type": "commonjs",
   "main": "./src/index.js",
@@ -25,6 +25,6 @@
     "pg": "^8.13.0"
   },
   "peerDependencies": {
-    "@nestledjs/utils": "0.2.3"
+    "@nestledjs/utils": "0.2.4"
   }
 }

--- a/generators/config/package.json
+++ b/generators/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestledjs/config",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "generators": "./generators.json",
   "type": "commonjs",
   "main": "./src/index.js",
@@ -23,6 +23,6 @@
     "yaml": "^2.8.0"
   },
   "peerDependencies": {
-    "@nestledjs/utils": "0.2.3"
+    "@nestledjs/utils": "0.2.4"
   }
 }

--- a/generators/generators/package.json
+++ b/generators/generators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestledjs/generators",
-  "version": "0.1.29",
+  "version": "0.2.0",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
@@ -33,11 +33,11 @@
   },
   "dependencies": {
     "tslib": "^2.3.0",
-    "@nestledjs/api": "1.0.7",
-    "@nestledjs/config": "0.1.8",
-    "@nestledjs/plugins": "0.1.8",
-    "@nestledjs/shared": "0.3.4",
-    "@nestledjs/utils": "0.2.3",
-    "@nestledjs/web": "0.1.9"
+    "@nestledjs/api": "1.0.8",
+    "@nestledjs/config": "0.1.9",
+    "@nestledjs/plugins": "0.1.9",
+    "@nestledjs/shared": "0.3.5",
+    "@nestledjs/utils": "0.2.4",
+    "@nestledjs/web": "0.1.10"
   }
 }

--- a/generators/plugins/package.json
+++ b/generators/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestledjs/plugins",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "generators": "./generators.json",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
@@ -20,6 +20,6 @@
     "@nx/js": "22.0.2"
   },
   "peerDependencies": {
-    "@nestledjs/utils": "0.2.3"
+    "@nestledjs/utils": "0.2.4"
   }
 }

--- a/generators/shared/package.json
+++ b/generators/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestledjs/shared",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "generators": "./generators.json",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
@@ -21,6 +21,6 @@
     "@prisma/internals": "^6.11.0"
   },
   "peerDependencies": {
-    "@nestledjs/utils": "0.2.3"
+    "@nestledjs/utils": "0.2.4"
   }
 }

--- a/generators/utils/package.json
+++ b/generators/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestledjs/utils",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/generators/utils/src/lib/generator-utils.ts
+++ b/generators/utils/src/lib/generator-utils.ts
@@ -874,6 +874,7 @@ export interface DatabaseModel {
     update?: string
     delete?: string
   }
+  idFieldType?: string
 }
 
 export const DATABASE_MODELS: DatabaseModel[] = ${JSON.stringify(models, null, 2)}

--- a/generators/web/package.json
+++ b/generators/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestledjs/web",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "generators": "./generators.json",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
@@ -21,6 +21,6 @@
     "@nx/js": "22.0.2"
   },
   "peerDependencies": {
-    "@nestledjs/utils": "0.2.3"
+    "@nestledjs/utils": "0.2.4"
   }
 }


### PR DESCRIPTION
## Summary
- Add idFieldType optional field to DatabaseModel interface
- Fixes TypeScript compilation errors when using BigInt ID fields

## Details
This PR fixes a missing field in the `DatabaseModel` interface that was added to the `ModelType` interface in PR #78. When the CRUD generator creates the `database-models.ts` file, it includes the `idFieldType` property on each model, but the `DatabaseModel` interface didn't have this field defined, causing TypeScript compilation errors.

## Error Fixed
```
TS2353: Object literal may only specify known properties, and 'idFieldType' does not exist in type 'DatabaseModel'.
```

## Changes
- Added `idFieldType?: string` to the `DatabaseModel` interface in `generators/utils/src/lib/generator-utils.ts:877`

## Test Plan
- [ ] Build the generators package
- [ ] Regenerate CRUD in a project with BigInt ID fields
- [ ] Verify TypeScript compilation succeeds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)