### PR TITLE
Fix/database model idfield type

### DIFF
--- a/generators/api/src/core/files/models/src/lib/generate-models.ts__tmpl__
+++ b/generators/api/src/core/files/models/src/lib/generate-models.ts__tmpl__
@@ -193,6 +193,10 @@ function generateModels(models: readonly any[], enums: readonly any[]): string {
   const usesFloat = models.some(model =>
     model.fields.some((field: { type: string }) => field.type === 'Float'),
   )
+  // Check if any model field uses BigInt
+  const usesBigInt = models.some(model =>
+    model.fields.some((field: { type: string }) => field.type === 'BigInt'),
+  )
   let output = `import { Field, ObjectType${usesFloat ? ', Float' : ''}, Int } from '@nestjs/graphql';\n`
   output += `import { GraphQLJSONObject } from 'graphql-type-json';\n`
 
@@ -203,6 +207,9 @@ function generateModels(models: readonly any[], enums: readonly any[]): string {
   if (usesDecimal) {
     output += `import { Decimal } from '@prisma/client/runtime/library';\n`
     output += `import { GraphQLDecimal } from 'prisma-graphql-type-decimal';\n`
+  }
+  if (usesBigInt) {
+    output += `import { GraphQLBigInt } from 'graphql-scalars';\n`
   }
   // Ensure Prisma and enums are imported correctly
   const enumNames = enums.map(e => e.name)
@@ -273,6 +280,7 @@ function generateModels(models: readonly any[], enums: readonly any[]): string {
         if (originalType === 'Int') listItemGraphQLType = 'Int'
         else if (originalType === 'Float') listItemGraphQLType = 'Float'
         else if (originalType === 'Decimal') listItemGraphQLType = 'GraphQLDecimal'
+        else if (originalType === 'BigInt') listItemGraphQLType = 'GraphQLBigInt'
         else if (originalType === 'Json') listItemGraphQLType = 'GraphQLJSONObject'
         else if (isEnum || isRelation)
           listItemGraphQLType = originalType // Assumes enum/type is registered with GraphQL
@@ -289,6 +297,7 @@ function generateModels(models: readonly any[], enums: readonly any[]): string {
         if (originalType === 'Int') decoratorType = '() => Int'
         else if (originalType === 'Float') decoratorType = '() => Float'
         else if (originalType === 'Decimal') decoratorType = '() => GraphQLDecimal'
+        else if (originalType === 'BigInt') decoratorType = '() => GraphQLBigInt'
         else if (originalType === 'Json') decoratorType = '() => GraphQLJSONObject'
         else if (isEnum || isRelation) decoratorType = `() => ${originalType}`
         else if (originalType === 'DateTime') decoratorType = '() => Date'

--- a/generators/api/src/generate-crud/files/data-access/src/lib/api-crud-data-access.service.ts__tmpl__
+++ b/generators/api/src/generate-crud/files/data-access/src/lib/api-crud-data-access.service.ts__tmpl__
@@ -192,26 +192,26 @@ export class ApiCrudDataAccessService {
     }
   }
 
-  async <%= model.modelName.charAt(0).toLowerCase() + model.modelName.slice(1) %>(info: GraphQLResolveInfo, id: string) {
+  async <%= model.modelName.charAt(0).toLowerCase() + model.modelName.slice(1) %>(info: GraphQLResolveInfo, id: <%= model.idFieldType === 'BigInt' ? 'bigint' : 'string' %>) {
     return this.data['<%= model.modelPropertyName %>'].findUnique({
-      where: { id: <%= model.idFieldType === 'BigInt' ? 'BigInt(id)' : 'id' %> },
+      where: { id },
       select: createSelect(info),
     });
   }
 
-  async update<%= model.modelName.charAt(0).toUpperCase() + model.modelName.slice(1) %>(info: GraphQLResolveInfo, id: string, input: dto.Update<%= model.modelName %>Input) {
+  async update<%= model.modelName.charAt(0).toUpperCase() + model.modelName.slice(1) %>(info: GraphQLResolveInfo, id: <%= model.idFieldType === 'BigInt' ? 'bigint' : 'string' %>, input: dto.Update<%= model.modelName %>Input) {
 <%- generateRelationHandling(model, 'update') %>
 
     return this.data['<%= model.modelPropertyName %>'].update({
-      where: { id: <%= model.idFieldType === 'BigInt' ? 'BigInt(id)' : 'id' %> },
+      where: { id },
       data,
       select: createSelect(info),
     });
   }
 
-  async delete<%= model.modelName.charAt(0).toUpperCase() + model.modelName.slice(1) %>(id: string) {
+  async delete<%= model.modelName.charAt(0).toUpperCase() + model.modelName.slice(1) %>(id: <%= model.idFieldType === 'BigInt' ? 'bigint' : 'string' %>) {
     return this.data['<%= model.modelPropertyName %>'].delete({
-      where: { id: <%= model.idFieldType === 'BigInt' ? 'BigInt(id)' : 'id' %> }
+      where: { id }
     });
   }
 <% } %>

--- a/generators/api/src/generate-crud/files/data-access/src/lib/dto/index.ts__tmpl__
+++ b/generators/api/src/generate-crud/files/data-access/src/lib/dto/index.ts__tmpl__
@@ -2,6 +2,7 @@
 <%
 let gqlImports = new Set(['Field', 'InputType'])
 let usesGraphQLJSON = false
+let usesGraphQLBigInt = false
 let usesInt = false
 let usesFloat = false
 let usesID = false
@@ -70,6 +71,7 @@ for (const model of models) {
         if (field.type === 'Int') usesInt = true
         if (field.type === 'Float' || field.type === 'Decimal') usesFloat = true
         if (field.type === 'Json') usesGraphQLJSON = true
+        if (field.type === 'BigInt') usesGraphQLBigInt = true
         if (field.type === 'ID') usesID = true
         if (field.kind === 'enum') {
             enumNames.add(field.type)
@@ -85,6 +87,7 @@ usesPartialType = models.length > 0 // If we generate any Update input, we need 
 import { <%= Array.from(gqlImports).join(', ') %> } from '@nestjs/graphql'
 <% if (enumNames.size > 0) { %>import { <%= Array.from(enumNames).join(', ') %> } from '@<%= npmScope %>/api/core/models'
 <% } %><% if (usesGraphQLJSON) { %>import { GraphQLJSON } from 'graphql-type-json'<% } %>
+<% if (usesGraphQLBigInt) { %>import { GraphQLBigInt } from 'graphql-scalars'<% } %>
 import { CorePagingInput } from '@<%= npmScope %>/api/core/data-access'
 
 <% for (const model of models) { %>
@@ -102,7 +105,7 @@ export class Create<%= model.modelName %>Input {
     let tsType;
     if (field.type === 'String') { baseGqlType = 'String'; tsType = 'string'; }
     else if (field.type === 'Int') { baseGqlType = 'Int'; tsType = 'number'; }
-    else if (field.type === 'BigInt') { baseGqlType = 'String'; tsType = 'string'; }
+    else if (field.type === 'BigInt') { baseGqlType = 'GraphQLBigInt'; tsType = 'bigint'; }
     else if (field.type === 'Float') { baseGqlType = 'Float'; tsType = 'number'; }
     else if (field.type === 'Decimal') { baseGqlType = 'Float'; tsType = 'number'; }
     else if (field.type === 'Boolean') { baseGqlType = 'Boolean'; tsType = 'boolean'; }
@@ -146,7 +149,7 @@ export class Update<%= model.modelName %>Input {
     let tsType;
     if (field.type === 'String') { baseGqlType = 'String'; tsType = 'string'; }
     else if (field.type === 'Int') { baseGqlType = 'Int'; tsType = 'number'; }
-    else if (field.type === 'BigInt') { baseGqlType = 'String'; tsType = 'string'; }
+    else if (field.type === 'BigInt') { baseGqlType = 'GraphQLBigInt'; tsType = 'bigint'; }
     else if (field.type === 'Float') { baseGqlType = 'Float'; tsType = 'number'; }
     else if (field.type === 'Decimal') { baseGqlType = 'Float'; tsType = 'number'; }
     else if (field.type === 'Boolean') { baseGqlType = 'Boolean'; tsType = 'boolean'; }
@@ -183,7 +186,7 @@ export class List<%= model.modelName %>Input extends CorePagingInput {
     let tsType;
     if (field.type === 'String') { baseGqlType = 'String'; tsType = 'string'; }
     else if (field.type === 'Int') { baseGqlType = 'Int'; tsType = 'number'; }
-    else if (field.type === 'BigInt') { baseGqlType = 'String'; tsType = 'string'; }
+    else if (field.type === 'BigInt') { baseGqlType = 'GraphQLBigInt'; tsType = 'bigint'; }
     else if (field.type === 'Float') { baseGqlType = 'Float'; tsType = 'number'; }
     else if (field.type === 'Decimal') { baseGqlType = 'Float'; tsType = 'number'; }
     else if (field.type === 'Boolean') { baseGqlType = 'Boolean'; tsType = 'boolean'; }

--- a/generators/api/src/generate-crud/generator.ts
+++ b/generators/api/src/generate-crud/generator.ts
@@ -127,6 +127,10 @@ export function generateResolverContent(model: ModelType, npmScope: string): str
   const countMethodName = `${model.pluralModelPropertyName}Count`
   const readOneMethodName = model.modelPropertyName
 
+  const idTsType = model.idFieldType === 'BigInt' ? 'bigint' : 'string'
+  const idArgsType = model.idFieldType === 'BigInt' ? ", { type: () => GraphQLBigInt }" : ''
+  const graphqlScalarImport = model.idFieldType === 'BigInt' ? "\nimport { GraphQLBigInt } from 'graphql-scalars'" : ''
+
   return `import { Args, Mutation, Query, Resolver, Info } from '@nestjs/graphql'
 import { UseGuards } from '@nestjs/common'
 import type { GraphQLResolveInfo } from 'graphql'
@@ -137,7 +141,7 @@ import {
     Create${model.modelName}Input,
     List${model.modelName}Input,
     Update${model.modelName}Input
-    } from '@${npmScope}/api/generated-crud/data-access'
+    } from '@${npmScope}/api/generated-crud/data-access'${graphqlScalarImport}
 ${guardImports}
 
 @Resolver(() => ${model.modelName})
@@ -169,7 +173,7 @@ export class Generated${model.modelName}Resolver {
   ${readOneGuardDecorator ? `@UseGuards(${readOneGuardDecorator})` : ''}
   ${readOneMethodName}(
     @Info() info: GraphQLResolveInfo,
-    @Args('${model.modelPropertyName}Id') ${model.modelPropertyName}Id: string
+    @Args('${model.modelPropertyName}Id'${idArgsType}) ${model.modelPropertyName}Id: ${idTsType}
   ) {
     return this.generatedService.${readOneMethodName}(info, ${model.modelPropertyName}Id)
   }
@@ -187,7 +191,7 @@ export class Generated${model.modelName}Resolver {
   ${updateGuardDecorator ? `@UseGuards(${updateGuardDecorator})` : ''}
   update${model.modelName}(
     @Info() info: GraphQLResolveInfo,
-    @Args('${model.modelPropertyName}Id') ${model.modelPropertyName}Id: string,
+    @Args('${model.modelPropertyName}Id'${idArgsType}) ${model.modelPropertyName}Id: ${idTsType},
     @Args('input') input: Update${model.modelName}Input,
   ) {
     return this.generatedService.update${model.modelName}(info, ${model.modelPropertyName}Id, input)
@@ -196,7 +200,7 @@ export class Generated${model.modelName}Resolver {
   @Mutation(() => ${model.modelName}, { nullable: true })
   ${deleteGuardDecorator ? `@UseGuards(${deleteGuardDecorator})` : ''}
   delete${model.modelName}(
-    @Args('${model.modelPropertyName}Id') ${model.modelPropertyName}Id: string,
+    @Args('${model.modelPropertyName}Id'${idArgsType}) ${model.modelPropertyName}Id: ${idTsType},
   ) {
     return this.generatedService.delete${model.modelName}(${model.modelPropertyName}Id)
   }


### PR DESCRIPTION
This pull request adds comprehensive support for the `BigInt` type in generated GraphQL models, DTOs, services, and resolvers. The changes ensure that fields and IDs of type `BigInt` are correctly handled as `bigint` in TypeScript and use the appropriate `GraphQLBigInt` scalar in GraphQL schemas, improving type safety and compatibility.

**GraphQL and TypeScript BigInt support**

* In `generate-models.ts__tmpl__`, the code now detects `BigInt` fields and imports `GraphQLBigInt` from `graphql-scalars`, mapping `BigInt` fields to the correct GraphQL and TypeScript types in generated models. [[1]](diffhunk://#diff-5155b83e6fbfc17ec8c993afcc18bf3603278aa68cdf1da24f4f8df72214fa73R196-R199) [[2]](diffhunk://#diff-5155b83e6fbfc17ec8c993afcc18bf3603278aa68cdf1da24f4f8df72214fa73R211-R213) [[3]](diffhunk://#diff-5155b83e6fbfc17ec8c993afcc18bf3603278aa68cdf1da24f4f8df72214fa73R283) [[4]](diffhunk://#diff-5155b83e6fbfc17ec8c993afcc18bf3603278aa68cdf1da24f4f8df72214fa73R300)
* In generated DTOs (`index.ts__tmpl__`), fields of type `BigInt` are now typed as `bigint` in TypeScript and use `GraphQLBigInt` in GraphQL, with the necessary import added only if needed. [[1]](diffhunk://#diff-dc7dc9567fd7228cb4b7bcb452a73dc5c350465165b264444b4cf13ef71c48e4R5) [[2]](diffhunk://#diff-dc7dc9567fd7228cb4b7bcb452a73dc5c350465165b264444b4cf13ef71c48e4R74) [[3]](diffhunk://#diff-dc7dc9567fd7228cb4b7bcb452a73dc5c350465165b264444b4cf13ef71c48e4R90) [[4]](diffhunk://#diff-dc7dc9567fd7228cb4b7bcb452a73dc5c350465165b264444b4cf13ef71c48e4L105-R108) [[5]](diffhunk://#diff-dc7dc9567fd7228cb4b7bcb452a73dc5c350465165b264444b4cf13ef71c48e4L149-R152) [[6]](diffhunk://#diff-dc7dc9567fd7228cb4b7bcb452a73dc5c350465165b264444b4cf13ef71c48e4L186-R189)

**Service and resolver method signature updates**

* In `api-crud-data-access.service.ts__tmpl__`, service methods now accept `bigint` for IDs when the model uses `BigInt`, and pass the ID directly to Prisma, removing unnecessary conversions.
* In resolver generation (`generator.ts`), resolver methods for read, update, and delete operations now use `bigint` for IDs when appropriate and apply the `GraphQLBigInt` scalar in argument decorators, with conditional imports. [[1]](diffhunk://#diff-8a42808218d3bc2d1598ec19834184b6413e9e25501fa68053cb481fdd4ceb85R130-R133) [[2]](diffhunk://#diff-8a42808218d3bc2d1598ec19834184b6413e9e25501fa68053cb481fdd4ceb85L140-R144) [[3]](diffhunk://#diff-8a42808218d3bc2d1598ec19834184b6413e9e25501fa68053cb481fdd4ceb85L172-R176) [[4]](diffhunk://#diff-8a42808218d3bc2d1598ec19834184b6413e9e25501fa68053cb481fdd4ceb85L190-R194) [[5]](diffhunk://#diff-8a42808218d3bc2d1598ec19834184b6413e9e25501fa68053cb481fdd4ceb85L199-R203)