### PR TITLE
fix(generators): add clarifying comment for BigInt ID field handling

### DIFF
--- a/generators/api/src/generate-crud/generator.ts
+++ b/generators/api/src/generate-crud/generator.ts
@@ -127,6 +127,8 @@ export function generateResolverContent(model: ModelType, npmScope: string): str
   const countMethodName = `${model.pluralModelPropertyName}Count`
   const readOneMethodName = model.modelPropertyName
 
+  // Handle BigInt ID fields: use GraphQLBigInt scalar from graphql-scalars
+  // to properly serialize/deserialize bigint values in GraphQL
   const idTsType = model.idFieldType === 'BigInt' ? 'bigint' : 'string'
   const idArgsType = model.idFieldType === 'BigInt' ? ", { type: () => GraphQLBigInt }" : ''
   const graphqlScalarImport = model.idFieldType === 'BigInt' ? "\nimport { GraphQLBigInt } from 'graphql-scalars'" : ''


### PR DESCRIPTION
## Summary
- Add documentation comment explaining BigInt ID field handling in resolver generator

## Details
This PR adds a clarifying comment to the resolver generator code to explain the use of GraphQLBigInt scalar for proper serialization/deserialization of bigint values in GraphQL.

This is a minor documentation improvement to help future maintainers understand the BigInt handling logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)