### PR TITLE
docs(generators): add clarifying comments for BigInt to GraphQLBigInt mapping

### DIFF
--- a/generators/api/src/core/files/models/src/lib/generate-models.ts__tmpl__
+++ b/generators/api/src/core/files/models/src/lib/generate-models.ts__tmpl__
@@ -280,6 +280,8 @@ function generateModels(models: readonly any[], enums: readonly any[]): string {
         if (originalType === 'Int') listItemGraphQLType = 'Int'
         else if (originalType === 'Float') listItemGraphQLType = 'Float'
         else if (originalType === 'Decimal') listItemGraphQLType = 'GraphQLDecimal'
+        // IMPORTANT: Use GraphQLBigInt from graphql-scalars for BigInt fields
+        // Never use raw 'BigInt' as it's not a valid GraphQL type
         else if (originalType === 'BigInt') listItemGraphQLType = 'GraphQLBigInt'
         else if (originalType === 'Json') listItemGraphQLType = 'GraphQLJSONObject'
         else if (isEnum || isRelation)
@@ -297,6 +299,8 @@ function generateModels(models: readonly any[], enums: readonly any[]): string {
         if (originalType === 'Int') decoratorType = '() => Int'
         else if (originalType === 'Float') decoratorType = '() => Float'
         else if (originalType === 'Decimal') decoratorType = '() => GraphQLDecimal'
+        // IMPORTANT: Use GraphQLBigInt from graphql-scalars for BigInt fields
+        // Never use raw 'BigInt' as it's not a valid GraphQL type
         else if (originalType === 'BigInt') decoratorType = '() => GraphQLBigInt'
         else if (originalType === 'Json') decoratorType = '() => GraphQLJSONObject'
         else if (isEnum || isRelation) decoratorType = `() => ${originalType}`


### PR DESCRIPTION
## Summary
- Add documentation comments emphasizing BigInt → GraphQLBigInt mapping in model generator

## Details
This PR adds clarifying comments to the model generator template to make it explicitly clear that BigInt fields must use `GraphQLBigInt` scalar from `graphql-scalars`, not the raw `BigInt` type.

The comments are added in two locations:
1. List field type mapping (line 283)
2. Single field type mapping (line 300)

## Why This Helps
- Makes the code more maintainable and self-documenting
- Prevents confusion for developers working with BigInt fields
- Emphasizes that raw 'BigInt' is not a valid GraphQL type

## Note to Users
If you have existing generated models that use `@Field(() => BigInt)`, you need to:
1. Update to @nestledjs/generators@0.2.2 or later  
2. Regenerate your models by running the model generation command in your project

The generator template is already correct - this PR just adds clarifying documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)