### PR TITLE
fix(shared): add BigInt scalar mapping to SDK codegen configuration

### DIFF
--- a/generators/shared/src/sdk/files/codegen.yml__tmpl__
+++ b/generators/shared/src/sdk/files/codegen.yml__tmpl__
@@ -16,11 +16,15 @@ generates:
       gqlImport: '@apollo/client#gql'
       preResolveTypes: true
       apolloReactHooksImportFrom: '@apollo/client/react'
+      scalars:
+        BigInt: bigint
   # Client preset for new code (Apollo Client 4 compatible)
   libs/shared/sdk/src/generated/client/:
     preset: client
     config:
       useTypeImports: true
+      scalars:
+        BigInt: bigint
 
 hooks:
   afterAllFileWrite:


### PR DESCRIPTION
## Summary
- Add BigInt scalar type mapping to GraphQL Code Generator configuration
- Fixes SDK input types to use `bigint` instead of `string` for BigInt fields

## Problem
The SDK generator was not configuring GraphQL Code Generator to properly map the BigInt scalar type to TypeScript's bigint type. This caused generated SDK code (both in `graphql/**` and `__admin/**`) to use `string` type for BigInt fields instead of `bigint`.

## Solution
Added scalar mappings to `codegen.yml` template:
```yaml
scalars:
  BigInt: bigint
```

This is applied to both:
1. Legacy hooks configuration (`libs/shared/sdk/src/generated/graphql.ts`)
2. Client preset configuration (`libs/shared/sdk/src/generated/client/`)

## Impact
After this fix and regenerating SDK:
- Input types will correctly use `bigint` for BigInt fields
- Output types will correctly use `bigint` for BigInt fields  
- Type safety is maintained throughout the SDK layer

## Note to Users
After updating to this version:
1. Regenerate SDK with `npm run sdk` or similar command
2. The generated types in `libs/shared/sdk/src/generated/` will now use `bigint` for BigInt fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)