### PR TITLE
fix(generators): use Apollo Client 4 compatible imports in web app template

### DIFF
--- a/generators/web/src/app/files/app/app.tsx__tmpl__
+++ b/generators/web/src/app/files/app/app.tsx__tmpl__
@@ -3,7 +3,7 @@ import type { UptimeQuery } from '@<%= npmScope %>/shared/sdk'
 import { UptimeDocument } from '@<%= npmScope %>/shared/sdk'
 import { apolloLoader } from './apollo-loader'
 import { useLoaderData } from 'react-router'
-import { useReadQuery } from '@apollo/client'
+import { useReadQuery } from '@apollo/client/react'
 
 export const loader = apolloLoader()(({ preloadQuery }) => {
   const uptimeQueryRef = preloadQuery(UptimeDocument)


### PR DESCRIPTION
## Summary
- Updated web app template to import `useReadQuery` from `@apollo/client/react` instead of `@apollo/client` for Apollo Client 4 compatibility

## Details
The `app.tsx__tmpl__` template file was importing React hooks directly from `@apollo/client`, but Apollo Client v4 requires React-specific hooks to be imported from the `@apollo/client/react` submodule. This change ensures that generated web applications will use the correct import paths.

## Files Changed
- `generators/web/src/app/files/app/app.tsx__tmpl__` - Updated `useReadQuery` import path

## Test Plan
- [ ] Verify the template change doesn't break existing generator tests
- [ ] Generate a new web app and confirm it uses the correct import
- [ ] Ensure the generated code works with Apollo Client 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)