### PR TITLE
fix: add 'use client' directives for React Server Components compatibility

### DIFF
--- a/forms/src/lib/fields/base-select-field.tsx
+++ b/forms/src/lib/fields/base-select-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { ReactElement, JSXElementConstructor } from 'react'
 import { Controller } from 'react-hook-form'
 import clsx from 'clsx'

--- a/forms/src/lib/fields/button-field.tsx
+++ b/forms/src/lib/fields/button-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 import { FormField, FormFieldProps, FormFieldType } from '../form-types'
 import { Button, ButtonProps } from './button'

--- a/forms/src/lib/fields/button.tsx
+++ b/forms/src/lib/fields/button.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 import clsx from 'clsx'
 import { useFormTheme } from '../theme-context'

--- a/forms/src/lib/fields/checkbox-field.tsx
+++ b/forms/src/lib/fields/checkbox-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import clsx from 'clsx'
 import React from 'react'
 import { useFormTheme } from '../theme-context'

--- a/forms/src/lib/fields/checkbox-group.tsx
+++ b/forms/src/lib/fields/checkbox-group.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 import { Controller } from 'react-hook-form'
 import clsx from 'clsx'

--- a/forms/src/lib/fields/custom-checkbox-field.tsx
+++ b/forms/src/lib/fields/custom-checkbox-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import clsx from 'clsx'
 import React from 'react'
 import { useFormTheme } from '../theme-context'

--- a/forms/src/lib/fields/custom-field.tsx
+++ b/forms/src/lib/fields/custom-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import clsx from 'clsx'
 import React from 'react'
 import { useFormTheme } from '../theme-context'

--- a/forms/src/lib/fields/datepicker-field.tsx
+++ b/forms/src/lib/fields/datepicker-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import clsx from 'clsx'
 import React from 'react'
 import { Controller } from 'react-hook-form'

--- a/forms/src/lib/fields/datetimepicker-field.tsx
+++ b/forms/src/lib/fields/datetimepicker-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import clsx from 'clsx'
 import React from 'react'
 import { Controller } from 'react-hook-form'

--- a/forms/src/lib/fields/email-field.tsx
+++ b/forms/src/lib/fields/email-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import clsx from 'clsx'
 import { FormField, FormFieldProps, FormFieldType } from '../form-types'
 import { useFormTheme } from '../theme-context'

--- a/forms/src/lib/fields/label.tsx
+++ b/forms/src/lib/fields/label.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 import clsx from 'clsx'
 import { useFormTheme } from '../theme-context'

--- a/forms/src/lib/fields/markdown-editor.tsx
+++ b/forms/src/lib/fields/markdown-editor.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { lazy, Suspense, useCallback, useEffect } from 'react'
 import { Controller } from 'react-hook-form'
 import clsx from 'clsx'

--- a/forms/src/lib/fields/money-field.tsx
+++ b/forms/src/lib/fields/money-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import clsx from 'clsx'
 import React, { useState, useEffect } from 'react'
 import { FormField, FormFieldType, FormFieldProps } from '../form-types'

--- a/forms/src/lib/fields/number-field.tsx
+++ b/forms/src/lib/fields/number-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import clsx from 'clsx'
 import { FormField, FormFieldProps, FormFieldType } from '../form-types'
 import { useFormTheme } from '../theme-context'

--- a/forms/src/lib/fields/password-field.tsx
+++ b/forms/src/lib/fields/password-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import clsx from 'clsx'
 import { FormField, FormFieldProps, FormFieldType } from '../form-types'
 import { useFormTheme } from '../theme-context'

--- a/forms/src/lib/fields/phone-field.tsx
+++ b/forms/src/lib/fields/phone-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { isPossiblePhoneNumber } from 'react-phone-number-input'
 import clsx from 'clsx'
 import { FormField, FormFieldProps, FormFieldType } from '../form-types'

--- a/forms/src/lib/fields/radio-field.tsx
+++ b/forms/src/lib/fields/radio-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { useEffect, useState } from 'react'
 import { FormFieldProps, FormField, FormFieldType, RadioOption, RadioFormFieldOptions } from '../form-types'
 import { Controller } from 'react-hook-form'

--- a/forms/src/lib/fields/search-select-base.tsx
+++ b/forms/src/lib/fields/search-select-base.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { useState, ReactNode, useRef, useEffect, useCallback } from 'react'
 import clsx from 'clsx'
 import { SearchSelectOption } from '../form-types'

--- a/forms/src/lib/fields/search-select-helpers.tsx
+++ b/forms/src/lib/fields/search-select-helpers.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { SearchSelectOption } from '../form-types'
 
 // Selected items component for multi-select

--- a/forms/src/lib/fields/select-field-enum.tsx
+++ b/forms/src/lib/fields/select-field-enum.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { FormField, FormFieldProps, FormFieldType } from '../form-types'
 import { SelectField } from './select-field'
 

--- a/forms/src/lib/fields/select-field-multi-search-apollo.tsx
+++ b/forms/src/lib/fields/select-field-multi-search-apollo.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { FormField, FormFieldProps, FormFieldType, SearchSelectOption } from '../form-types'
 import { SearchSelectBase } from './search-select-base'
 import { multiSelectDisplayValue, SelectedItems } from './search-select-helpers'

--- a/forms/src/lib/fields/select-field-multi-search.tsx
+++ b/forms/src/lib/fields/select-field-multi-search.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { FormField, FormFieldProps, FormFieldType } from '../form-types'
 import { SearchSelectBase } from './search-select-base'
 import { SelectedItems, multiSelectDisplayValue } from './search-select-helpers'

--- a/forms/src/lib/fields/select-field-multi.tsx
+++ b/forms/src/lib/fields/select-field-multi.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { FormFieldProps, FormField, FormFieldType } from '../form-types'
 import { SearchSelectBase } from './search-select-base'
 import { SelectedItems } from './search-select-helpers'

--- a/forms/src/lib/fields/select-field-search-apollo.tsx
+++ b/forms/src/lib/fields/select-field-search-apollo.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { FormField, FormFieldProps, FormFieldType } from '../form-types'
 import { SearchSelectBase } from './search-select-base'
 import { singleSelectDisplayValue } from './search-select-helpers'

--- a/forms/src/lib/fields/select-field-search.tsx
+++ b/forms/src/lib/fields/select-field-search.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { FormField, FormFieldProps, FormFieldType } from '../form-types'
 import { SearchSelectBase } from './search-select-base'
 import { singleSelectDisplayValue } from './search-select-helpers'

--- a/forms/src/lib/fields/select-field.tsx
+++ b/forms/src/lib/fields/select-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import clsx from 'clsx'
 import { FormField, FormFieldProps, FormFieldType, SelectOption } from '../form-types'
 import { BaseSelectField } from './base-select-field'

--- a/forms/src/lib/fields/switch-field.tsx
+++ b/forms/src/lib/fields/switch-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import clsx from 'clsx'
 import { Controller } from 'react-hook-form'
 import { FormField, FormFieldProps, FormFieldType } from '../form-types'

--- a/forms/src/lib/fields/text-field.tsx
+++ b/forms/src/lib/fields/text-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import clsx from 'clsx'
 import { FormField, FormFieldProps, FormFieldType } from '../form-types'
 import { useFormTheme } from '../theme-context'

--- a/forms/src/lib/fields/textarea-field.tsx
+++ b/forms/src/lib/fields/textarea-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import clsx from 'clsx'
 import { FormField, FormFieldProps, FormFieldType } from '../form-types'
 import { useFormTheme } from '../theme-context'

--- a/forms/src/lib/fields/timepicker-field.tsx
+++ b/forms/src/lib/fields/timepicker-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import clsx from 'clsx'
 import { FormFieldProps, FormFieldType, BaseFieldOptions } from '../form-types'
 import { useFormTheme } from '../theme-context'

--- a/forms/src/lib/fields/url-field.tsx
+++ b/forms/src/lib/fields/url-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import clsx from 'clsx'
 import { FormField, FormFieldProps, FormFieldType } from '../form-types'
 import { useFormTheme } from '../theme-context'

--- a/forms/src/lib/fields/use-apollo-search.ts
+++ b/forms/src/lib/fields/use-apollo-search.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useQuery } from '@apollo/client/react'
 import { useEffect, useState, useCallback } from 'react'
 import { SearchSelectOption, SearchSelectApolloOptions } from '../form-types'

--- a/forms/src/lib/form-config-context.ts
+++ b/forms/src/lib/form-config-context.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { createContext, useContext } from 'react';
 
 /**

--- a/forms/src/lib/form-context.ts
+++ b/forms/src/lib/form-context.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { createContext, useContext } from 'react'
 import { UseFormReturn, FieldValues } from 'react-hook-form'
 

--- a/forms/src/lib/form.tsx
+++ b/forms/src/lib/form.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { useEffect, useMemo } from 'react'
 import { useForm, UseFormProps, FieldValues } from 'react-hook-form'
 import { FormField, FormFieldType, InputFieldOptions } from './form-types'

--- a/forms/src/lib/hooks/use-field-validation.ts
+++ b/forms/src/lib/hooks/use-field-validation.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useMemo } from 'react'
 import { UseFormReturn, FieldValues } from 'react-hook-form'
 import { createFieldValidation } from '../utils/validation'

--- a/forms/src/lib/render-form-field.tsx
+++ b/forms/src/lib/render-form-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { useMemo, useEffect, useRef } from 'react'
 import clsx from 'clsx'
 import { FormField, FormFieldType } from './form-types'

--- a/forms/src/lib/theme-context.ts
+++ b/forms/src/lib/theme-context.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { createContext, useContext } from 'react'
 import { FormTheme, FormThemeSchema } from './form-theme'
 

--- a/forms/src/lib/utils/client-only.tsx
+++ b/forms/src/lib/utils/client-only.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { useEffect, useState, ReactNode } from 'react'
 
 interface ClientOnlyProps {

--- a/forms/src/lib/utils/debounce.ts
+++ b/forms/src/lib/utils/debounce.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useEffect, useState } from 'react'
 
 export function useDebounce<T>(value: T, delay = 500): T {


### PR DESCRIPTION
## Summary
Adds `'use client'` directive to all components and hooks that use React features, ensuring proper SSR/hydration behavior in Next.js App Router and React Router v7.

## Problem
The library was causing production errors in SSR environments where FormField components attempted to access Form context before it was properly established during server-side rendering, resulting in:
```
FormField components must be used within a <Form> component.
```

## Solution
Added `'use client'` directives to 40 files:
- **Context providers** (form-context, form-config-context, theme-context)
- **Core components** (Form, RenderFormField)
- **All field components** (text, email, checkbox, select, etc.)
- **Hooks** (useFieldValidation, useApolloSearch, useDebounce)
- **Utility components** (ClientOnly)

## Impact
- ✅ Fixes SSR/hydration errors in production
- ✅ Eliminates need for ClientOnly workarounds
- ✅ Restores proper SSR benefits for form content
- ✅ Ensures compatibility with React Server Components

## Test Plan
- [ ] Test in Next.js App Router with SSR
- [ ] Test in React Router v7 with SSR
- [ ] Verify forms render correctly on initial page load
- [ ] Verify no hydration warnings in console
- [ ] Test that forms still work in development mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)