### PR TITLE
feat(sdk): preserve existing codegen.yml files in SDK generator

### DIFF
--- a/generators/shared/src/sdk/generator.spec.ts
+++ b/generators/shared/src/sdk/generator.spec.ts
@@ -24,6 +24,8 @@ describe('sdk generator', () => {
 
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
+    // Add a package.json to the root for getNpmScope to work
+    tree.write('package.json', JSON.stringify({ name: '@test/workspace' }));
     mockDependencies = {
       formatFiles: vi.fn(),
       installPackagesTask: vi.fn(),
@@ -34,6 +36,7 @@ describe('sdk generator', () => {
       addScriptToPackageJson: vi.fn(),
       getPluralName: vi.fn((name: string) => name + 's'),
       libraryGenerator: vi.fn(),
+      getNpmScope: vi.fn().mockReturnValue('test'),
       join: vi.fn((...args: string[]) => args.join('/')),
       existsSync: vi.fn().mockReturnValue(true),
       statSync: vi.fn().mockReturnValue({ isDirectory: () => false }),
@@ -100,7 +103,7 @@ describe('sdk generator', () => {
     it('preserves existing codegen.yml by default', async () => {
       const existingContent = 'overwrite: true\nschema: "./api-schema.graphql"';
       tree.exists = vi.fn().mockImplementation((path: string) => {
-        return path === 'libs/shared/sdk/src/codegen.yml' || path !== 'libs/shared/sdk';
+        return path === 'libs/shared/sdk/src/codegen.yml' || path === 'package.json' || path !== 'libs/shared/sdk';
       });
       tree.read = vi.fn().mockImplementation((path: string) => {
         if (path === 'libs/shared/sdk/src/codegen.yml') {
@@ -118,7 +121,7 @@ describe('sdk generator', () => {
 
     it('forces regeneration when forceCodegen is true', async () => {
       tree.exists = vi.fn().mockImplementation((path: string) => {
-        return path === 'libs/shared/sdk/src/codegen.yml' || path !== 'libs/shared/sdk';
+        return path === 'libs/shared/sdk/src/codegen.yml' || path === 'package.json' || path !== 'libs/shared/sdk';
       });
       tree.write = vi.fn();
 
@@ -136,7 +139,7 @@ describe('sdk generator', () => {
 
     it('handles null return from tree.read gracefully', async () => {
       tree.exists = vi.fn().mockImplementation((path: string) => {
-        return path === 'libs/shared/sdk/src/codegen.yml' || path !== 'libs/shared/sdk';
+        return path === 'libs/shared/sdk/src/codegen.yml' || path === 'package.json' || path !== 'libs/shared/sdk';
       });
       tree.read = vi.fn().mockReturnValue(null);
       tree.write = vi.fn();

--- a/generators/shared/src/sdk/generator.spec.ts
+++ b/generators/shared/src/sdk/generator.spec.ts
@@ -98,11 +98,16 @@ describe('sdk generator', () => {
     });
 
     it('preserves existing codegen.yml by default', async () => {
-      const existingContent = 'existing config content';
+      const existingContent = 'overwrite: true\nschema: "./api-schema.graphql"';
       tree.exists = vi.fn().mockImplementation((path: string) => {
         return path === 'libs/shared/sdk/src/codegen.yml' || path !== 'libs/shared/sdk';
       });
-      tree.read = vi.fn().mockReturnValue(existingContent);
+      tree.read = vi.fn().mockImplementation((path: string) => {
+        if (path === 'libs/shared/sdk/src/codegen.yml') {
+          return existingContent;
+        }
+        return null;
+      });
       tree.write = vi.fn();
 
       await sdkGeneratorLogic(tree, {}, mockDependencies);

--- a/generators/shared/src/sdk/generator.spec.ts
+++ b/generators/shared/src/sdk/generator.spec.ts
@@ -80,4 +80,65 @@ describe('sdk generator', () => {
     expect(userCall[3].adminPrefix).toBe('');
     expect(adminCall[3].adminPrefix).toBe('__Admin');
   });
+
+  describe('codegen.yml handling', () => {
+    it('generates new codegen.yml when file does not exist', async () => {
+      tree.exists = vi.fn().mockImplementation((path: string) => {
+        return path !== 'libs/shared/sdk/src/codegen.yml';
+      });
+
+      await sdkGeneratorLogic(tree, {}, mockDependencies);
+
+      expect(mockDependencies.generateFiles).toHaveBeenCalledWith(
+        tree,
+        expect.stringContaining('./files'),
+        'libs/shared/sdk/src',
+        { tmpl: '' }
+      );
+    });
+
+    it('preserves existing codegen.yml by default', async () => {
+      const existingContent = 'existing config content';
+      tree.exists = vi.fn().mockImplementation((path: string) => {
+        return path === 'libs/shared/sdk/src/codegen.yml' || path !== 'libs/shared/sdk';
+      });
+      tree.read = vi.fn().mockReturnValue(existingContent);
+      tree.write = vi.fn();
+
+      await sdkGeneratorLogic(tree, {}, mockDependencies);
+
+      expect(tree.read).toHaveBeenCalledWith('libs/shared/sdk/src/codegen.yml', 'utf-8');
+      expect(tree.write).toHaveBeenCalledWith('libs/shared/sdk/src/codegen.yml', existingContent);
+    });
+
+    it('forces regeneration when forceCodegen is true', async () => {
+      tree.exists = vi.fn().mockImplementation((path: string) => {
+        return path === 'libs/shared/sdk/src/codegen.yml' || path !== 'libs/shared/sdk';
+      });
+      tree.write = vi.fn();
+
+      await sdkGeneratorLogic(tree, { forceCodegen: true }, mockDependencies);
+
+      expect(mockDependencies.generateFiles).toHaveBeenCalledWith(
+        tree,
+        expect.stringContaining('./files'),
+        'libs/shared/sdk/src',
+        { tmpl: '' }
+      );
+      // Should not restore the existing content
+      expect(tree.write).not.toHaveBeenCalledWith('libs/shared/sdk/src/codegen.yml', expect.any(String));
+    });
+
+    it('handles null return from tree.read gracefully', async () => {
+      tree.exists = vi.fn().mockImplementation((path: string) => {
+        return path === 'libs/shared/sdk/src/codegen.yml' || path !== 'libs/shared/sdk';
+      });
+      tree.read = vi.fn().mockReturnValue(null);
+      tree.write = vi.fn();
+
+      await sdkGeneratorLogic(tree, {}, mockDependencies);
+
+      expect(tree.write).toHaveBeenCalledWith('libs/shared/sdk/src/codegen.yml', '');
+    });
+  });
 }); 

--- a/generators/shared/src/sdk/generator.ts
+++ b/generators/shared/src/sdk/generator.ts
@@ -24,6 +24,10 @@ import { getDMMF } from '@prisma/internals'
 
 const SCALAR_TYPES = ['String', 'Int', 'Boolean', 'Float', 'DateTime', 'Json', 'BigInt', 'Decimal', 'Bytes']
 
+interface SdkGeneratorSchema {
+  forceCodegen?: boolean
+}
+
 function kebabCase(str: string): string {
   return str
     .replace(/([a-z])([A-Z])/g, '$1-$2')
@@ -116,7 +120,7 @@ export type SdkGeneratorDependencies = typeof defaultDependencies
 
 export async function sdkGeneratorLogic(
   tree: Tree,
-  schema: unknown,
+  schema: SdkGeneratorSchema,
   dependencies: SdkGeneratorDependencies = defaultDependencies,
 ) {
   // 1. Resolve prisma schema path using shared utility (config-aware), fallback to package.json
@@ -230,9 +234,34 @@ export async function sdkGeneratorLogic(
     })
   }
 
-  // 7. Always write codegen.yml and index.ts
+  // 7. Handle codegen.yml generation with existence check
   const sdkSrcDir = 'libs/shared/sdk/src'
+  const codegenPath = 'libs/shared/sdk/src/codegen.yml'
+  
+  // Check if codegen.yml exists before generation
+  const codegenExists = tree.exists(codegenPath)
+  const shouldPreserveCodegen = codegenExists && !schema.forceCodegen
+  let existingCodegenContent: string | null = null
+  
+  if (shouldPreserveCodegen) {
+    // Backup existing codegen.yml content
+    existingCodegenContent = tree.read(codegenPath, 'utf-8')
+    console.log('⚠️  codegen.yml already exists. Preserving existing configuration.')
+    console.log('   Use --forceCodegen=true to regenerate codegen.yml.')
+  } else if (codegenExists && schema.forceCodegen) {
+    console.log('🔄 Forcing regeneration of codegen.yml as requested.')
+  }
+  
+  // Generate all files from template
   dependencies.generateFiles(tree, dependencies.joinPathFragments(__dirname, './files'), sdkSrcDir, { tmpl: '' })
+  
+  // Restore existing codegen.yml if it existed and we should preserve it
+  if (shouldPreserveCodegen && existingCodegenContent) {
+    tree.write(codegenPath, existingCodegenContent)
+    console.log('✅ Existing codegen.yml configuration has been preserved.')
+  } else {
+    console.log('⚙️  Generated codegen.yml file.')
+  }
 
   // 8. Add scripts to package.json
   dependencies.addScriptToPackageJson(tree, 'sdk', 'graphql-codegen --config libs/shared/sdk/src/codegen.yml')
@@ -259,6 +288,6 @@ export async function sdkGeneratorLogic(
   }
 }
 
-export default async function (tree: Tree, schema: unknown) {
+export default async function (tree: Tree, schema: SdkGeneratorSchema) {
   return sdkGeneratorLogic(tree, schema)
 }

--- a/generators/shared/src/sdk/generator.ts
+++ b/generators/shared/src/sdk/generator.ts
@@ -288,6 +288,6 @@ export async function sdkGeneratorLogic(
   }
 }
 
-export default async function (tree: Tree, schema: SdkGeneratorSchema) {
+export default async function sdkGenerator(tree: Tree, schema: SdkGeneratorSchema) {
   return sdkGeneratorLogic(tree, schema)
 }

--- a/generators/shared/src/sdk/generator.ts
+++ b/generators/shared/src/sdk/generator.ts
@@ -64,7 +64,7 @@ function getAdminFragmentFields(model: any, allModels: ReadonlyArray<any>): stri
 
 async function ensureSdkLibrary(tree: Tree, dependencies: SdkGeneratorDependencies) {
   const sdkPath = 'libs/shared/sdk'
-  const npmScope = getNpmScope(tree)
+  const npmScope = dependencies.getNpmScope(tree)
   if (!tree.exists(sdkPath)) {
     // Create the sdk library if it doesn't exist
     await dependencies.libraryGenerator(tree, {
@@ -109,6 +109,7 @@ const defaultDependencies = {
   getPluralName,
   libraryGenerator,
   getPrismaSchemaPath,
+  getNpmScope,
   // Specific functions from path and fs
   join: path.join,
   existsSync: fs.existsSync,

--- a/generators/shared/src/sdk/generator.ts
+++ b/generators/shared/src/sdk/generator.ts
@@ -245,7 +245,7 @@ export async function sdkGeneratorLogic(
   
   if (shouldPreserveCodegen) {
     // Backup existing codegen.yml content
-    existingCodegenContent = tree.read(codegenPath, 'utf-8')
+    existingCodegenContent = tree.read(codegenPath, 'utf-8') || ''
     console.log('⚠️  codegen.yml already exists. Preserving existing configuration.')
     console.log('   Use --forceCodegen=true to regenerate codegen.yml.')
   } else if (codegenExists && schema.forceCodegen) {
@@ -256,11 +256,13 @@ export async function sdkGeneratorLogic(
   dependencies.generateFiles(tree, dependencies.joinPathFragments(__dirname, './files'), sdkSrcDir, { tmpl: '' })
   
   // Restore existing codegen.yml if it existed and we should preserve it
-  if (shouldPreserveCodegen && existingCodegenContent) {
+  if (shouldPreserveCodegen) {
     tree.write(codegenPath, existingCodegenContent)
     console.log('✅ Existing codegen.yml configuration has been preserved.')
-  } else {
-    console.log('⚙️  Generated codegen.yml file.')
+  } else if (!codegenExists) {
+    console.log('⚙️  Generated new codegen.yml file.')
+  } else if (codegenExists && schema.forceCodegen) {
+    console.log('⚙️  Force-regenerated codegen.yml file.')
   }
 
   // 8. Add scripts to package.json

--- a/generators/shared/src/sdk/schema.json
+++ b/generators/shared/src/sdk/schema.json
@@ -3,6 +3,12 @@
   "id": "sdk-generator",
   "title": "SDK GraphQL Files Generator",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "forceCodegen": {
+      "type": "boolean",
+      "description": "Force regeneration of codegen.yml even if it already exists",
+      "default": false
+    }
+  },
   "required": []
 } 


### PR DESCRIPTION
## Summary
- Prevents SDK generator from overwriting existing `codegen.yml` files without explicit permission
- Adds `forceCodegen` option to control when codegen.yml should be regenerated
- Provides clear console feedback about file preservation/generation

## Problem
The SDK generator was unconditionally overwriting `codegen.yml` files on every run, which caused issues for projects using different Apollo versions that require specific codegen configurations.

## Solution
- **Default behavior**: Preserve existing `codegen.yml` files
- **Override option**: Use `--forceCodegen=true` to force regeneration
- **Clear messaging**: Console logs inform users about what's happening and how to override

## Usage Examples
```bash
# Normal run - preserves existing codegen.yml
nx g @nestledjs/shared:sdk

# Force regeneration of codegen.yml  
nx g @nestledjs/shared:sdk --forceCodegen=true
```

## Changes Made
1. Added `SdkGeneratorSchema` interface with `forceCodegen` boolean option
2. Updated generator logic to check file existence before overwriting
3. Added schema.json configuration for the new option
4. Implemented backup/restore mechanism for existing configurations
5. Added user-friendly console messages

## Test Plan
- [ ] Run generator on project without existing codegen.yml (should generate)
- [ ] Run generator on project with existing codegen.yml (should preserve)
- [ ] Run generator with `--forceCodegen=true` (should overwrite)
- [ ] Verify console messages are clear and helpful

🤖 Generated with [Claude Code](https://claude.ai/code)