### PR TITLE
fix(forms,shared,utils): Update codegen and add type to database-models

### DIFF
--- a/forms/src/lib/form-fields.ts
+++ b/forms/src/lib/form-fields.ts
@@ -224,7 +224,7 @@ export class FormFieldClass {
    * })
    * ```
    */
-  password(key: string, options: PasswordFieldOptions = {}): FormField {
+  static password(key: string, options: PasswordFieldOptions = {}): FormField {
     return this.field(FormFieldType.Password, key, options)
   }
 

--- a/generators/shared/src/sdk/files/codegen.yml__tmpl__
+++ b/generators/shared/src/sdk/files/codegen.yml__tmpl__
@@ -4,21 +4,18 @@ documents:
   - 'libs/shared/sdk/src/graphql/**/*.graphql'
   - 'libs/shared/sdk/src/__admin/**/*.graphql'
 generates:
-  # Legacy hooks for existing code
+  # TypedDocumentNode exports for reusable documents
   libs/shared/sdk/src/generated/graphql.ts:
     plugins:
       - typescript
       - typescript-operations
-      - typescript-react-apollo
+      - typescript-document-nodes
     config:
-      withHooks: true
-      useTypedDocumentNode: true
-      gqlImport: '@apollo/client#gql'
+      useTypeImports: true
       preResolveTypes: true
-      apolloReactHooksImportFrom: '@apollo/client/react'
       scalars:
         BigInt: bigint
-  # Client preset for new code (Apollo Client 4 compatible)
+  # Client preset for inline queries
   libs/shared/sdk/src/generated/client/:
     preset: client
     config:

--- a/generators/utils/src/lib/generator-utils.ts
+++ b/generators/utils/src/lib/generator-utils.ts
@@ -831,6 +831,7 @@ export function generateDatabaseModelContent(models: ModelType[]): string {
 
 export interface DatabaseField {
   name: string
+  kind?: string
   type: string
   isOptional?: boolean
   isId?: boolean


### PR DESCRIPTION
This pull request introduces some updates to form field handling, code generation configuration, and database model utilities. The main changes include making the `password` method static in the form field class, updating the GraphQL code generation configuration to use `TypedDocumentNode` exports, and adding a new `kind` property to the `DatabaseField` interface.

**Form field improvements:**
* Changed the `password` method in `FormFieldClass` to be a static method, making it easier to use without instantiating the class.

**Code generation configuration updates:**
* Updated the codegen configuration in `codegen.yml__tmpl__` to export `TypedDocumentNode` for reusable GraphQL documents, replaced the legacy React Apollo hooks with `typescript-document-nodes`, and cleaned up related config options.

**Database model utility enhancements:**
* Added a new optional `kind` property to the `DatabaseField` interface in `generator-utils.ts` to support more flexible field definitions.