### PR TITLE
fix(generators): Resolve GraphQL fragment naming collision in SDK

### DIFF
--- a/generators/shared/src/sdk/graphql/__name__-fragments.graphql__tmpl__
+++ b/generators/shared/src/sdk/graphql/__name__-fragments.graphql__tmpl__
@@ -1,8 +1,8 @@
-fragment <%= adminPrefix ? adminPrefix : '' %><%= className %>List on <%= className %> {
+fragment <%= adminPrefix ? adminPrefix : '' %><%= className %>Summary on <%= className %> {
   id
   <%= fragmentFields %>
 }
 
 fragment <%= adminPrefix ? adminPrefix : '' %><%= className %>Details on <%= className %> {
-  ...<%= adminPrefix ? adminPrefix : '' %><%= className %>List
+  ...<%= adminPrefix ? adminPrefix : '' %><%= className %>Summary
 }

--- a/generators/shared/src/sdk/graphql/__name__-queries.graphql__tmpl__
+++ b/generators/shared/src/sdk/graphql/__name__-queries.graphql__tmpl__
@@ -6,7 +6,7 @@ query <%= adminPrefix ? adminPrefix : '' %><%= className %>($<%= propertyName %>
 
 query <%= adminPrefix ? adminPrefix : '' %><%= pluralClassName %>($input: List<%= className %>Input) {
   <%= pluralPropertyName %>(input: $input) {
-    ...<%= adminPrefix ? adminPrefix : '' %><%= className %>List
+    ...<%= adminPrefix ? adminPrefix : '' %><%= className %>Summary
   }
   counters: <%= pluralPropertyName %>Count(input: $input) {
     ...CorePagingDetails


### PR DESCRIPTION
## Summary
- Fixed GraphQL fragment naming collision in SDK generator templates
- Changed fragment naming from 'List' to 'Summary' to avoid conflicts with query names

## Root Cause
When Apollo 4 codegen processes models where singular equals plural (e.g., AppMetadata, News, Statistics), the custom pluralizer adds "List" suffix. This created naming conflicts between:
- Fragment: `__AdminAppMetadataList` 
- Query: `__AdminAppMetadataList` (from pluralized className)

## Changes
- Renamed fragment from `<%= className %>List` to `<%= className %>Summary`
- Updated fragment reference in queries template
- Maintains semantic meaning: Summary = minimal data for list views, Details = full data

## Test plan
- [ ] Regenerate SDK and verify no duplicate export errors
- [ ] Confirm fragments generate as `__AdminAppMetadataSummary`, `__AdminAppMetadataDetails`  
- [ ] Confirm queries generate as `__AdminAppMetadata`, `__AdminAppMetadataList`

🤖 Generated with [Claude Code](https://claude.ai/code)