### PR TITLE
fix(shared): Remove unused typescript-react-apollo dependency

### DIFF
--- a/generators/generators/package.json
+++ b/generators/generators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestledjs/generators",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
@@ -36,7 +36,7 @@
     "@nestledjs/api": "1.0.14",
     "@nestledjs/config": "0.1.14",
     "@nestledjs/plugins": "0.1.14",
-    "@nestledjs/shared": "0.3.12",
+    "@nestledjs/shared": "0.3.13",
     "@nestledjs/utils": "0.2.9",
     "@nestledjs/web": "0.1.14"
   }

--- a/generators/shared/package.json
+++ b/generators/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestledjs/shared",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "generators": "./generators.json",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/generators/shared/src/sdk/generator.ts
+++ b/generators/shared/src/sdk/generator.ts
@@ -281,7 +281,6 @@ export async function sdkGeneratorLogic(
       '@graphql-codegen/typescript': '^5.0.2',
       '@graphql-codegen/typescript-document-nodes': '^5.0.2',
       '@graphql-codegen/typescript-operations': '^5.0.2',
-      '@graphql-codegen/typescript-react-apollo': '^4.3.3',
     },
   )
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,8 +392,8 @@ importers:
         specifier: 0.1.14
         version: 0.1.14(1c976fbf43f825f5baba746ddb97a4f0)
       '@nestledjs/shared':
-        specifier: 0.3.12
-        version: 0.3.12(7e7aa301f610eb3bf6feb99ffc22eacf)
+        specifier: 0.3.13
+        version: 0.3.13(7e7aa301f610eb3bf6feb99ffc22eacf)
       '@nestledjs/utils':
         specifier: 0.2.9
         version: 0.2.9(@babel/traverse@7.28.5)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(eslint@9.39.1(jiti@2.4.2))(magicast@0.3.5)(nx@22.0.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.24)(typescript@5.7.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
@@ -2876,8 +2876,8 @@ packages:
     peerDependencies:
       '@nestledjs/utils': 0.2.9
 
-  '@nestledjs/shared@0.3.12':
-    resolution: {integrity: sha512-EHwLoKJ2CfDxVQqz7/7l/TD/mlOyTk+xKJ7n+UduYE5uxUARxBXLfbC876lyxTkvA53wnus6WaQqxPk6cZ8qzg==}
+  '@nestledjs/shared@0.3.13':
+    resolution: {integrity: sha512-wOoWN0lr42RJvV2jkRX89j27DPR68+e+0ARl9dLX5jSZJHpdgADFQ71NehOXScWlKdiApXVCciZEGfULFn7Azw==}
     peerDependencies:
       '@nestledjs/utils': 0.2.9
 
@@ -15588,7 +15588,7 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nestledjs/shared@0.3.12(7e7aa301f610eb3bf6feb99ffc22eacf)':
+  '@nestledjs/shared@0.3.13(7e7aa301f610eb3bf6feb99ffc22eacf)':
     dependencies:
       '@nestledjs/utils': 0.2.9(@babel/traverse@7.28.5)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(eslint@9.39.1(jiti@2.4.2))(magicast@0.3.5)(nx@22.0.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.24)(typescript@5.7.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
       '@nx/devkit': 22.0.2(nx@22.0.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))


### PR DESCRIPTION
## Summary
- Removed `@graphql-codegen/typescript-react-apollo` dependency from the shared SDK generator
- This package was being added unnecessarily during `pnpm db-update` runs
- The project uses `typescript-document-nodes` instead (configured in codegen.yml)

## Test plan
- [x] Verified the dependency is no longer added by the generator
- [x] Confirmed no other generators reference this package
- [ ] Run `pnpm db-update` to verify the dependency is not added to package.json
- [ ] Rebuild generators and test the SDK generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)