### PR TITLE
feat(api): add configurable session cookie and IPv6 Redis support

### DIFF
--- a/generators/api/src/core/files/data-access/src/lib/api-core-pub-sub.ts__tmpl__
+++ b/generators/api/src/core/files/data-access/src/lib/api-core-pub-sub.ts__tmpl__
@@ -46,6 +46,8 @@ function createRedisPubSub(): RedisPubSub | PubSub {
         rejectUnauthorized: false,
       },
     }),
+    // Force IPv6 for Railway private networking
+    family: 6,
     // Retry strategy to handle temporary connection issues
     retryStrategy: (times: number) => {
       if (times > 3) {

--- a/generators/api/src/core/files/feature/src/lib/api-core-feature.module.ts__tmpl__
+++ b/generators/api/src/core/files/feature/src/lib/api-core-feature.module.ts__tmpl__
@@ -40,7 +40,7 @@ const redisPubSubProvider = {
                     const cookies = rawHeaders[i + 1].split(';')
                     for (const cookie of cookies) {
                       const [name, value] = cookie.trim().split('=')
-                      if (name === '__session') {
+                      if (name === '<%= cookieName %>') {
                         token = value
                         break
                       }

--- a/generators/api/src/core/generator.ts
+++ b/generators/api/src/core/generator.ts
@@ -8,6 +8,7 @@ export default async function generateLibraries(
 ): Promise<GeneratorCallback> {
   const templateRootPath = joinPathFragments(__dirname, './files')
   const overwrite = options.overwrite === true
+  const cookieName = options.cookieName || '__session'
 
   const dependencies = {
     'graphql-type-json': '^0.3.2',
@@ -29,7 +30,7 @@ export default async function generateLibraries(
   await installPlugins(tree, dependencies, devDependencies)
 
   await apiLibraryGenerator(tree, { name: 'core', overwrite }, templateRootPath, 'data-access')
-  await apiLibraryGenerator(tree, { name: 'core', overwrite }, templateRootPath, 'feature', true)
+  await apiLibraryGenerator(tree, { name: 'core', overwrite, cookieName }, templateRootPath, 'feature', true)
   await apiLibraryGenerator(tree, { name: 'core', overwrite }, templateRootPath, 'models')
   await apiLibraryGenerator(tree, { name: 'core', overwrite }, templateRootPath, 'helpers')
 

--- a/generators/api/src/core/schema.d.ts
+++ b/generators/api/src/core/schema.d.ts
@@ -1,3 +1,4 @@
 export interface ApiCoreGeneratorSchema {
   overwrite?: boolean
+  cookieName?: string
 }

--- a/generators/api/src/core/schema.json
+++ b/generators/api/src/core/schema.json
@@ -8,6 +8,11 @@
       "type": "boolean",
       "description": "Whether to overwrite existing core libraries if they exist.",
       "default": false
+    },
+    "cookieName": {
+      "type": "string",
+      "description": "The name of the session cookie used for WebSocket authentication.",
+      "default": "__session"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `cookieName` option to core generator schema (defaults to `__session`) for configurable WebSocket session cookie
- Add `family: 6` to Redis options for Railway private networking IPv6 support

## Test plan
- [ ] Run core generator with default options and verify `__session` cookie name
- [ ] Run core generator with `--cookieName=custom` and verify custom cookie name in output
- [ ] Verify Redis connections work with IPv6 family setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)