### PR TITLE
feat(api): add Prisma v7 JsonValue type re-exports and update dependencies

### DIFF
--- a/generators/api/package.json
+++ b/generators/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestledjs/api",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "generators": "./generators.json",
   "type": "commonjs",
   "main": "./src/index.js",

--- a/generators/api/src/app/files/webpack.config.js__tmpl__
+++ b/generators/api/src/app/files/webpack.config.js__tmpl__
@@ -23,12 +23,9 @@ module.exports = {
       {
         test: /\.ts$/,
         use: 'ts-loader',
-        exclude: [
-          /node_modules/,
-          path.resolve(__dirname, '../../libs/api/prisma/src/lib/prisma-generated')
-        ],
+        // Prisma v7 generates TypeScript files that need to be compiled
+        exclude: /node_modules/,
       },
-
     ],
   },
   externals: [
@@ -36,19 +33,23 @@ module.exports = {
       allowlist: [
         /^@<%= npmScope %>\/api/, // allow your own libs
       ],
-      // Manually exclude Prisma internals if needed
-      function ({ request }, callback) {
-        if (request && request.includes('@prisma/client')) {
-          return callback(null, 'commonjs @prisma/client')
-        }
-        if (request && request.includes('.prisma/client')) {
-          return callback(null, 'commonjs .prisma/client')
-        }
-        if (request && request === '@<%= npmScope %>/api/prisma') {
-          return callback(null, 'commonjs @<%= npmScope %>/api/prisma')
-        }
-        callback()
+    }),
+    // Externalize Prisma packages for v7 compatibility
+    function ({ request }, callback) {
+      if (request && request.includes('@prisma/client')) {
+        return callback(null, 'commonjs ' + request)
       }
-    })
+      if (request && request.includes('.prisma/client')) {
+        return callback(null, 'commonjs ' + request)
+      }
+      // Externalize Prisma adapter for v7 compatibility
+      if (request && (request === '@prisma/adapter-pg' || request.startsWith('@prisma/adapter-pg/'))) {
+        return callback(null, 'commonjs ' + request)
+      }
+      if (request && request === '@<%= npmScope %>/api/prisma') {
+        return callback(null, 'commonjs ' + request)
+      }
+      callback()
+    }
   ]
 };

--- a/generators/api/src/core/generator.spec.ts
+++ b/generators/api/src/core/generator.spec.ts
@@ -43,7 +43,7 @@ describe('core generator', () => {
     )
     expect(apiLibraryGenerator).toHaveBeenCalledWith(
       tree,
-      { name: 'core', overwrite: false },
+      { name: 'core', overwrite: false, cookieName: '__session' },
       expect.any(String),
       'feature',
       true,
@@ -53,6 +53,12 @@ describe('core generator', () => {
       { name: 'core', overwrite: false },
       expect.any(String),
       'models',
+    )
+    expect(apiLibraryGenerator).toHaveBeenCalledWith(
+      tree,
+      { name: 'core', overwrite: false },
+      expect.any(String),
+      'helpers',
     )
     expect(formatFiles).toHaveBeenCalledWith(tree)
     expect(installPackagesTask).toHaveBeenCalledWith(tree)
@@ -70,7 +76,7 @@ describe('core generator', () => {
     )
     expect(apiLibraryGenerator).toHaveBeenCalledWith(
       tree,
-      { name: 'core', overwrite: true },
+      { name: 'core', overwrite: true, cookieName: '__session' },
       expect.any(String),
       'feature',
       true,
@@ -80,6 +86,12 @@ describe('core generator', () => {
       { name: 'core', overwrite: true },
       expect.any(String),
       'models',
+    )
+    expect(apiLibraryGenerator).toHaveBeenCalledWith(
+      tree,
+      { name: 'core', overwrite: true },
+      expect.any(String),
+      'helpers',
     )
   })
 })

--- a/generators/api/src/core/generator.ts
+++ b/generators/api/src/core/generator.ts
@@ -20,7 +20,7 @@ export default async function generateLibraries(
     '@apollo/server': '^5.1.0',
     'graphql-fields': '^2.0.3',
     'decimal.js': '^10.4.3',
-    'prisma-graphql-type-decimal': '^3.0.0',
+    'prisma-graphql-type-decimal': '^4.0.2',
   }
 
   const devDependencies = {

--- a/generators/api/src/prisma/files/src/index.ts__tmpl__
+++ b/generators/api/src/prisma/files/src/index.ts__tmpl__
@@ -3,3 +3,13 @@ export * from './lib/prisma-generated/client'
 
 // Explicitly export Prisma namespace for better CI compatibility
 export { Prisma } from './lib/prisma-generated/client'
+
+// Re-export commonly used Prisma utility types for direct import
+// This fixes webpack resolution issues with Prisma.JsonValue etc.
+import { Prisma as PrismaNamespace } from './lib/prisma-generated/client'
+export type JsonValue = PrismaNamespace.JsonValue
+export type JsonObject = PrismaNamespace.JsonObject
+export type JsonArray = PrismaNamespace.JsonArray
+export type InputJsonValue = PrismaNamespace.InputJsonValue
+export type InputJsonObject = PrismaNamespace.InputJsonObject
+export type InputJsonArray = PrismaNamespace.InputJsonArray

--- a/generators/api/src/setup/generator.ts
+++ b/generators/api/src/setup/generator.ts
@@ -75,7 +75,7 @@ export async function apiSetupGenerator(tree: Tree): Promise<GeneratorCallback> 
       'webpack-cli': '^6.0.1',
       'webpack-node-externals': '^3.0.0',
       'tsconfig-paths-webpack-plugin': '^4.2.0',
-      'prisma-graphql-type-decimal': '^3.0.1',
+      'prisma-graphql-type-decimal': '^4.0.2',
       'graphql-type-json': '^0.3.2',
     },
   )

--- a/generators/generators/package.json
+++ b/generators/generators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestledjs/generators",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "tslib": "^2.3.0",
-    "@nestledjs/api": "2.3.0",
+    "@nestledjs/api": "2.4.0",
     "@nestledjs/config": "0.1.15",
     "@nestledjs/plugins": "0.1.15",
     "@nestledjs/shared": "1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,8 +386,8 @@ importers:
   generators/generators:
     dependencies:
       '@nestledjs/api':
-        specifier: 2.3.0
-        version: 2.3.0(dfb3e8415db8c4b34a6207ed0a216ede)
+        specifier: 2.4.0
+        version: 2.4.0(dfb3e8415db8c4b34a6207ed0a216ede)
       '@nestledjs/config':
         specifier: 0.1.15
         version: 0.1.15(@nestledjs/utils@1.0.0(@babel/traverse@7.28.5)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(eslint@9.39.1(jiti@2.4.2))(magicast@0.3.5)(nx@22.0.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.24)(typescript@5.7.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0)))(nx@22.0.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
@@ -2907,8 +2907,8 @@ packages:
       '@nestjs/platform-express':
         optional: true
 
-  '@nestledjs/api@2.3.0':
-    resolution: {integrity: sha512-zUYCWvnXoDRHLG2OLfmr/fUdktPDHvuhsR6h+1S1Ct8ZjhuqaBKk+uoajkJvL/WEdddPRe1C3JxaFm6YLDFP7Q==}
+  '@nestledjs/api@2.4.0':
+    resolution: {integrity: sha512-bAxUskECtuURbXTH8KX+2OdxeHfP26Fr2kLZ9HgdR4DZ/jzaz4PV/6X5VUiNcmM805ZxM1fRZe58zAzttg+sNg==}
     peerDependencies:
       '@nestledjs/utils': 1.0.0
 
@@ -15789,7 +15789,7 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20)
 
-  '@nestledjs/api@2.3.0(dfb3e8415db8c4b34a6207ed0a216ede)':
+  '@nestledjs/api@2.4.0(dfb3e8415db8c4b34a6207ed0a216ede)':
     dependencies:
       '@nestledjs/utils': 1.0.0(@babel/traverse@7.28.5)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(eslint@9.39.1(jiti@2.4.2))(magicast@0.3.5)(nx@22.0.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.24)(typescript@5.7.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
       '@nx/devkit': 22.0.2(nx@22.0.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))


### PR DESCRIPTION
## Summary
- Add top-level re-exports for Prisma utility types (JsonValue, JsonObject, JsonArray, InputJsonValue, InputJsonObject, InputJsonArray) in barrel export template
- Update webpack config to externalize @prisma/adapter-pg for v7 compatibility
- Remove prisma-generated exclusion from ts-loader (v7 generates TypeScript that needs compilation)
- Update prisma-graphql-type-decimal to ^4.0.2
- Fix core generator tests to include helpers call and cookieName option

## Test plan
- [x] All 25 tests passing (`npx nx test api`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)