### PR TITLE
Add disconnect support for null single relationships in update operations

### DIFF
--- a/generators/api/src/generate-crud/files/data-access/src/lib/api-crud-data-access.service.ts__tmpl__
+++ b/generators/api/src/generate-crud/files/data-access/src/lib/api-crud-data-access.service.ts__tmpl__
@@ -112,12 +112,12 @@ function generateRelationHandling(model, operation) {
   
   // Add virtual relation fields to the mapping
   virtualRelationFields.forEach(field => {
-    code += `      ${field.relatedField}: { ids: ${field.name}, isVirtual: true, isList: ${field.isList} },\n`;
+    code += `      ${field.relatedField}: { ids: ${field.name}, isVirtual: true, isList: ${field.isList}, isRequired: false },\n`;
   });
-  
+
   // Add foreign key fields to the mapping
   foreignKeyFields.forEach(field => {
-    code += `      ${field.relationName}: { ids: ${field.fieldName}, isVirtual: false, isList: ${field.isList || false} },\n`;
+    code += `      ${field.relationName}: { ids: ${field.fieldName}, isVirtual: false, isList: ${field.isList || false}, isRequired: ${field.isRequired} },\n`;
   });
   
   code += '    };\n\n';
@@ -147,8 +147,8 @@ function generateRelationHandling(model, operation) {
   code += '          data[relationName] = { connect: { id: config.ids } };\n';
   code += '        }\n';
   if (operation === 'update') {
-    code += '      } else if (config.ids === null && !config.isList) {\n';
-    code += '        // Explicitly null - disconnect the single relationship\n';
+    code += '      } else if (config.ids === null && !config.isList && !config.isRequired) {\n';
+    code += '        // Explicitly null - disconnect the optional single relationship\n';
     code += '        data[relationName] = { disconnect: true };\n';
     code += '      }\n';
   } else {

--- a/generators/api/src/generate-crud/files/data-access/src/lib/api-crud-data-access.service.ts__tmpl__
+++ b/generators/api/src/generate-crud/files/data-access/src/lib/api-crud-data-access.service.ts__tmpl__
@@ -139,7 +139,11 @@ function generateRelationHandling(model, operation) {
   
   code += '          data[relationName] = { [relationOperation]: ids };\n';
   code += '        } else {\n';
-  code += '          // Single relationship - always use connect\n';
+  if (operation === 'update') {
+    code += '          // Single relationship - connect when an id is provided; disconnect when null on update\n';
+  } else {
+    code += '          // Single relationship - always use connect\n';
+  }
   code += '          data[relationName] = { connect: { id: config.ids } };\n';
   code += '        }\n';
   if (operation === 'update') {

--- a/generators/api/src/generate-crud/files/data-access/src/lib/api-crud-data-access.service.ts__tmpl__
+++ b/generators/api/src/generate-crud/files/data-access/src/lib/api-crud-data-access.service.ts__tmpl__
@@ -142,7 +142,14 @@ function generateRelationHandling(model, operation) {
   code += '          // Single relationship - always use connect\n';
   code += '          data[relationName] = { connect: { id: config.ids } };\n';
   code += '        }\n';
-  code += '      }\n';
+  if (operation === 'update') {
+    code += '      } else if (config.ids === null && !config.isList) {\n';
+    code += '        // Explicitly null - disconnect the single relationship\n';
+    code += '        data[relationName] = { disconnect: true };\n';
+    code += '      }\n';
+  } else {
+    code += '      }\n';
+  }
   code += '    }\n';
 
   return code;

--- a/generators/api/src/generate-crud/relation-handling.spec.ts
+++ b/generators/api/src/generate-crud/relation-handling.spec.ts
@@ -69,6 +69,24 @@ const modelWithMixedRelations: ModelLike = {
   ],
 }
 
+// Model with a required single FK relation (Post -> Author via authorId, non-optional)
+const modelWithRequiredSingleRelation: ModelLike = {
+  fields: [
+    { name: 'id', type: 'String', isId: true, isList: false, isOptional: false, hasDefaultValue: true },
+    { name: 'title', type: 'String', isList: false, isOptional: false },
+    { name: 'authorId', type: 'String', isList: false, isOptional: false },
+    {
+      name: 'author',
+      type: 'User',
+      kind: 'object',
+      isList: false,
+      isOptional: false,
+      relationName: 'PostToUser',
+      relationFromFields: ['authorId'],
+    },
+  ],
+}
+
 // Model with no relations
 const modelWithNoRelations: ModelLike = {
   fields: [
@@ -131,9 +149,9 @@ describe('relation-handling', () => {
     })
 
     describe('update operation - single FK relation', () => {
-      it('includes disconnect branch for explicit null on single relation', () => {
+      it('includes disconnect branch for explicit null on optional single relation', () => {
         const result = generateRelationHandling(modelWithOptionalSingleRelation, 'update')
-        expect(result).toContain('} else if (config.ids === null && !config.isList) {')
+        expect(result).toContain('} else if (config.ids === null && !config.isList && !config.isRequired) {')
         expect(result).toContain('data[relationName] = { disconnect: true }')
       })
 
@@ -166,12 +184,12 @@ describe('relation-handling', () => {
     })
 
     describe('update operation - virtual list relation', () => {
-      it('guards disconnect branch with !config.isList so it cannot fire for list relations', () => {
+      it('guards disconnect branch so it cannot fire for list relations', () => {
         const result = generateRelationHandling(modelWithVirtualListRelation, 'update')
-        // The disconnect branch is present in the generated code but guarded by !config.isList
-        expect(result).toContain('config.ids === null && !config.isList')
+        // The disconnect branch is present but guarded by !config.isList && !config.isRequired
+        expect(result).toContain('config.ids === null && !config.isList && !config.isRequired')
         // The relation mapping sets isList: true, so the guard prevents disconnect at runtime
-        expect(result).toContain('tags: { ids: tagsIds, isVirtual: true, isList: true }')
+        expect(result).toContain('tags: { ids: tagsIds, isVirtual: true, isList: true, isRequired: false }')
       })
 
       it('uses set operation for virtual list relations on update', () => {
@@ -181,10 +199,10 @@ describe('relation-handling', () => {
     })
 
     describe('mixed relations (single FK + virtual list)', () => {
-      it('includes disconnect branch only for single relations on update', () => {
+      it('includes disconnect branch only for optional single relations on update', () => {
         const result = generateRelationHandling(modelWithMixedRelations, 'update')
-        // Disconnect branch is present (for the single FK relation)
-        expect(result).toContain('} else if (config.ids === null && !config.isList) {')
+        // Disconnect branch is present but guarded by isRequired check
+        expect(result).toContain('} else if (config.ids === null && !config.isList && !config.isRequired) {')
         expect(result).toContain('data[relationName] = { disconnect: true }')
       })
 
@@ -193,10 +211,25 @@ describe('relation-handling', () => {
         expect(result).toContain('tagsIds, locationId, ...regularFields')
       })
 
-      it('creates relation mappings for both relation types', () => {
+      it('creates relation mappings for both relation types with isRequired metadata', () => {
         const result = generateRelationHandling(modelWithMixedRelations, 'update')
-        expect(result).toContain('tags: { ids: tagsIds, isVirtual: true, isList: true }')
-        expect(result).toContain('location: { ids: locationId, isVirtual: false, isList: false }')
+        expect(result).toContain('tags: { ids: tagsIds, isVirtual: true, isList: true, isRequired: false }')
+        expect(result).toContain('location: { ids: locationId, isVirtual: false, isList: false, isRequired: false }')
+      })
+    })
+
+    describe('update operation - required single FK relation', () => {
+      it('does not allow disconnect for required relations at runtime', () => {
+        const result = generateRelationHandling(modelWithRequiredSingleRelation, 'update')
+        // The mapping marks the relation as isRequired: true
+        expect(result).toContain('author: { ids: authorId, isVirtual: false, isList: false, isRequired: true }')
+        // The disconnect guard includes !config.isRequired, so required relations cannot disconnect
+        expect(result).toContain('!config.isRequired')
+      })
+
+      it('still allows connect for required relations', () => {
+        const result = generateRelationHandling(modelWithRequiredSingleRelation, 'update')
+        expect(result).toContain('data[relationName] = { connect: { id: config.ids } }')
       })
     })
   })

--- a/generators/api/src/generate-crud/relation-handling.spec.ts
+++ b/generators/api/src/generate-crud/relation-handling.spec.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest'
+import {
+  generateRelationHandling,
+  getForeignKeyRelationFields,
+  getRelationFields,
+  getVirtualRelationFields,
+  type ModelLike,
+} from './relation-handling'
+
+// Model with an optional single FK relation (Event -> Location via locationId)
+const modelWithOptionalSingleRelation: ModelLike = {
+  fields: [
+    { name: 'id', type: 'String', isId: true, isList: false, isOptional: false, hasDefaultValue: true },
+    { name: 'name', type: 'String', isList: false, isOptional: false },
+    { name: 'locationId', type: 'String', isList: false, isOptional: true },
+    {
+      name: 'location',
+      type: 'Location',
+      kind: 'object',
+      isList: false,
+      isOptional: true,
+      relationName: 'EventToLocation',
+      relationFromFields: ['locationId'],
+    },
+  ],
+}
+
+// Model with a virtual list relation (Event -> Tags, many-to-many without FK)
+const modelWithVirtualListRelation: ModelLike = {
+  fields: [
+    { name: 'id', type: 'String', isId: true, isList: false, isOptional: false, hasDefaultValue: true },
+    { name: 'name', type: 'String', isList: false, isOptional: false },
+    {
+      name: 'tags',
+      type: 'Tag',
+      kind: 'object',
+      isList: true,
+      isOptional: true,
+      relationName: 'EventToTag',
+      relationFromFields: [],
+    },
+  ],
+}
+
+// Model with both FK single relation and virtual list relation
+const modelWithMixedRelations: ModelLike = {
+  fields: [
+    { name: 'id', type: 'String', isId: true, isList: false, isOptional: false, hasDefaultValue: true },
+    { name: 'name', type: 'String', isList: false, isOptional: false },
+    { name: 'locationId', type: 'String', isList: false, isOptional: true },
+    {
+      name: 'location',
+      type: 'Location',
+      kind: 'object',
+      isList: false,
+      isOptional: true,
+      relationName: 'EventToLocation',
+      relationFromFields: ['locationId'],
+    },
+    {
+      name: 'tags',
+      type: 'Tag',
+      kind: 'object',
+      isList: true,
+      isOptional: true,
+      relationName: 'EventToTag',
+      relationFromFields: [],
+    },
+  ],
+}
+
+// Model with no relations
+const modelWithNoRelations: ModelLike = {
+  fields: [
+    { name: 'id', type: 'String', isId: true, isList: false, isOptional: false, hasDefaultValue: true },
+    { name: 'name', type: 'String', isList: false, isOptional: false },
+  ],
+}
+
+describe('relation-handling', () => {
+  describe('getRelationFields', () => {
+    it('returns fields with non-empty relationName', () => {
+      const result = getRelationFields(modelWithOptionalSingleRelation)
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('location')
+    })
+
+    it('returns empty array for model without relations', () => {
+      expect(getRelationFields(modelWithNoRelations)).toHaveLength(0)
+    })
+  })
+
+  describe('getVirtualRelationFields', () => {
+    it('generates virtual field for relation without explicit FK', () => {
+      const result = getVirtualRelationFields(modelWithVirtualListRelation)
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        name: 'tagsIds',
+        isList: true,
+        isVirtual: true,
+        relatedField: 'tags',
+      })
+    })
+
+    it('does not generate virtual field for relation with explicit FK', () => {
+      const result = getVirtualRelationFields(modelWithOptionalSingleRelation)
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('getForeignKeyRelationFields', () => {
+    it('returns FK field metadata for relation with explicit FK', () => {
+      const result = getForeignKeyRelationFields(modelWithOptionalSingleRelation)
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        fieldName: 'locationId',
+        relationName: 'location',
+        isList: false,
+      })
+    })
+
+    it('returns empty array for virtual relations', () => {
+      expect(getForeignKeyRelationFields(modelWithVirtualListRelation)).toHaveLength(0)
+    })
+  })
+
+  describe('generateRelationHandling', () => {
+    it('returns simple assignment when model has no relations', () => {
+      const result = generateRelationHandling(modelWithNoRelations, 'update')
+      expect(result).toBe('    const data = input;')
+    })
+
+    describe('update operation - single FK relation', () => {
+      it('includes disconnect branch for explicit null on single relation', () => {
+        const result = generateRelationHandling(modelWithOptionalSingleRelation, 'update')
+        expect(result).toContain('} else if (config.ids === null && !config.isList) {')
+        expect(result).toContain('data[relationName] = { disconnect: true }')
+      })
+
+      it('includes connect logic for non-null values', () => {
+        const result = generateRelationHandling(modelWithOptionalSingleRelation, 'update')
+        expect(result).toContain('data[relationName] = { connect: { id: config.ids } }')
+      })
+
+      it('includes updated comment about connect/disconnect behavior', () => {
+        const result = generateRelationHandling(modelWithOptionalSingleRelation, 'update')
+        expect(result).toContain('connect when an id is provided; disconnect when null on update')
+      })
+    })
+
+    describe('create operation - single FK relation', () => {
+      it('does NOT include disconnect branch', () => {
+        const result = generateRelationHandling(modelWithOptionalSingleRelation, 'create')
+        expect(result).not.toContain('disconnect')
+      })
+
+      it('includes connect logic for non-null values', () => {
+        const result = generateRelationHandling(modelWithOptionalSingleRelation, 'create')
+        expect(result).toContain('data[relationName] = { connect: { id: config.ids } }')
+      })
+
+      it('uses the original "always use connect" comment', () => {
+        const result = generateRelationHandling(modelWithOptionalSingleRelation, 'create')
+        expect(result).toContain('Single relationship - always use connect')
+      })
+    })
+
+    describe('update operation - virtual list relation', () => {
+      it('guards disconnect branch with !config.isList so it cannot fire for list relations', () => {
+        const result = generateRelationHandling(modelWithVirtualListRelation, 'update')
+        // The disconnect branch is present in the generated code but guarded by !config.isList
+        expect(result).toContain('config.ids === null && !config.isList')
+        // The relation mapping sets isList: true, so the guard prevents disconnect at runtime
+        expect(result).toContain('tags: { ids: tagsIds, isVirtual: true, isList: true }')
+      })
+
+      it('uses set operation for virtual list relations on update', () => {
+        const result = generateRelationHandling(modelWithVirtualListRelation, 'update')
+        expect(result).toContain("config.isVirtual ? 'set' : 'connect'")
+      })
+    })
+
+    describe('mixed relations (single FK + virtual list)', () => {
+      it('includes disconnect branch only for single relations on update', () => {
+        const result = generateRelationHandling(modelWithMixedRelations, 'update')
+        // Disconnect branch is present (for the single FK relation)
+        expect(result).toContain('} else if (config.ids === null && !config.isList) {')
+        expect(result).toContain('data[relationName] = { disconnect: true }')
+      })
+
+      it('destructures both virtual and FK fields from input', () => {
+        const result = generateRelationHandling(modelWithMixedRelations, 'update')
+        expect(result).toContain('tagsIds, locationId, ...regularFields')
+      })
+
+      it('creates relation mappings for both relation types', () => {
+        const result = generateRelationHandling(modelWithMixedRelations, 'update')
+        expect(result).toContain('tags: { ids: tagsIds, isVirtual: true, isList: true }')
+        expect(result).toContain('location: { ids: locationId, isVirtual: false, isList: false }')
+      })
+    })
+  })
+})

--- a/generators/api/src/generate-crud/relation-handling.ts
+++ b/generators/api/src/generate-crud/relation-handling.ts
@@ -72,7 +72,7 @@ export function getVirtualRelationFields(model: ModelLike): VirtualRelationField
             isList: true,
             isOptional: true,
             isVirtual: true,
-            relationName: relationField.relationName!,
+            relationName: relationField.relationName,
             relatedField: relationField.name,
           })
         }
@@ -88,7 +88,7 @@ export function getVirtualRelationFields(model: ModelLike): VirtualRelationField
             isList: false,
             isOptional: true,
             isVirtual: true,
-            relationName: relationField.relationName!,
+            relationName: relationField.relationName,
             relatedField: relationField.name,
           })
         }

--- a/generators/api/src/generate-crud/relation-handling.ts
+++ b/generators/api/src/generate-crud/relation-handling.ts
@@ -1,0 +1,193 @@
+/**
+ * Relation handling code generation for CRUD services.
+ *
+ * These functions are the canonical source of truth for the relation-mapping
+ * logic used in the EJS template (api-crud-data-access.service.ts__tmpl__).
+ * The template contains identical copies of these functions so EJS can
+ * execute them without external imports.  Any change here MUST be mirrored
+ * in the template, and vice versa.
+ */
+
+export interface ModelField {
+  name: string
+  type: string
+  kind?: string
+  isId?: boolean
+  isList: boolean
+  isOptional: boolean
+  isVirtual?: boolean
+  isReadOnly?: boolean
+  hasDefaultValue?: boolean
+  default?: unknown
+  relationName?: string
+  relationFromFields?: string[]
+  relationToFields?: string[]
+  relationOnDelete?: string
+  relationOnUpdate?: string
+  isGenerated?: boolean
+  isUpdatedAt?: boolean
+  documentation?: string
+}
+
+export interface ModelLike {
+  fields: ModelField[]
+}
+
+export interface VirtualRelationField {
+  name: string
+  type: string
+  isList: boolean
+  isOptional: boolean
+  isVirtual: boolean
+  relationName: string
+  relatedField: string
+}
+
+export interface ForeignKeyRelationField {
+  fieldName: string
+  relationName: string
+  isRequired: boolean
+  isList: boolean
+}
+
+export function getRelationFields(model: ModelLike): ModelField[] {
+  return model.fields.filter((field) => field.relationName && field.relationName.length > 0)
+}
+
+export function getVirtualRelationFields(model: ModelLike): VirtualRelationField[] {
+  const relationFields = getRelationFields(model)
+  const virtualFields: VirtualRelationField[] = []
+
+  relationFields.forEach((relationField) => {
+    if (!relationField.relationFromFields || relationField.relationFromFields.length === 0) {
+      if (relationField.isList) {
+        const virtualFieldName = relationField.name + 'Ids'
+        const existingField = model.fields.find(
+          (f) => f.name === virtualFieldName && (!f.relationName || f.relationName.length === 0),
+        )
+        if (!existingField) {
+          virtualFields.push({
+            name: virtualFieldName,
+            type: 'String',
+            isList: true,
+            isOptional: true,
+            isVirtual: true,
+            relationName: relationField.relationName!,
+            relatedField: relationField.name,
+          })
+        }
+      } else {
+        const virtualFieldName = relationField.name + 'Id'
+        const existingField = model.fields.find(
+          (f) => f.name === virtualFieldName && (!f.relationName || f.relationName.length === 0),
+        )
+        if (!existingField) {
+          virtualFields.push({
+            name: virtualFieldName,
+            type: 'String',
+            isList: false,
+            isOptional: true,
+            isVirtual: true,
+            relationName: relationField.relationName!,
+            relatedField: relationField.name,
+          })
+        }
+      }
+    }
+  })
+
+  return virtualFields
+}
+
+export function getForeignKeyRelationFields(model: ModelLike): ForeignKeyRelationField[] {
+  const relationFields = getRelationFields(model)
+  const foreignKeyFields: ForeignKeyRelationField[] = []
+
+  relationFields.forEach((relationField) => {
+    if (relationField.relationFromFields && relationField.relationFromFields.length > 0) {
+      relationField.relationFromFields.forEach((fkFieldName) => {
+        const fkField = model.fields.find((f) => f.name === fkFieldName)
+        if (fkField) {
+          foreignKeyFields.push({
+            fieldName: fkFieldName,
+            relationName: relationField.name,
+            isRequired: !fkField.isOptional,
+            isList: relationField.isList,
+          })
+        }
+      })
+    }
+  })
+
+  return foreignKeyFields
+}
+
+export function generateRelationHandling(model: ModelLike, operation: 'create' | 'update'): string {
+  const virtualRelationFields = getVirtualRelationFields(model)
+  const foreignKeyFields = getForeignKeyRelationFields(model)
+  const allRelationFields = [...virtualRelationFields, ...foreignKeyFields]
+
+  if (allRelationFields.length === 0) {
+    return '    const data = input;'
+  }
+
+  let code = '    const { '
+  code += virtualRelationFields.map((field) => field.name).join(', ')
+  if (foreignKeyFields.length > 0) {
+    if (virtualRelationFields.length > 0) code += ', '
+    code += foreignKeyFields.map((field) => field.fieldName).join(', ')
+  }
+  code += ', ...regularFields } = input;\n'
+  code += '    const data: any = regularFields;\n\n'
+
+  // Create relation mapping object with field type metadata
+  code += '    const relationMappings = {\n'
+
+  // Add virtual relation fields to the mapping
+  virtualRelationFields.forEach((field) => {
+    code += `      ${field.relatedField}: { ids: ${field.name}, isVirtual: true, isList: ${field.isList} },\n`
+  })
+
+  // Add foreign key fields to the mapping
+  foreignKeyFields.forEach((field) => {
+    code += `      ${field.relationName}: { ids: ${field.fieldName}, isVirtual: false, isList: ${field.isList || false} },\n`
+  })
+
+  code += '    };\n\n'
+
+  // Generate the improved iteration logic
+  code += '    for (const [relationName, config] of Object.entries(relationMappings)) {\n'
+  code += '      if (config.ids !== undefined && config.ids !== null) {\n'
+  code += '        const ids = Array.isArray(config.ids) ? config.ids.map(id => ({ id })) : [{ id: config.ids }];\n'
+  code += '        \n'
+  code += '        if (config.isList) {\n'
+
+  if (operation === 'update') {
+    code += '          // List relationships: use set for updates on virtual relations, connect for foreign key relations\n'
+    code += "          const relationOperation = config.isVirtual ? 'set' : 'connect';\n"
+  } else {
+    code += '          // List relationships: always use connect for creates\n'
+    code += "          const relationOperation = 'connect';\n"
+  }
+
+  code += '          data[relationName] = { [relationOperation]: ids };\n'
+  code += '        } else {\n'
+  if (operation === 'update') {
+    code += '          // Single relationship - connect when an id is provided; disconnect when null on update\n'
+  } else {
+    code += '          // Single relationship - always use connect\n'
+  }
+  code += '          data[relationName] = { connect: { id: config.ids } };\n'
+  code += '        }\n'
+  if (operation === 'update') {
+    code += '      } else if (config.ids === null && !config.isList) {\n'
+    code += '        // Explicitly null - disconnect the single relationship\n'
+    code += '        data[relationName] = { disconnect: true };\n'
+    code += '      }\n'
+  } else {
+    code += '      }\n'
+  }
+  code += '    }\n'
+
+  return code
+}

--- a/generators/api/src/generate-crud/relation-handling.ts
+++ b/generators/api/src/generate-crud/relation-handling.ts
@@ -145,12 +145,12 @@ export function generateRelationHandling(model: ModelLike, operation: 'create' |
 
   // Add virtual relation fields to the mapping
   virtualRelationFields.forEach((field) => {
-    code += `      ${field.relatedField}: { ids: ${field.name}, isVirtual: true, isList: ${field.isList} },\n`
+    code += `      ${field.relatedField}: { ids: ${field.name}, isVirtual: true, isList: ${field.isList}, isRequired: false },\n`
   })
 
   // Add foreign key fields to the mapping
   foreignKeyFields.forEach((field) => {
-    code += `      ${field.relationName}: { ids: ${field.fieldName}, isVirtual: false, isList: ${field.isList || false} },\n`
+    code += `      ${field.relationName}: { ids: ${field.fieldName}, isVirtual: false, isList: ${field.isList || false}, isRequired: ${field.isRequired} },\n`
   })
 
   code += '    };\n\n'
@@ -180,8 +180,8 @@ export function generateRelationHandling(model: ModelLike, operation: 'create' |
   code += '          data[relationName] = { connect: { id: config.ids } };\n'
   code += '        }\n'
   if (operation === 'update') {
-    code += '      } else if (config.ids === null && !config.isList) {\n'
-    code += '        // Explicitly null - disconnect the single relationship\n'
+    code += '      } else if (config.ids === null && !config.isList && !config.isRequired) {\n'
+    code += '        // Explicitly null - disconnect the optional single relationship\n'
     code += '        data[relationName] = { disconnect: true };\n'
     code += '      }\n'
   } else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,8 +407,8 @@ importers:
         specifier: 2.9.1
         version: 2.9.1(16587fe02cbb2bac796d9cf6b7b28a1b)
       '@nestledjs/config':
-        specifier: 0.2.1
-        version: 0.2.1(@nestledjs/utils@1.0.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.17.6))(eslint@9.39.1(jiti@2.4.2))(magicast@0.3.5)(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.7.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0)))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        specifier: 0.2.2
+        version: 0.2.2(@nestledjs/utils@1.0.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.17.6))(eslint@9.39.1(jiti@2.4.2))(magicast@0.3.5)(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.7.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0)))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nestledjs/plugins':
         specifier: 0.1.16
         version: 0.1.16(44105f6b873609173fedade3f84485c2)
@@ -2969,8 +2969,8 @@ packages:
     peerDependencies:
       '@nestledjs/utils': 1.0.1
 
-  '@nestledjs/config@0.2.1':
-    resolution: {integrity: sha512-dm9JZgWFe6VKf3ZoGqgpxBjTwMwpIDXguU2Mu66kM+wP2AqyUAFccXuulDUs0FT8KeMYmsNDiBBX3CvkvWP1OA==}
+  '@nestledjs/config@0.2.2':
+    resolution: {integrity: sha512-2TcpNEpHkz2WVJHGiHazUBkmQzy70AbyctEoL1sRHVj+bdEiJdpQwpazv/ZTqx5UHDE/K7+a6t0y7MYc5U73Gw==}
     peerDependencies:
       '@nestledjs/utils': 1.0.1
 
@@ -16433,7 +16433,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nestledjs/config@0.2.1(@nestledjs/utils@1.0.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.17.6))(eslint@9.39.1(jiti@2.4.2))(magicast@0.3.5)(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.7.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0)))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@nestledjs/config@0.2.2(@nestledjs/utils@1.0.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.17.6))(eslint@9.39.1(jiti@2.4.2))(magicast@0.3.5)(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.7.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0)))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
       '@nestledjs/utils': 1.0.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.17.6))(eslint@9.39.1(jiti@2.4.2))(magicast@0.3.5)(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.7.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
       '@nx/devkit': 22.0.2(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))


### PR DESCRIPTION
## Summary
This change adds support for explicitly disconnecting single relationships when they are set to null during update operations in the CRUD data access service generator.

## Key Changes
- Added conditional logic to handle null values for single relationships during update operations
- When `config.ids === null` and the relationship is not a list, the generated code now uses `disconnect: true` instead of `connect`
- This behavior is specific to update operations; create operations maintain the existing logic

## Implementation Details
- The change modifies the `generateRelationHandling` function to differentiate between update and other operations
- For update operations, an additional `else if` branch is generated that explicitly disconnects single relationships when they are set to null
- This allows users to remove/clear single relationship associations during updates, which was not previously possible
- The implementation maintains backward compatibility by only applying this logic to update operations

https://claude.ai/code/session_018eaQqREjVkJ6KJc4SFK3ZR