### PR TITLE
Replace GraphQLJSONObject with GraphQLJSON in model generation

### DIFF
--- a/generators/api/src/core/files/models/src/lib/generate-models.ts__tmpl__
+++ b/generators/api/src/core/files/models/src/lib/generate-models.ts__tmpl__
@@ -202,7 +202,6 @@ function generateModels(models: readonly any[], enums: readonly any[]): string {
     model.fields.some((field: { type: string }) => field.type === 'DateTime'),
   )
   let output = `import { Field, ObjectType${usesFloat ? ', Float' : ''}${usesDateTime ? ', GraphQLISODateTime' : ''}, Int } from '@nestjs/graphql';\n`
-  output += `import { GraphQLJSONObject } from 'graphql-type-json';\n`
 
   // Check if any model field uses Decimal
   const usesDecimal = models.some(model =>
@@ -212,6 +211,9 @@ function generateModels(models: readonly any[], enums: readonly any[]): string {
   const usesJson = models.some(model =>
     model.fields.some((field: { type: string }) => field.type === 'Json'),
   )
+  if (usesJson) {
+    output += `import { GraphQLJSON } from 'graphql-type-json';\n`
+  }
   if (usesDecimal) {
     output += `import Decimal from 'decimal.js';\n`
     output += `import { GraphQLDecimal } from 'prisma-graphql-type-decimal';\n`
@@ -282,7 +284,7 @@ function generateModels(models: readonly any[], enums: readonly any[]): string {
         else if (originalType === 'Float') listItemGraphQLType = 'Float'
         else if (originalType === 'Decimal') listItemGraphQLType = 'GraphQLDecimal'
         else if (originalType === 'BigInt') listItemGraphQLType = 'GraphQLBigInt'
-        else if (originalType === 'Json') listItemGraphQLType = 'GraphQLJSONObject'
+        else if (originalType === 'Json') listItemGraphQLType = 'GraphQLJSON'
         else if (isEnum || isRelation)
           listItemGraphQLType = originalType // Assumes enum/type is registered with GraphQL
         else if (originalType === 'DateTime') listItemGraphQLType = 'GraphQLISODateTime'
@@ -299,7 +301,7 @@ function generateModels(models: readonly any[], enums: readonly any[]): string {
         else if (originalType === 'Float') decoratorType = '() => Float'
         else if (originalType === 'Decimal') decoratorType = '() => GraphQLDecimal'
         else if (originalType === 'BigInt') decoratorType = '() => GraphQLBigInt'
-        else if (originalType === 'Json') decoratorType = '() => GraphQLJSONObject'
+        else if (originalType === 'Json') decoratorType = '() => GraphQLJSON'
         else if (isEnum || isRelation) decoratorType = `() => ${originalType}`
         else if (originalType === 'DateTime') decoratorType = '() => GraphQLISODateTime'
         else if (originalType === 'Boolean') decoratorType = '() => Boolean'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,8 +404,8 @@ importers:
   generators/generators:
     dependencies:
       '@nestledjs/api':
-        specifier: 2.9.1
-        version: 2.9.1(16587fe02cbb2bac796d9cf6b7b28a1b)
+        specifier: 2.9.2
+        version: 2.9.2(16587fe02cbb2bac796d9cf6b7b28a1b)
       '@nestledjs/config':
         specifier: 0.2.2
         version: 0.2.2(@nestledjs/utils@1.0.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.17.6))(eslint@9.39.1(jiti@2.4.2))(magicast@0.3.5)(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.7.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0)))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
@@ -2964,8 +2964,8 @@ packages:
       '@nestjs/platform-express':
         optional: true
 
-  '@nestledjs/api@2.9.1':
-    resolution: {integrity: sha512-JvCuNHLkAe/KM6aGuAYjj5s5SQwxhmwqpq7BohYEnimw8QmPN9srXVZyi4DI+/KfucXiArT+9/BAaaE2jQrWCQ==}
+  '@nestledjs/api@2.9.2':
+    resolution: {integrity: sha512-0hoVtU6Iv32g9ER+tJay0XQuXF3RX57nx2mLEdyMP81Hhk5SurmpX/6sKKzac81XjBtwqAG/HSPxh5fS7ZJfpg==}
     peerDependencies:
       '@nestledjs/utils': 1.0.1
 
@@ -16411,7 +16411,7 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20)
 
-  '@nestledjs/api@2.9.1(16587fe02cbb2bac796d9cf6b7b28a1b)':
+  '@nestledjs/api@2.9.2(16587fe02cbb2bac796d9cf6b7b28a1b)':
     dependencies:
       '@nestledjs/utils': 1.0.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.17.6))(eslint@9.39.1(jiti@2.4.2))(magicast@0.3.5)(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.7.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
       '@nx/devkit': 22.0.2(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))


### PR DESCRIPTION
## Summary
Updated the GraphQL model generation to use `GraphQLJSON` instead of `GraphQLJSONObject` from the `graphql-type-json` package, and made the import conditional based on actual usage.

## Key Changes
- Removed the unconditional import of `GraphQLJSONObject` from `graphql-type-json`
- Added conditional import of `GraphQLJSON` that only includes the import when models actually use JSON fields
- Updated all references to `GraphQLJSONObject` to use `GraphQLJSON` instead:
  - List item GraphQL type mapping for JSON fields
  - Field decorator type mapping for JSON fields

## Implementation Details
The import is now only added when the `usesJson` flag is true, meaning it will only be included in generated files that actually contain JSON-typed fields. This reduces unnecessary imports in generated code and aligns with the pattern used for other conditional imports like `GraphQLDecimal`.

https://claude.ai/code/session_01Wb2jKBeeobrFBKye8X4eN6