### PR TITLE
fix(crud): resolve @crudAuth from the DMMF model instead of scanning schema text

### DIFF
--- a/generators/src/crud/generator.spec.ts
+++ b/generators/src/crud/generator.spec.ts
@@ -2,7 +2,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing'
-import { GenerateCrudGeneratorDependencies, generateCrudLogic } from './generator'
+import { GenerateCrudGeneratorDependencies, generateCrudLogic, getCrudAuthForModel } from './generator'
 import { Tree } from '@nx/devkit'
 
 // The mocked DMMF object
@@ -106,5 +106,84 @@ describe('generate-crud generator', () => {
     expect(modelsArg.pluralName).toBe('DataList')
     expect(modelsArg.pluralModelName).toBe('DataList')
     expect(modelsArg.pluralModelPropertyName).toBe('dataList')
+  })
+
+  it('does not inherit @crudAuth from a model whose name merely starts with this model name', async () => {
+    // Regression: looking up `User` used to match `model UserSessionProgress` because the schema
+    // scan had no word boundary, so User silently inherited the other model's user-level config.
+    const collidingDmmf = {
+      datamodel: {
+        models: [
+          {
+            name: 'UserSessionProgress',
+            documentation:
+              '@crudAuth: { "readOne": "user", "readMany": "user", "count": "user", "create": "user", "update": "user" }',
+            fields: [{ name: 'id', type: 'Int', isId: true }],
+          },
+          {
+            name: 'User',
+            fields: [{ name: 'id', type: 'Int', isId: true }],
+          },
+        ],
+      },
+    }
+    mockDependencies.getDMMF = vi.fn().mockResolvedValue(collidingDmmf)
+
+    await generateCrudLogic(tree, { name: 'crud' } as any, mockDependencies)
+
+    const models = (mockDependencies.apiLibraryGenerator as any).mock.calls[0][1].models
+    const user = models.find((model: any) => model.name === 'User')
+    expect(user.auth).toEqual({
+      readOne: 'admin',
+      readMany: 'admin',
+      count: 'admin',
+      create: 'admin',
+      update: 'admin',
+      delete: 'admin',
+    })
+
+    // The annotated model itself must still keep its own configuration.
+    const progress = models.find((model: any) => model.name === 'UserSessionProgress')
+    expect(progress.auth).toMatchObject({ readOne: 'user', readMany: 'user', delete: 'admin' })
+  })
+
+  describe('getCrudAuthForModel', () => {
+    it('defaults every operation to admin when the model carries no documentation', () => {
+      expect(getCrudAuthForModel({})).toEqual({
+        readOne: 'admin',
+        readMany: 'admin',
+        count: 'admin',
+        create: 'admin',
+        update: 'admin',
+        delete: 'admin',
+      })
+    })
+
+    it('merges a partial annotation over the admin defaults', () => {
+      expect(getCrudAuthForModel({ documentation: '@crudAuth: { "readMany": "user" }' })).toEqual({
+        readOne: 'admin',
+        readMany: 'user',
+        count: 'admin',
+        create: 'admin',
+        update: 'admin',
+        delete: 'admin',
+      })
+    })
+
+    it('falls back to admin defaults when the annotation is not valid JSON', () => {
+      expect(getCrudAuthForModel({ documentation: '@crudAuth: { not json }' })).toEqual({
+        readOne: 'admin',
+        readMany: 'admin',
+        count: 'admin',
+        create: 'admin',
+        update: 'admin',
+        delete: 'admin',
+      })
+    })
+
+    it('reads the annotation when other doc lines surround it', () => {
+      const documentation = 'Some note about the model\n@crudAuth: { "create": "user" }\nAnother note'
+      expect(getCrudAuthForModel({ documentation }).create).toBe('user')
+    })
   })
 })

--- a/generators/src/crud/generator.ts
+++ b/generators/src/crud/generator.ts
@@ -51,7 +51,18 @@ export function parseCrudAuth(comment: string): CrudAuthConfig | null {
   }
 }
 
-export function getCrudAuthForModel(schema: string, modelName: string): CrudAuthConfig {
+// Read the annotation off the DMMF model rather than re-scanning the raw schema text. The previous
+// implementation searched for a line starting with `model ${modelName}`, which has no word boundary:
+// looking up `User` also matched `model UserSessionProgress`, `model UserAddress`, or any other
+// model whose name merely starts with those characters. It broke on the first such match and
+// returned that unrelated model's @crudAuth block, so a model that should default to admin could
+// silently inherit a "user" or "public" level from a neighbour. Multi-file schema directories made
+// this easy to hit, since the files are concatenated alphabetically and the hijacking model only
+// has to sort earlier.
+//
+// Prisma already associates each `///` doc comment with its own model, so `model.documentation` is
+// unambiguous. This mirrors what getAllPrismaModels in lib/engine/generator-utils.ts already does.
+export function getCrudAuthForModel(model: { documentation?: string | null }): CrudAuthConfig {
   const defaultConfig: CrudAuthConfig = {
     readOne: 'admin',
     readMany: 'admin',
@@ -60,28 +71,8 @@ export function getCrudAuthForModel(schema: string, modelName: string): CrudAuth
     update: 'admin',
     delete: 'admin',
   }
-  const lines = schema.split('\n')
-  let modelDoc: string[] = []
-  let foundModel = false
-  for (const line of lines) {
-    const trimmedLine = line.trim()
-    if (
-      trimmedLine.startsWith(`model ${modelName}`) ||
-      trimmedLine.startsWith(`model ${modelName} `) ||
-      trimmedLine.startsWith(`model ${modelName}{`)
-    ) {
-      foundModel = true
-      break
-    } else if (trimmedLine.startsWith('model ') && !foundModel) {
-      modelDoc = []
-    } else if (trimmedLine.startsWith('///') && !foundModel) {
-      modelDoc.push(trimmedLine)
-    }
-  }
-  if (!foundModel) return defaultConfig
-  const authLine = modelDoc.find((line) => line.includes('@crudAuth:'))
-  if (!authLine) return defaultConfig
-  const config = parseCrudAuth(authLine)
+  if (!model.documentation) return defaultConfig
+  const config = parseCrudAuth(model.documentation)
   return config ? { ...defaultConfig, ...config } : defaultConfig
 }
 
@@ -247,7 +238,7 @@ export async function generateCrudLogic(
       return dmmf.datamodel.models.filter(model => !skippedModelNames.has(model.name)).map((model) => {
         const singularPropertyName = model.name.charAt(0).toLowerCase() + model.name.slice(1)
         const pluralPropertyName = getPluralName(singularPropertyName)
-        const authConfig = getCrudAuthForModel(prismaSchema, model.name)
+        const authConfig = getCrudAuthForModel(model)
         const idField = model.fields.find((f) => f.isId)
         const idFieldType = idField ? idField.type : 'String'
         return {


### PR DESCRIPTION
## The bug

`getCrudAuthForModel` walked the raw schema looking for the model and stopped on:

```ts
if (trimmedLine.startsWith(`model ${modelName}`) ||        // ← no word boundary
    trimmedLine.startsWith(`model ${modelName} `) ||
    trimmedLine.startsWith(`model ${modelName}{`)) {
```

The first clause has no delimiter, so looking up `User` also matches `model UserSessionProgress`, `model UserAddress`, `model UserEmail` — anything starting with those characters. The loop `break`s at the first one it hits and returns the `modelDoc` accumulated before it, i.e. **that other model's `@crudAuth` annotation**. (The two extra clauses are dead code — both are strict subsets of the first.)

**The direction of the failure is privilege escalation.** A model that should default to admin silently inherits a `"user"` — or `"public"` — level from a neighbour. Operations missing from the hijacked annotation still fall back to admin, producing the telltale mixed shape:

```
{ readOne: 'user', readMany: 'user', count: 'user', create: 'user', update: 'user', delete: 'admin' }
```

which is exactly what shows up as five operations on `GqlAuthGuard` and `delete` on `GqlAuthAdminGuard`.

The asymmetry matters: **short model names are the vulnerable ones.** `User` can be hijacked by `UserSessionProgress`, but not the reverse. A schema directory makes it easy to hit, since files are concatenated alphabetically and the hijacker only has to sort earlier — `course_models.prisma` before `user_models.prisma`.

## The fix

Prisma already associates each `///` doc comment with its own model, so `model.documentation` is unambiguous. Read that instead of re-scanning text.

Notably, `getAllPrismaModels` in `lib/engine/generator-utils.ts:431` **already does this correctly** (`model.documentation ? parseCrudAuth(model.documentation) : null`). There are two parallel implementations and only the injected copy in `crud/generator.ts` hand-rolled a text scan. This brings them into line.

Admin-default merging is preserved, so a partial annotation still fills unspecified operations with `admin`.

## Verification

- Reproduced against the shipped logic first: `getCrudAuthForModel(schema, 'User')` with `UserSessionProgress` declared earlier returns the escalated config above.
- All 5 new tests fail against the old implementation and pass against the new one; full suite 99/99.
- `nx lint` and `nx build` clean.

Tests cover: the prefix-collision regression (and that the annotated model keeps its own config), admin defaults with no documentation, partial-annotation merging, malformed JSON falling back to admin, and reading the annotation when other doc lines surround it.

Only `generator.ts` and its spec are touched. The file is not prettier-clean on `develop` (12 files in `generators/src` aren't), so I deliberately did **not** run prettier over it — that would have buried a 20-line fix in 120 lines of unrelated reformatting.

## Note on signature

`getCrudAuthForModel(schema, modelName)` becomes `getCrudAuthForModel(model)`. It is exported but has no consumers outside this file and is not part of the Nx generator surface in `generators.json`.

## Worth a separate look

`getGuardForAuthLevel` returns `null` for `"public"`, so `@crudAuth: { "readMany": "public" }` emits generated CRUD with **no guard at all**. That is presumably intentional, but combined with this bug it was reachable by accident — a model could inherit `public` from a neighbour. The existing spec fixture uses `"create": "public"`, so the path is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)