### PR TITLE
fix(crud): preserve custom @crudAuth level casing when building guard names

### DIFF
--- a/generators/src/crud/generator.spec.ts
+++ b/generators/src/crud/generator.spec.ts
@@ -2,7 +2,12 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing'
-import { GenerateCrudGeneratorDependencies, generateCrudLogic, getCrudAuthForModel } from './generator'
+import {
+  GenerateCrudGeneratorDependencies,
+  generateCrudLogic,
+  getCrudAuthForModel,
+  getGuardForAuthLevel,
+} from './generator'
 import { Tree } from '@nx/devkit'
 
 // The mocked DMMF object
@@ -184,6 +189,33 @@ describe('generate-crud generator', () => {
     it('reads the annotation when other doc lines surround it', () => {
       const documentation = 'Some note about the model\n@crudAuth: { "create": "user" }\nAnother note'
       expect(getCrudAuthForModel({ documentation }).create).toBe('user')
+    })
+  })
+
+  describe('getGuardForAuthLevel', () => {
+    it('maps the built-in levels', () => {
+      expect(getGuardForAuthLevel('admin')).toBe('GqlAuthAdminGuard')
+      expect(getGuardForAuthLevel('user')).toBe('GqlAuthGuard')
+      expect(getGuardForAuthLevel('')).toBe('GqlAuthAdminGuard')
+      expect(getGuardForAuthLevel('public')).toBeNull()
+    })
+
+    it('accepts the built-in levels case-insensitively', () => {
+      expect(getGuardForAuthLevel('Admin')).toBe('GqlAuthAdminGuard')
+      expect(getGuardForAuthLevel('USER')).toBe('GqlAuthGuard')
+      expect(getGuardForAuthLevel('Public')).toBeNull()
+    })
+
+    it('preserves interior casing for custom levels', () => {
+      // Regression: the level used to be lowercased in full, yielding
+      // GqlAuthBillingadminGuard, which matches no real class.
+      expect(getGuardForAuthLevel('billingAdmin')).toBe('GqlAuthBillingAdminGuard')
+      expect(getGuardForAuthLevel('organizationOwner')).toBe('GqlAuthOrganizationOwnerGuard')
+    })
+
+    it('still capitalises the first character of a custom level', () => {
+      expect(getGuardForAuthLevel('staff')).toBe('GqlAuthStaffGuard')
+      expect(getGuardForAuthLevel('noaccess')).toBe('GqlAuthNoaccessGuard')
     })
   })
 })

--- a/generators/src/crud/generator.ts
+++ b/generators/src/crud/generator.ts
@@ -78,12 +78,16 @@ export function getCrudAuthForModel(model: { documentation?: string | null }): C
 
 export function getGuardForAuthLevel(level: string): string | null {
   if (!level) return 'GqlAuthAdminGuard'
-  level = level.toLowerCase()
-  if (level === 'public') return null
-  if (level === 'user') return 'GqlAuthGuard'
-  if (level === 'admin') return 'GqlAuthAdminGuard'
-  const pascalCase = level.charAt(0).toUpperCase() + level.slice(1).toLowerCase()
-  return `GqlAuth${pascalCase}Guard`
+  const normalized = level.toLowerCase()
+  if (normalized === 'public') return null
+  if (normalized === 'user') return 'GqlAuthGuard'
+  if (normalized === 'admin') return 'GqlAuthAdminGuard'
+  // Only the first character is normalised. The previous implementation lowercased the whole level
+  // first, so a custom level like "billingAdmin" produced GqlAuthBillingadminGuard — a symbol that
+  // does not exist — and downstream repos had to alias their real guard to the mangled name to make
+  // generated code compile. Preserve the author's casing so "billingAdmin" resolves to
+  // GqlAuthBillingAdminGuard, matching the convention documented in AGENTS.md.
+  return `GqlAuth${level.charAt(0).toUpperCase()}${level.slice(1)}Guard`
 }
 
 function toKebabCase(str: string): string {


### PR DESCRIPTION
Follow-up to #111. Same function, separate defect.

## The bug

`getGuardForAuthLevel` lowercased the **entire** level before capitalising the first character:

```ts
level = level.toLowerCase()
...
const pascalCase = level.charAt(0).toUpperCase() + level.slice(1).toLowerCase()
return `GqlAuth${pascalCase}Guard`
```

So a custom level `"billingAdmin"` produced `GqlAuthBillingadminGuard` — a symbol that does not exist. The convention documented in AGENTS.md (`"organizationOwner"` → `GqlAuthOrganizationOwnerGuard`) never actually worked for any multi-word level.

## Why it matters

This fails loudly rather than insecurely — the generated import does not resolve — but it has been quietly costing downstream repos. travel-outlook uses `"billingAdmin"` on 10+ models and worked around it by re-exporting its real guard under the mangled name so generated code would compile:

```ts
// generators lowercase everything after the first character
// ("billingAdmin" -> GqlAuthBillingadminGuard), so the
export { GqlAuthBillingAdminGuard as GqlAuthBillingadminGuard }
```

That alias is a workaround for this bug, in the wrong repo.

## The fix

Normalise only for the built-in level comparison (`public` / `user` / `admin` stay case-insensitive) and preserve the author's casing when constructing the custom guard name.

## Impact

- `"billingAdmin"` → `GqlAuthBillingAdminGuard`, which is the class travel-outlook actually defines. Their alias becomes redundant and can be removed on their next regeneration.
- Single-word levels are unaffected: cashcast's `"noaccess"` → `GqlAuthNoaccessGuard` and moceanic-ai's `"staff"` → `GqlAuthStaffGuard` are unchanged.
- No other repo uses a multi-word custom level, so this is the full blast radius.

## Verification

103 tests pass; lint and build clean. New cases cover built-in levels, case-insensitive built-ins, interior casing preserved for custom levels (`billingAdmin`, `organizationOwner`), and first-character capitalisation for single-word levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)