### PR TITLE
feat(generators)!: canonical CRUD feature module + model-extension generator (2.0.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,12 @@
 ## Repository Structure
 
 This is an Nx workspace that publishes a **single package: `@nestledjs/generators`**
-(at `generators/`) — an Nx plugin with five generators (four Prisma-driven codegen
+(at `generators/`) — an Nx plugin with six generators (four ongoing codegen/scaffolding
 generators plus a one-time workspace bootstrap):
 
 - `crud` — CRUD resolvers/services from Prisma models
-- `custom` — custom library wrappers for models
+- `custom` — creates or maintains the custom API library shell
+- `model-extension` — explicitly scaffolds an additive resolver module for one Prisma model
 - `sdk` — GraphQL client SDK (fragments, mutations, queries)
 - `models` — GraphQL `@ObjectType` models and enums from Prisma models
 - `workspace-setup` — one-time bootstrap of a freshly cloned workspace (rename the
@@ -27,7 +28,7 @@ Their source remains in git history prior to the consolidation commit.
 nx build generators          # build the package
 nx test generators           # run the vitest suite
 nx lint generators           # lint
-nx list @nestledjs/generators  # list the five generators
+nx list @nestledjs/generators  # list the six generators
 pnpm push generators         # build + push to the local yalc store (see README)
 ```
 
@@ -60,11 +61,13 @@ Types: `feat` (minor), `fix` (patch), `!` / `BREAKING CHANGE` (major), plus
 `docs`, `style`, `refactor`, `test`, `chore` (no bump).
 
 Scopes:
+
 - `generators` — the package
 - `nx` — Nx configuration
 - `tools` — tooling/scripts
 
 Examples:
+
 ```
 feat(generators): add option to crud generator
 fix(generators): correct enum import ordering in models output

--- a/README.md
+++ b/README.md
@@ -31,20 +31,22 @@ This runs:
 2. **`generators:crud`** — Generates CRUD resolvers and services from your Prisma models
 3. **`generators:models`** — Generates GraphQL `@ObjectType` models and enums from your Prisma models
 4. **`generators:sdk`** — Generates the GraphQL client SDK (fragments, mutations, queries)
-5. **`generators:custom`** — Generates custom library wrappers for your models
+5. **`generators:custom`** — Creates or maintains the custom API library shell. Model-specific
+   extensions are created explicitly with `model-extension`, not automatically for every model.
 
 Most one-time project scaffolding (the initial NestJS/web apps, library layout) lives in the starter templates themselves. The one exception is `workspace-setup`, the post-clone bootstrap (rename the project, `.env`/Docker, migrate, seed) — it ships in the package because it's run once right after cloning a template.
 
 ## Generators
 
-`@nestledjs/generators` exposes five generators — four Prisma-driven codegen generators plus a one-time workspace bootstrap:
+`@nestledjs/generators` exposes six generators:
 
-| Generator | Description |
-|---|---|
-| `@nestledjs/generators:crud` | Generate CRUD resolvers/services from Prisma models |
-| `@nestledjs/generators:models` | Generate GraphQL `@ObjectType` models and enums from Prisma models |
-| `@nestledjs/generators:sdk` | Generate the GraphQL client SDK (fragments, mutations, queries) |
-| `@nestledjs/generators:custom` | Generate custom library wrappers for models |
+| Generator                               | Description                                                                                                                                    |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@nestledjs/generators:crud`            | Generate CRUD resolvers/services from Prisma models                                                                                            |
+| `@nestledjs/generators:models`          | Generate GraphQL `@ObjectType` models and enums from Prisma models                                                                             |
+| `@nestledjs/generators:sdk`             | Generate the GraphQL client SDK (fragments, mutations, queries)                                                                                |
+| `@nestledjs/generators:custom`          | Create or maintain the custom API library shell                                                                                                |
+| `@nestledjs/generators:model-extension` | Scaffold an additive resolver module for one Prisma model                                                                                      |
 | `@nestledjs/generators:workspace-setup` | One-time bootstrap of a freshly cloned workspace: rename the project, ensure `.env`/Docker, apply Prisma migrations, generate models, and seed |
 
 List them any time with:
@@ -55,14 +57,39 @@ nx list @nestledjs/generators
 
 See [`generators/CHANGELOG.md`](./generators/CHANGELOG.md) for release notes.
 
+### Generated CRUD and model extensions
+
+The `crud` generator writes and registers one populated `ApiGeneratedCrudFeatureModule`. That
+module is the sole owner of generated resolver providers. Custom resolvers compose additional
+queries, mutations, and field resolvers; they do not inherit `Generated<Model>Resolver`.
+
+The `custom` generator remains in `db-update` because it safely creates or maintains the custom
+library barrels. It no longer creates an empty resolver/service/module for every Prisma model.
+Create a model-adjacent extension only when needed:
+
+```sh
+nx g @nestledjs/generators:model-extension User
+```
+
+By convention this creates `libs/api/custom/src/lib/default/user/user.{module,resolver}.ts`, exports
+the module, and registers it in `defaultModules`. A distinct artifact name is supported without
+changing the target GraphQL model:
+
+```sh
+nx g @nestledjs/generators:model-extension User --name=UserProfile
+```
+
+Generated CRUD names remain reserved. Custom operations must use additive names such as
+`myOrganizations`, `userCreateOrganization`, or `currentSubscription`.
+
 ### Schema annotations
 
 The codegen generators honor two annotations written as Prisma triple-slash (`///`) doc comments, so you control what reaches the generated GraphQL layer directly from `schema.prisma`:
 
-| Annotation | Applies to | Effect |
-|---|---|---|
-| `@skipCrud` | model | Excludes the model from all generated output (`crud`, `sdk`, `models`) and strips inbound relation fields that point at it from other models. Use for types that must never appear in the GraphQL schema. |
-| `@graphqlOmit` | field | Omits the field from the generated `@ObjectType` (`models`), client operations (`sdk`), and CRUD inputs (`crud`). Use for secrets/columns that must never be exposed through the API. |
+| Annotation     | Applies to | Effect                                                                                                                                                                                                    |
+| -------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@skipCrud`    | model      | Excludes the model from all generated output (`crud`, `sdk`, `models`) and strips inbound relation fields that point at it from other models. Use for types that must never appear in the GraphQL schema. |
+| `@graphqlOmit` | field      | Omits the field from the generated `@ObjectType` (`models`), client operations (`sdk`), and CRUD inputs (`crud`). Use for secrets/columns that must never be exposed through the API.                     |
 
 ```prisma
 /// @skipCrud
@@ -85,11 +112,11 @@ model OAuthAccount {
 Every generated CRUD operation declares its access level explicitly, resolved from the model's
 `@crudAuth` annotation (all operations default to `admin` when unannotated):
 
-| Level | Emitted |
-|---|---|
-| `admin` | `@AdminOnly()` + `@UseGuards(GqlAuthAdminGuard)` |
-| `user` | `@Authenticated()` + `@UseGuards(GqlAuthGuard)` |
-| `public` | `@Public()`, no guard |
+| Level                       | Emitted                                                     |
+| --------------------------- | ----------------------------------------------------------- |
+| `admin`                     | `@AdminOnly()` + `@UseGuards(GqlAuthAdminGuard)`            |
+| `user`                      | `@Authenticated()` + `@UseGuards(GqlAuthGuard)`             |
+| `public`                    | `@Public()`, no guard                                       |
 | custom, e.g. `billingAdmin` | `@Authenticated()` + `@UseGuards(GqlAuthBillingAdminGuard)` |
 
 A custom level's decorator declares only that a level exists — the custom guard remains
@@ -142,7 +169,11 @@ Before v1.0.0, the framework published seven packages:
 `@nestledjs/api`, `@nestledjs/shared`, `@nestledjs/utils`, `@nestledjs/config`,
 `@nestledjs/plugins`, `@nestledjs/web`, and `@nestledjs/helpers`.
 
-In practice, only three generators plus a local `generate-models` script were used for ongoing development; the rest were one-time scaffolding that belongs in the starter templates, private engine code (`@nestledjs/utils`), or unused. **v1.0.0 collapses everything into a single package, `@nestledjs/generators`, containing the five generators above** (`crud`, `custom`, `sdk`, `models`, `workspace-setup`) with the shared engine inlined.
+In practice, only three generators plus a local `generate-models` script were used for ongoing
+development; the rest were one-time scaffolding that belongs in the starter templates, private
+engine code (`@nestledjs/utils`), or unused. **v1.0.0 collapsed everything into a single package,
+`@nestledjs/generators`**, with the shared engine inlined. Later releases added `workspace-setup`
+and the explicit `model-extension` scaffolder.
 
 **The seven old packages are deprecated on npm but not unpublished** — existing installs and lockfiles keep working. To migrate:
 
@@ -159,16 +190,16 @@ To test `@nestledjs/generators` in a local project, use [YALC](https://github.co
 
 1. **Publish/push from this repo** (builds `@nestledjs/generators` and pushes to the yalc store):
 
-    ```sh
-    pnpm push generators
-    ```
+   ```sh
+   pnpm push generators
+   ```
 
 2. **In your consumer project, link the package:**
 
-    ```sh
-    yalc add @nestledjs/generators
-    pnpm install
-    ```
+   ```sh
+   yalc add @nestledjs/generators
+   pnpm install
+   ```
 
 Re-run `pnpm push generators` after any change; `yalc push` propagates it to every linked consumer.
 

--- a/generators/CHANGELOG.md
+++ b/generators/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to `@nestledjs/generators` are documented here. This project
 uses independent semantic versioning; the current version is resolved from the npm
 registry (see `nx.json` → `release`).
 
+## 2.0.0
+
+### Changed
+
+- **`crud`: register generated resolvers through one canonical feature module.** The populated
+  module is now written to `api-generated-crud-feature.module.ts`, imported into the API's
+  `coreModules`, and exported from the generated feature barrel. The legacy
+  `api-admin-crud-feature.module.ts` is deleted during generation. This removes the duplicate
+  `ApiGeneratedCrudFeatureModule` class created by the old scaffold-plus-alternate-file flow.
+- **`custom`: stop generating an inheriting resolver/service/module shell for every Prisma model.**
+  Generated CRUD no longer depends on custom resolver inheritance for registration. The generator
+  now maintains only the custom API library and its stable barrels, preserving every explicit
+  extension already present.
+
+### Added
+
+- **New `model-extension` generator.** Run
+  `nx g @nestledjs/generators:model-extension <Model>` to create an additive model-specific resolver
+  module on demand. The conventional artifact name defaults to the Prisma model, while `--name`
+  supports a more specific feature name without changing the target GraphQL type.
+
+### Migration
+
+This release changes resolver registration and therefore requires a coordinated consumer update:
+
+1. Upgrade the template wiring so `ApiGeneratedCrudFeatureModule` is in `coreModules`.
+2. Remove `extends Generated<Model>Resolver`, generated resolver imports, generated data-access
+   constructor injection, and `super(...)` from custom resolvers.
+3. Delete empty legacy default-model shells; preserve modules that contain real custom behavior.
+4. Run `pnpm db-update`, then verify the GraphQL root fields and authorization guards.
+
+Do not import the generated feature module while leaving inheriting custom resolvers registered:
+Nest scans inherited resolver methods, so that temporarily registers duplicate callbacks for every
+generated GraphQL field.
+
 ## 1.1.6
 
 ### Added
@@ -19,12 +54,12 @@ registry (see `nx.json` → `release`).
 
   Levels map as follows, from the resolved `@crudAuth` config:
 
-  | Level | Emitted |
-  | ----- | ------- |
-  | `admin` (also the default when unannotated) | `@AdminOnly()` + `@UseGuards(GqlAuthAdminGuard)` |
-  | `user` | `@Authenticated()` + `@UseGuards(GqlAuthGuard)` |
-  | `public` | `@Public()`, no guard |
-  | custom, e.g. `billingAdmin` | `@Authenticated()` + `@UseGuards(GqlAuthBillingAdminGuard)` |
+  | Level                                       | Emitted                                                     |
+  | ------------------------------------------- | ----------------------------------------------------------- |
+  | `admin` (also the default when unannotated) | `@AdminOnly()` + `@UseGuards(GqlAuthAdminGuard)`            |
+  | `user`                                      | `@Authenticated()` + `@UseGuards(GqlAuthGuard)`             |
+  | `public`                                    | `@Public()`, no guard                                       |
+  | custom, e.g. `billingAdmin`                 | `@Authenticated()` + `@UseGuards(GqlAuthBillingAdminGuard)` |
 
   A custom level's decorator declares only that a level exists; the custom guard stays
   authoritative about what it means, so a `noaccess` guard still denies everyone. No stricter

--- a/generators/README.md
+++ b/generators/README.md
@@ -1,6 +1,28 @@
-# generators
+# @nestledjs/generators
 
-This library was generated with [Nx](https://nx.dev).
+Nx generators for keeping a Nestled workspace aligned with its Prisma schema and for scaffolding
+explicit API extensions.
+
+## Model extensions
+
+Generated CRUD resolvers are registered by `ApiGeneratedCrudFeatureModule`. Custom model behavior
+is additive and must not inherit a generated resolver. Scaffold a conventional model-adjacent
+resolver module only when the model needs custom behavior:
+
+```sh
+nx g @nestledjs/generators:model-extension User
+```
+
+This creates `libs/api/custom/src/lib/default/user/user.{module,resolver}.ts`, exports the module,
+and adds it to the API's `defaultModules`. The default artifact name follows the Prisma model; use
+`--name` when a more specific feature name is clearer:
+
+```sh
+nx g @nestledjs/generators:model-extension User --name=UserProfile
+```
+
+Both resolvers target the `User` GraphQL model. The name and folder layout are conventions, not an
+inheritance contract.
 
 ## Building
 

--- a/generators/generators.json
+++ b/generators/generators.json
@@ -11,7 +11,7 @@
     "custom": {
       "factory": "./src/custom/generator.js",
       "schema": "./src/custom/schema.json",
-      "description": "Generate custom API libraries based on Prisma models"
+      "description": "Create or maintain the custom API library shell"
     },
     "sdk": {
       "factory": "./src/sdk/generator.js",
@@ -27,6 +27,11 @@
       "factory": "./src/workspace-setup/generator.js",
       "schema": "./src/workspace-setup/schema.json",
       "description": "Set up a freshly cloned workspace: rename the project, ensure .env/Docker, apply Prisma migrations, generate models, and seed"
+    },
+    "model-extension": {
+      "factory": "./src/model-extension/generator.js",
+      "schema": "./src/model-extension/schema.json",
+      "description": "Scaffold an additive model-specific API resolver module"
     }
   }
 }

--- a/generators/package.json
+++ b/generators/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
-  "description": "Prisma-driven code generators for Nestled projects (crud, custom, sdk, models, workspace-setup)",
+  "description": "Prisma-driven code generators for Nestled projects (crud, custom, model-extension, sdk, models, workspace-setup)",
   "keywords": [
     "nestled",
     "generators",
@@ -29,8 +29,8 @@
     "access": "public"
   },
   "dependencies": {
-    "tslib": "^2.3.0",
     "@nx/devkit": "22.0.2",
+    "tslib": "^2.3.0",
     "@nx/js": "22.0.2",
     "@nx/nest": "22.0.2",
     "@prisma/internals": "^7.3.0",

--- a/generators/src/crud/generator.spec.ts
+++ b/generators/src/crud/generator.spec.ts
@@ -80,12 +80,41 @@ describe('generate-crud generator', () => {
   it('generates files and calls utilities for valid models', async () => {
     const callback = await generateCrudLogic(tree, { name: 'crud' } as any, mockDependencies)
 
-    expect(mockDependencies.apiLibraryGenerator).toHaveBeenCalled()
+    expect(mockDependencies.apiLibraryGenerator).toHaveBeenNthCalledWith(
+      1,
+      tree,
+      expect.objectContaining({ name: 'crud' }),
+      expect.any(String),
+      'data-access',
+    )
+    expect(mockDependencies.apiLibraryGenerator).toHaveBeenNthCalledWith(
+      2,
+      tree,
+      expect.objectContaining({ name: 'crud' }),
+      expect.any(String),
+      'feature',
+      true,
+    )
     expect(mockDependencies.formatFiles).toHaveBeenCalled()
 
     expect(typeof callback).toBe('function')
     if (callback) callback()
     expect(mockDependencies.installPackagesTask).toHaveBeenCalled()
+  })
+
+  it('writes one canonical populated feature module and removes the legacy duplicate', async () => {
+    const legacyPath = 'libs/api/crud/feature/src/lib/api-admin-crud-feature.module.ts'
+    tree.write(legacyPath, 'legacy module')
+
+    await generateCrudLogic(tree, { name: 'crud' } as any, mockDependencies)
+
+    const canonicalPath = 'libs/api/crud/feature/src/lib/api-generated-crud-feature.module.ts'
+    expect(tree.read(canonicalPath, 'utf-8')).toContain('export class ApiGeneratedCrudFeatureModule')
+    expect(tree.read(canonicalPath, 'utf-8')).toContain('providers: [GeneratedUserResolver]')
+    expect(tree.exists(legacyPath)).toBe(false)
+    expect(tree.read('libs/api/crud/feature/src/index.ts', 'utf-8')).toContain(
+      "export * from './lib/api-generated-crud-feature.module'",
+    )
   })
 
   it('appends "List" to plural when singular and plural forms are the same', async () => {
@@ -260,10 +289,7 @@ describe('generate-crud generator', () => {
       // Previously this emitted no decorator at all — output indistinguishable from a dropped one.
       const source = generateResolverContent({ ...baseModel, auth: allLevels('public') }, 'scope')
 
-      expect(decoratorsFor(source, 'users')).toEqual([
-        '@Query(() => [User], { nullable: true })',
-        '@Public()',
-      ])
+      expect(decoratorsFor(source, 'users')).toEqual(['@Query(() => [User], { nullable: true })', '@Public()'])
       expect(source).not.toContain('@UseGuards')
     })
 
@@ -290,7 +316,14 @@ describe('generate-crud generator', () => {
       const source = generateResolverContent(
         {
           ...baseModel,
-          auth: { readMany: 'public', count: 'user', readOne: 'admin', create: 'billingAdmin', update: 'admin', delete: 'admin' },
+          auth: {
+            readMany: 'public',
+            count: 'user',
+            readOne: 'admin',
+            create: 'billingAdmin',
+            update: 'admin',
+            delete: 'admin',
+          },
         },
         'scope',
       )
@@ -308,7 +341,14 @@ describe('generate-crud generator', () => {
         const source = generateResolverContent(
           {
             ...baseModel,
-            auth: { readMany: 'public', count: 'user', readOne: 'admin', create: 'admin', update: 'admin', delete: 'admin' },
+            auth: {
+              readMany: 'public',
+              count: 'user',
+              readOne: 'admin',
+              create: 'admin',
+              update: 'admin',
+              delete: 'admin',
+            },
           },
           'scope',
         )

--- a/generators/src/crud/generator.ts
+++ b/generators/src/crud/generator.ts
@@ -138,7 +138,7 @@ export function generateResolverContent(model: ModelType, npmScope: string): str
   // Handle BigInt ID fields: use GraphQLBigInt scalar from graphql-scalars
   // to properly serialize/deserialize bigint values in GraphQL
   const idTsType = model.idFieldType === 'BigInt' ? 'bigint' : 'string'
-  const idArgsType = model.idFieldType === 'BigInt' ? ", { type: () => GraphQLBigInt }" : ''
+  const idArgsType = model.idFieldType === 'BigInt' ? ', { type: () => GraphQLBigInt }' : ''
   const graphqlScalarImport = model.idFieldType === 'BigInt' ? "\nimport { GraphQLBigInt } from 'graphql-scalars'" : ''
 
   return `import { Args, Mutation, Query, Resolver, Info } from '@nestjs/graphql'${nestCommonImports}
@@ -226,7 +226,7 @@ export function generateFeatureModuleContent(models: ModelType[], npmScope: stri
 }
 
 export function generateFeatureIndexContent(models: ModelType[]): string {
-  return `export * from './lib/api-admin-crud-feature.module'\n${models
+  return `export * from './lib/api-generated-crud-feature.module'\n${models
     .map((model) => `export * from './lib/${toKebabCase(model.modelName)}.resolver'`)
     .join('\n')}\n`
 }
@@ -249,46 +249,48 @@ export async function generateCrudLogic(
     try {
       const dmmf = await dependencies.getDMMF({ datamodel: prismaSchema })
       const skippedModelNames = getSkippedModelNames(dmmf.datamodel.models)
-      return dmmf.datamodel.models.filter(model => !skippedModelNames.has(model.name)).map((model) => {
-        const singularPropertyName = model.name.charAt(0).toLowerCase() + model.name.slice(1)
-        const pluralPropertyName = getPluralName(singularPropertyName)
-        const authConfig = getCrudAuthForModel(model)
-        const idField = model.fields.find((f) => f.isId)
-        const idFieldType = idField ? idField.type : 'String'
-        return {
-          name: model.name,
-          pluralName: getPluralName(model.name),
-          fields: filterSkippedRelationFields(model.fields, skippedModelNames)
-            .filter((field) => !field.documentation?.includes('@graphqlOmit'))
-            .map((field) => ({
-              name: field.name,
-              kind: field.kind,
-              type: field.type,
-              isOptional: !field.isRequired,
-              isId: field.isId,
-              isUnique: field.isUnique,
-              isList: field.isList,
-              isReadOnly: field.isReadOnly,
-              hasDefaultValue: field.hasDefaultValue,
-              default: field.default,
-              relationName: field.relationName,
-              relationFromFields: field.relationFromFields ? [...field.relationFromFields] : undefined,
-              relationToFields: field.relationToFields ? [...field.relationToFields] : undefined,
-              relationOnDelete: field.relationOnDelete,
-              relationOnUpdate: field.relationOnUpdate,
-              isGenerated: field.isGenerated,
-              isUpdatedAt: field.isUpdatedAt,
-              documentation: field.documentation,
-            })),
-          primaryField: model.fields.find((f) => !f.isId && f.type === 'String')?.name || 'name',
-          modelName: model.name,
-          modelPropertyName: singularPropertyName,
-          pluralModelName: getPluralName(model.name),
-          pluralModelPropertyName: pluralPropertyName,
-          auth: authConfig,
-          idFieldType,
-        }
-      })
+      return dmmf.datamodel.models
+        .filter((model) => !skippedModelNames.has(model.name))
+        .map((model) => {
+          const singularPropertyName = model.name.charAt(0).toLowerCase() + model.name.slice(1)
+          const pluralPropertyName = getPluralName(singularPropertyName)
+          const authConfig = getCrudAuthForModel(model)
+          const idField = model.fields.find((f) => f.isId)
+          const idFieldType = idField ? idField.type : 'String'
+          return {
+            name: model.name,
+            pluralName: getPluralName(model.name),
+            fields: filterSkippedRelationFields(model.fields, skippedModelNames)
+              .filter((field) => !field.documentation?.includes('@graphqlOmit'))
+              .map((field) => ({
+                name: field.name,
+                kind: field.kind,
+                type: field.type,
+                isOptional: !field.isRequired,
+                isId: field.isId,
+                isUnique: field.isUnique,
+                isList: field.isList,
+                isReadOnly: field.isReadOnly,
+                hasDefaultValue: field.hasDefaultValue,
+                default: field.default,
+                relationName: field.relationName,
+                relationFromFields: field.relationFromFields ? [...field.relationFromFields] : undefined,
+                relationToFields: field.relationToFields ? [...field.relationToFields] : undefined,
+                relationOnDelete: field.relationOnDelete,
+                relationOnUpdate: field.relationOnUpdate,
+                isGenerated: field.isGenerated,
+                isUpdatedAt: field.isUpdatedAt,
+                documentation: field.documentation,
+              })),
+            primaryField: model.fields.find((f) => !f.isId && f.type === 'String')?.name || 'name',
+            modelName: model.name,
+            modelPropertyName: singularPropertyName,
+            pluralModelName: getPluralName(model.name),
+            pluralModelPropertyName: pluralPropertyName,
+            auth: authConfig,
+            idFieldType,
+          }
+        })
     } catch (error) {
       console.error('Error parsing Prisma schema:', error)
       return []
@@ -307,7 +309,10 @@ export async function generateCrudLogic(
     const templateSchema = { name, models, filterInputs, filterInputNames }
 
     await dependencies.apiLibraryGenerator(tree, templateSchema, templatePath, 'data-access')
-    await dependencies.apiLibraryGenerator(tree, templateSchema, templatePath, 'feature')
+    // The generated resolver module is the single registration point for generated CRUD. Import
+    // it into the API's core module list instead of relying on custom resolvers to inherit the
+    // generated classes and register their methods indirectly.
+    await dependencies.apiLibraryGenerator(tree, templateSchema, templatePath, 'feature', true)
     return { dataAccessLibraryRoot, featureLibraryRoot }
   }
 
@@ -322,9 +327,17 @@ export async function generateCrudLogic(
     // Generate feature module and resolvers
     const featureModuleContent = generateFeatureModuleContent(models, npmScope)
     tree.write(
-      dependencies.joinPathFragments(featureLibraryRoot, 'src/lib/api-admin-crud-feature.module.ts'),
+      dependencies.joinPathFragments(featureLibraryRoot, 'src/lib/api-generated-crud-feature.module.ts'),
       featureModuleContent,
     )
+
+    // Older releases wrote the populated module beside the empty module scaffolded by @nx/nest.
+    // Remove that alternate file so the library has one canonical module and one exported class.
+    const legacyFeatureModulePath = dependencies.joinPathFragments(
+      featureLibraryRoot,
+      'src/lib/api-admin-crud-feature.module.ts',
+    )
+    if (tree.exists(legacyFeatureModulePath)) tree.delete(legacyFeatureModulePath)
 
     const featureIndexContent = generateFeatureIndexContent(models)
     tree.write(dependencies.joinPathFragments(featureLibraryRoot, 'src/index.ts'), featureIndexContent)

--- a/generators/src/custom/generator.spec.ts
+++ b/generators/src/custom/generator.spec.ts
@@ -3,20 +3,6 @@ import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { customGeneratorLogic, CustomGeneratorDependencies } from './generator'
 
-const dmmf = {
-  datamodel: {
-    models: [
-      {
-        name: 'User',
-        fields: [
-          { name: 'id', type: 'Int', isId: true },
-          { name: 'name', type: 'String' },
-        ],
-      },
-    ],
-  },
-}
-
 describe('custom-generator', () => {
   let tree: Tree
   let mockDependencies: CustomGeneratorDependencies
@@ -26,50 +12,36 @@ describe('custom-generator', () => {
     mockDependencies = {
       formatFiles: vi.fn(),
       installPackagesTask: vi.fn(),
-      getDMMF: vi.fn().mockResolvedValue(dmmf),
-      addToModules: vi.fn(),
       apiLibraryGenerator: vi.fn(),
-      getPrismaSchemaPath: vi.fn(() => 'prisma/schema.prisma'),
-      readPrismaSchema: vi.fn(() => `model User {}`),
       execSync: vi.fn(),
-      getNpmScope: vi.fn(() => 'test-scope'),
-      pluralize: vi.fn((name: string) => (name.endsWith('s') ? name : name + 's')) as any,
       join: vi.fn((...args: string[]) => args.join('/')),
     }
     vi.clearAllMocks()
   })
 
-  it('should generate files correctly', async () => {
+  it('creates the custom library shell without generating a wrapper for every model', async () => {
     await customGeneratorLogic(tree, { name: 'custom' }, mockDependencies)
-    expect(mockDependencies.apiLibraryGenerator).toHaveBeenCalledWith(
-      tree,
-      { name: 'custom' },
-      '',
-      undefined,
-      false,
-    )
-    // Check if files are generated in the new structure
-    expect(tree.exists('libs/api/custom/src/lib/default/user/user.service.ts')).toBe(true)
-    expect(tree.exists('libs/api/custom/src/lib/default/user/user.resolver.ts')).toBe(true)
-    expect(tree.exists('libs/api/custom/src/lib/default/user/user.module.ts')).toBe(true)
+    expect(mockDependencies.apiLibraryGenerator).toHaveBeenCalledWith(tree, { name: 'custom' }, '', undefined, false)
     expect(tree.exists('libs/api/custom/src/index.ts')).toBe(true)
-    expect(tree.exists('libs/api/custom/src/lib/plugins')).toBe(true)
+    expect(tree.exists('libs/api/custom/src/lib/default/index.ts')).toBe(true)
+    expect(tree.read('libs/api/custom/src/lib/plugins/index.ts', 'utf-8')).toBe('export const customPlugins = []\n')
+    expect(tree.exists('libs/api/custom/src/lib/default/user/user.resolver.ts')).toBe(false)
   })
 
-  it('should be idempotent and not overwrite existing model folders', async () => {
-    // First run
+  it('is idempotent and preserves explicitly generated model extensions', async () => {
     await customGeneratorLogic(tree, { name: 'custom' }, mockDependencies)
-    // Write a marker file to simulate user customization
     tree.write('libs/api/custom/src/lib/default/user/custom.txt', 'do not overwrite')
-    // Second run
     await customGeneratorLogic(tree, { name: 'custom' }, mockDependencies)
-    // The marker file should still exist
     expect(tree.read('libs/api/custom/src/lib/default/user/custom.txt', 'utf-8')).toBe('do not overwrite')
   })
 
-  it('should not generate files if no models are found', async () => {
-    mockDependencies.getDMMF = vi.fn().mockResolvedValue({ datamodel: { models: [] } })
+  it('restores an accidentally emptied plugins index without changing other custom code', async () => {
+    tree.write('libs/api/custom/src/lib/plugins/index.ts', '')
+    tree.write('libs/api/custom/src/lib/default/user/custom.txt', 'preserve me')
+
     await customGeneratorLogic(tree, { name: 'custom' }, mockDependencies)
-    expect(mockDependencies.execSync).not.toHaveBeenCalled()
+
+    expect(tree.read('libs/api/custom/src/lib/plugins/index.ts', 'utf-8')).toBe('export const customPlugins = []\n')
+    expect(tree.read('libs/api/custom/src/lib/default/user/custom.txt', 'utf-8')).toBe('preserve me')
   })
 })

--- a/generators/src/custom/generator.ts
+++ b/generators/src/custom/generator.ts
@@ -1,254 +1,38 @@
 import { formatFiles, installPackagesTask, Tree } from '@nx/devkit'
-import { getDMMF } from '@prisma/internals'
-import {
-  addToModules,
-  apiLibraryGenerator,
-  filterSkippedRelationFields,
-  getPrismaSchemaPath,
-  getSkippedModelNames,
-  readPrismaSchema,
-} from '../lib/engine'
+import { apiLibraryGenerator } from '../lib/engine'
 import { GenerateCustomGeneratorSchema } from './schema'
 import { execSync } from 'child_process'
-import { getNpmScope } from '@nx/js/src/utils/package-json/get-npm-scope'
-import pluralize from 'pluralize'
 import { join } from 'path'
 
 // Group all dependencies into a single object
 const defaultDependencies = {
   formatFiles,
   installPackagesTask,
-  getDMMF,
-  addToModules,
   apiLibraryGenerator,
-  getPrismaSchemaPath,
-  readPrismaSchema,
   execSync,
-  getNpmScope,
-  pluralize,
   join,
 }
 export type CustomGeneratorDependencies = typeof defaultDependencies
-
-interface ModelType {
-  name: string
-  pluralName: string
-  fields: ReadonlyArray<Record<string, unknown> & { name: string; type: string }>
-  primaryField: string
-  modelName: string
-  modelPropertyName: string
-  pluralModelName: string
-  pluralModelPropertyName: string
-}
-
-async function getAllPrismaModels(tree: Tree, dependencies: CustomGeneratorDependencies): Promise<ModelType[]> {
-  const prismaPath = dependencies.getPrismaSchemaPath(tree)
-  const prismaSchema = dependencies.readPrismaSchema(tree, prismaPath)
-  if (!prismaSchema) {
-    console.error(`No Prisma schema found at ${prismaPath}`)
-    return []
-  }
-
-  try {
-    const dmmf = await dependencies.getDMMF({ datamodel: prismaSchema })
-    const skippedModelNames = getSkippedModelNames(dmmf.datamodel.models)
-    return dmmf.datamodel.models.filter(model => !skippedModelNames.has(model.name)).map((model) => {
-      const singularPropertyName = model.name.charAt(0).toLowerCase() + model.name.slice(1)
-      const pluralPropertyName = dependencies.pluralize(singularPropertyName)
-
-      // Create a properly typed fields array
-      const fields = filterSkippedRelationFields(model.fields, skippedModelNames).map((field) => ({
-        name: field.name,
-        type: field.type,
-        isId: field.isId,
-        isRequired: field.isRequired,
-        isList: field.isList,
-        isUnique: field.isUnique,
-        isReadOnly: field.isReadOnly,
-        isGenerated: field.isGenerated,
-        isUpdatedAt: field.isUpdatedAt,
-        documentation: field.documentation,
-        // Include any other properties that might be needed
-        ...field,
-      }))
-
-      // Create and return the model
-      const modelData: ModelType = {
-        name: model.name,
-        pluralName: dependencies.pluralize(model.name),
-        fields,
-        primaryField: model.fields.find((f) => !f.isId && f.type === 'String')?.name || 'name',
-        modelName: model.name,
-        modelPropertyName: singularPropertyName,
-        pluralModelName: dependencies.pluralize(model.name),
-        pluralModelPropertyName: pluralPropertyName,
-      }
-
-      return modelData
-    })
-  } catch (error) {
-    console.error('Error parsing Prisma schema:', error)
-    return []
-  }
-}
-
-async function ensureDirExists(tree: Tree, path: string) {
-  if (!tree.exists(path)) {
-    // Only create the directory, do not write .gitkeep
-    // Directory will be created when a file is written into it
-  }
-}
-
-function toKebabCase(str: string): string {
-  return str
-    .replace(/([a-z])([A-Z])/g, '$1-$2')
-    .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
-    .toLowerCase()
-}
-
-function updateIndexFileAdditively(
-  tree: Tree,
-  indexPath: string,
-  newExports: string[],
-  removedExports: string[] = [],
-) {
-  const existingContent = tree.exists(indexPath) ? tree.read(indexPath)?.toString() || '' : ''
-  const removedExportSet = new Set(removedExports)
-  const existingLines = existingContent
-    .split('\n')
-    .filter(line => line.trim() !== '' && !removedExportSet.has(line))
-  const existingExports = new Set(existingLines)
-  
-  // Add new exports that don't already exist
-  newExports.forEach(exportLine => {
-    if (!existingExports.has(exportLine)) {
-      existingExports.add(exportLine)
-    }
-  })
-  
-  // Convert back to sorted array and join
-  const allExports = Array.from(existingExports).sort((a, b) => a.localeCompare(b))
-  const updatedContent = allExports.map(exp => String(exp)).join('\n') + (allExports.length > 0 ? '\n' : '')
-  
-  tree.write(indexPath, updatedContent)
-}
-
-function removeSkippedModulesFromAppModule(tree: Tree, skippedModelNames: Set<string>) {
-  const modulePath = 'apps/api/src/app.module.ts'
-  if (!tree.exists(modulePath)) return
-  let content = tree.read(modulePath, 'utf-8') || ''
-  for (const modelName of skippedModelNames) {
-    content = content.replace(new RegExp(`\\n\\s*${modelName}Module,`, 'g'), '')
-  }
-  tree.write(modulePath, content)
-}
-
-async function generateCustomFiles(
+function ensureCustomLibraryIndexes(
   tree: Tree,
   customLibraryRoot: string,
-  models: ModelType[],
-  npmScope: string,
   dependencies: CustomGeneratorDependencies,
-  skippedModelNames = new Set<string>(),
-) {
+): void {
   const defaultDir = dependencies.join(customLibraryRoot, 'src/lib/default')
   const pluginsDir = dependencies.join(customLibraryRoot, 'src/lib/plugins')
-  await ensureDirExists(tree, defaultDir)
-  await ensureDirExists(tree, pluginsDir)
-  // Create empty index.ts in pluginsDir for custom plugins (only if it doesn't exist)
+  const defaultIndexPath = dependencies.join(defaultDir, 'index.ts')
   const pluginsIndexPath = dependencies.join(pluginsDir, 'index.ts')
+
+  if (!tree.exists(defaultIndexPath)) tree.write(defaultIndexPath, '')
+
   if (!tree.exists(pluginsIndexPath)) {
-    tree.write(pluginsIndexPath, "export const customPlugins = []\n")
+    tree.write(pluginsIndexPath, 'export const customPlugins = []\n')
   } else {
     const existingPluginsIndex = tree.read(pluginsIndexPath)?.toString() ?? ''
     if (existingPluginsIndex.trim() === '') {
-      tree.write(pluginsIndexPath, "export const customPlugins = []\n")
+      tree.write(pluginsIndexPath, 'export const customPlugins = []\n')
     }
   }
-
-  for (const model of models) {
-    const kebabModel = toKebabCase(model.modelName)
-    const modelFolder = dependencies.join(defaultDir, kebabModel)
-    if (tree.exists(modelFolder)) {
-      // Skip if model folder already exists
-      continue
-    }
-    await ensureDirExists(tree, modelFolder)
-
-    // Generate service.ts
-    const serviceContent = `import { Injectable } from '@nestjs/common'
-
-@Injectable()
-export class ${model.modelName}Service {
-  // Empty for now; will override or extend later if needed
-}
-`
-    tree.write(dependencies.join(modelFolder, `${kebabModel}.service.ts`), serviceContent)
-
-    // Generate resolver.ts
-    const resolverContent = `
-import { ApiCrudDataAccessService } from '${npmScope}/api/generated-crud/data-access'
-import { Generated${model.modelName}Resolver } from '${npmScope}/api/generated-crud/feature'
-import { Injectable } from '@nestjs/common'
-import { Resolver } from '@nestjs/graphql'
-import { ${model.modelName} } from '${npmScope}/api/core/models'
-
-@Resolver(() => ${model.modelName})
-@Injectable()
-export class ${model.modelName}Resolver extends Generated${model.modelName}Resolver {
-  constructor(
-    // private readonly customService: ${model.modelName}Service,
-    generatedService: ApiCrudDataAccessService,
-  ) {
-    super(generatedService)
-  }
-}
-`
-    tree.write(dependencies.join(modelFolder, `${kebabModel}.resolver.ts`), resolverContent)
-
-    // Generate module.ts
-    const moduleContent = `import { Module } from '@nestjs/common'
-import { ${model.modelName}Service } from './${kebabModel}.service'
-import { ${model.modelName}Resolver } from './${kebabModel}.resolver'
-import { ApiCrudDataAccessModule } from '${npmScope}/api/generated-crud/data-access'
-
-@Module({
-  imports: [ApiCrudDataAccessModule],
-  providers: [${model.modelName}Service, ${model.modelName}Resolver],
-  exports: [${model.modelName}Service, ${model.modelName}Resolver],
-})
-export class ${model.modelName}Module {}
-`
-    tree.write(dependencies.join(modelFolder, `${kebabModel}.module.ts`), moduleContent)
-
-    // Add to defaultModules in app.module.ts__tmpl__
-    dependencies.addToModules({
-      tree,
-      modulePath: 'apps/api/src/app.module.ts',
-      moduleArrayName: 'defaultModules',
-      moduleToAdd: `${model.modelName}Module`,
-      importPath: `${npmScope}/api/custom`,
-    })
-  }
-
-  // Delete stale default folders for models that now have @skipCrud
-  for (const modelName of skippedModelNames) {
-    const staleFolder = dependencies.join(defaultDir, toKebabCase(modelName))
-    if (tree.exists(staleFolder)) {
-      for (const child of tree.children(staleFolder)) {
-        tree.delete(dependencies.join(staleFolder, child))
-      }
-    }
-  }
-  const skippedModelFolders = Array.from(skippedModelNames).map(toKebabCase)
-  const removedModelExports = skippedModelFolders.map(m => `export * from './${m}/${m}.module'`)
-
-  // Update default/index.ts to additively export model modules
-  const modelFolders = models.map((m) => toKebabCase(m.modelName))
-  const newModelExports = modelFolders.map((m) => `export * from './${m}/${m}.module'`)
-  const defaultIndexPath = dependencies.join(defaultDir, 'index.ts')
-  updateIndexFileAdditively(tree, defaultIndexPath, newModelExports, removedModelExports)
-  removeSkippedModulesFromAppModule(tree, skippedModelNames)
 }
 
 export async function customGeneratorLogic(
@@ -276,30 +60,13 @@ export async function customGeneratorLogic(
     // Use the shared apiLibraryGenerator but pass empty template to avoid conflicts
     await dependencies.apiLibraryGenerator(tree, { name }, '', undefined, false)
 
-    await ensureDirExists(tree, dependencies.join(customLibraryRoot, 'src/lib/default'))
-    await ensureDirExists(tree, dependencies.join(customLibraryRoot, 'src/lib/plugins'))
+    ensureCustomLibraryIndexes(tree, customLibraryRoot, dependencies)
 
     // Override the main index.ts created by apiLibraryGenerator with our stable version
     const mainIndexContent = `export * from './lib/plugins'
 export * from './lib/default'
 `
     tree.write(dependencies.join(customLibraryRoot, 'src/index.ts'), mainIndexContent)
-
-    // Get all Prisma models
-    const models = await getAllPrismaModels(tree, dependencies)
-    if (models.length === 0) {
-      console.error('No Prisma models found')
-      return
-    }
-
-    const skippedModelNames = getSkippedModelNames(
-      (await dependencies.getDMMF({ datamodel: dependencies.readPrismaSchema(tree, dependencies.getPrismaSchemaPath(tree))! }))
-        .datamodel.models
-    )
-
-    // Generate custom files per model
-    const npmScope = `@${dependencies.getNpmScope(tree)}`
-    await generateCustomFiles(tree, customLibraryRoot, models, npmScope, dependencies, skippedModelNames)
 
     // Format files
     await dependencies.formatFiles(tree)

--- a/generators/src/custom/schema.json
+++ b/generators/src/custom/schema.json
@@ -3,7 +3,7 @@
   "extends": "../../node_modules/@nx/devkit/generators.json",
   "properties": {
     "name": {
-      "description": "Name of the custom library to generate",
+      "description": "Name of the custom API library to create or maintain",
       "type": "string",
       "default": "custom"
     },
@@ -12,7 +12,7 @@
       "type": "string"
     },
     "overwrite": {
-      "description": "Whether to overwrite existing files",
+      "description": "Whether to recreate the custom API library",
       "type": "boolean",
       "default": false
     }

--- a/generators/src/model-extension/files/__extensionFileName__/__extensionFileName__.module.ts.template
+++ b/generators/src/model-extension/files/__extensionFileName__/__extensionFileName__.module.ts.template
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common'
+import { <%= extensionClassName %>Resolver } from './<%= extensionFileName %>.resolver'
+
+@Module({
+  providers: [<%= extensionClassName %>Resolver],
+  exports: [<%= extensionClassName %>Resolver],
+})
+export class <%= extensionClassName %>Module {}

--- a/generators/src/model-extension/files/__extensionFileName__/__extensionFileName__.resolver.ts.template
+++ b/generators/src/model-extension/files/__extensionFileName__/__extensionFileName__.resolver.ts.template
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common'
+import { Resolver } from '@nestjs/graphql'
+import { <%= modelName %> } from '@<%= npmScope %>/api/core/models'
+
+@Resolver(() => <%= modelName %>)
+@Injectable()
+export class <%= extensionClassName %>Resolver {
+  // Add model-specific queries, mutations, and field resolvers here.
+}

--- a/generators/src/model-extension/generator.spec.ts
+++ b/generators/src/model-extension/generator.spec.ts
@@ -1,0 +1,140 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing'
+import { Tree } from '@nx/devkit'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  ModelExtensionGeneratorDependencies,
+  modelExtensionGeneratorLogic,
+} from './generator'
+
+describe('model-extension generator', () => {
+  let tree: Tree
+  let dependencies: ModelExtensionGeneratorDependencies
+
+  const dmmf = {
+    datamodel: {
+      models: [
+        { name: 'User', fields: [] },
+        { name: 'PasswordHistory', documentation: '@skipCrud', fields: [] },
+      ],
+    },
+  }
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace()
+    tree.write('prisma/schema.prisma', 'model User { id String @id }')
+    tree.write('libs/api/custom/src/lib/default/index.ts', '')
+    tree.write(
+      'apps/api/src/app.module.ts',
+      `import { Module } from '@nestjs/common'
+
+export const defaultModules = []
+
+@Module({ imports: [...defaultModules] })
+export class AppModule {}
+`,
+    )
+    dependencies = {
+      addToModules: vi.fn(),
+      formatFiles: vi.fn(),
+      generateFiles: vi.fn((host, source, destination, substitutions) => {
+        const name = substitutions.extensionFileName
+        host.write(
+          `${destination}/${name}/${name}.resolver.ts`,
+          `export class ${substitutions.extensionClassName}Resolver {}`,
+        )
+        host.write(
+          `${destination}/${name}/${name}.module.ts`,
+          `export class ${substitutions.extensionClassName}Module {}`,
+        )
+      }) as any,
+      getDMMF: vi.fn().mockResolvedValue(dmmf),
+      getNpmScope: vi.fn(() => 'test-scope'),
+      getPrismaSchemaPath: vi.fn(() => 'prisma/schema.prisma'),
+      joinPathFragments: vi.fn((...parts: string[]) => parts.join('/')),
+      names: vi.fn((value: string) => {
+        const fileName = value
+          .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+          .replace(/\s+/g, '-')
+          .toLowerCase()
+        return {
+          name: value,
+          className: value.replace(/(^|-|\s)(\w)/g, (_match, _prefix, letter) => letter.toUpperCase()),
+          propertyName: value,
+          constantName: value.toUpperCase(),
+          fileName,
+        }
+      }) as any,
+      readPrismaSchema: vi.fn(() => 'model User { id String @id }'),
+    }
+  })
+
+  it('scaffolds an additive resolver module for a Prisma model', async () => {
+    await modelExtensionGeneratorLogic(tree, { model: 'user' }, dependencies)
+
+    expect(tree.exists('libs/api/custom/src/lib/default/user/user.resolver.ts')).toBe(true)
+    expect(tree.exists('libs/api/custom/src/lib/default/user/user.module.ts')).toBe(true)
+    expect(tree.read('libs/api/custom/src/lib/default/index.ts', 'utf-8')).toBe(
+      "export * from './user/user.module'\n",
+    )
+    expect(dependencies.generateFiles).toHaveBeenCalledWith(
+      tree,
+      expect.stringContaining('/model-extension/files'),
+      'libs/api/custom/src/lib/default',
+      expect.objectContaining({
+        extensionClassName: 'User',
+        extensionFileName: 'user',
+        modelName: 'User',
+        npmScope: 'test-scope',
+      }),
+    )
+    expect(dependencies.addToModules).toHaveBeenCalledWith({
+      tree,
+      modulePath: 'apps/api/src/app.module.ts',
+      moduleArrayName: 'defaultModules',
+      moduleToAdd: 'UserModule',
+      importPath: '@test-scope/api/custom',
+    })
+  })
+
+  it('allows a separate artifact name while preserving the target GraphQL model', async () => {
+    await modelExtensionGeneratorLogic(
+      tree,
+      { model: 'User', name: 'UserProfile' },
+      dependencies,
+    )
+
+    expect(dependencies.generateFiles).toHaveBeenCalledWith(
+      tree,
+      expect.any(String),
+      'libs/api/custom/src/lib/default',
+      expect.objectContaining({ extensionClassName: 'UserProfile', modelName: 'User' }),
+    )
+    expect(dependencies.addToModules).toHaveBeenCalledWith(
+      expect.objectContaining({ moduleToAdd: 'UserProfileModule' }),
+    )
+  })
+
+  it('refuses to overwrite an existing extension folder', async () => {
+    tree.write('libs/api/custom/src/lib/default/user/user.resolver.ts', 'preserve me')
+
+    await expect(
+      modelExtensionGeneratorLogic(tree, { model: 'User' }, dependencies),
+    ).rejects.toThrow('Model extension folder already exists')
+    expect(tree.read('libs/api/custom/src/lib/default/user/user.resolver.ts', 'utf-8')).toBe(
+      'preserve me',
+    )
+  })
+
+  it('reports unknown models with the available model names', async () => {
+    await expect(
+      modelExtensionGeneratorLogic(tree, { model: 'Account' }, dependencies),
+    ).rejects.toThrow('Available models: PasswordHistory, User')
+  })
+
+  it('rejects @skipCrud models because their GraphQL model is not generated', async () => {
+    await expect(
+      modelExtensionGeneratorLogic(tree, { model: 'PasswordHistory' }, dependencies),
+    ).rejects.toThrow('uses @skipCrud')
+  })
+})

--- a/generators/src/model-extension/generator.ts
+++ b/generators/src/model-extension/generator.ts
@@ -1,0 +1,119 @@
+import { formatFiles, generateFiles, joinPathFragments, names, Tree } from '@nx/devkit'
+import { getDMMF } from '@prisma/internals'
+import { getNpmScope } from '@nx/js/src/utils/package-json/get-npm-scope'
+import {
+  addToModules,
+  getPrismaSchemaPath,
+  getSkippedModelNames,
+  readPrismaSchema,
+} from '../lib/engine'
+import { ModelExtensionGeneratorSchema } from './schema'
+
+const defaultDependencies = {
+  addToModules,
+  formatFiles,
+  generateFiles,
+  getDMMF,
+  getNpmScope,
+  getPrismaSchemaPath,
+  joinPathFragments,
+  names,
+  readPrismaSchema,
+}
+
+export type ModelExtensionGeneratorDependencies = typeof defaultDependencies
+
+interface PrismaModel {
+  name: string
+  documentation?: string
+}
+
+function resolveModel(models: readonly PrismaModel[], requestedName: string): PrismaModel {
+  const exactMatch = models.find(model => model.name === requestedName)
+  if (exactMatch) return exactMatch
+
+  const normalizedName = requestedName.toLowerCase()
+  const caseInsensitiveMatch = models.find(model => model.name.toLowerCase() === normalizedName)
+  if (caseInsensitiveMatch) return caseInsensitiveMatch
+
+  const availableModels = models.map(model => model.name).sort((left, right) => left.localeCompare(right))
+  throw new Error(
+    `Prisma model "${requestedName}" was not found. Available models: ${availableModels.join(', ') || '(none)'}`,
+  )
+}
+
+function addBarrelExport(tree: Tree, indexPath: string, exportLine: string): void {
+  const existingLines = tree.exists(indexPath)
+    ? (tree.read(indexPath, 'utf-8') ?? '')
+        .split('\n')
+        .map(line => line.trim())
+        .filter(Boolean)
+    : []
+  const lines = [...new Set([...existingLines, exportLine])].sort((left, right) => left.localeCompare(right))
+  tree.write(indexPath, `${lines.join('\n')}\n`)
+}
+
+export async function modelExtensionGeneratorLogic(
+  tree: Tree,
+  options: ModelExtensionGeneratorSchema,
+  dependencies: ModelExtensionGeneratorDependencies = defaultDependencies,
+): Promise<void> {
+  const prismaPath = dependencies.getPrismaSchemaPath(tree)
+  const prismaSchema = dependencies.readPrismaSchema(tree, prismaPath)
+  if (!prismaSchema) throw new Error(`No Prisma schema found at ${prismaPath}`)
+
+  const dmmf = await dependencies.getDMMF({ datamodel: prismaSchema })
+  const model = resolveModel(dmmf.datamodel.models, options.model)
+  const skippedModelNames = getSkippedModelNames(dmmf.datamodel.models)
+  if (skippedModelNames.has(model.name)) {
+    throw new Error(
+      `Prisma model "${model.name}" uses @skipCrud and has no generated GraphQL model to target. ` +
+        'Create an explicit plugin maintenance path instead.',
+    )
+  }
+
+  const extensionNames = dependencies.names(options.name ?? model.name)
+  const customLibraryRoot = 'libs/api/custom'
+  const defaultRoot = dependencies.joinPathFragments(customLibraryRoot, 'src/lib/default')
+  const extensionRoot = dependencies.joinPathFragments(defaultRoot, extensionNames.fileName)
+  const defaultIndexPath = dependencies.joinPathFragments(defaultRoot, 'index.ts')
+  const appModulePath = 'apps/api/src/app.module.ts'
+
+  if (!tree.exists(defaultIndexPath) || !tree.exists(appModulePath)) {
+    throw new Error(
+      'The custom API library is not initialized. Run @nestledjs/generators:custom before scaffolding an extension.',
+    )
+  }
+  if (tree.exists(extensionRoot) && tree.children(extensionRoot).length > 0) {
+    throw new Error(`Model extension folder already exists: ${extensionRoot}`)
+  }
+
+  dependencies.generateFiles(tree, dependencies.joinPathFragments(__dirname, 'files'), defaultRoot, {
+    extensionClassName: extensionNames.className,
+    extensionFileName: extensionNames.fileName,
+    modelName: model.name,
+    npmScope: dependencies.getNpmScope(tree),
+    template: '',
+  })
+
+  addBarrelExport(
+    tree,
+    defaultIndexPath,
+    `export * from './${extensionNames.fileName}/${extensionNames.fileName}.module'`,
+  )
+  dependencies.addToModules({
+    tree,
+    modulePath: appModulePath,
+    moduleArrayName: 'defaultModules',
+    moduleToAdd: `${extensionNames.className}Module`,
+    importPath: `@${dependencies.getNpmScope(tree)}/api/custom`,
+  })
+
+  await dependencies.formatFiles(tree)
+}
+
+export async function modelExtensionGenerator(tree: Tree, options: ModelExtensionGeneratorSchema) {
+  await modelExtensionGeneratorLogic(tree, options)
+}
+
+export default modelExtensionGenerator

--- a/generators/src/model-extension/schema.d.ts
+++ b/generators/src/model-extension/schema.d.ts
@@ -1,0 +1,4 @@
+export interface ModelExtensionGeneratorSchema {
+  model: string
+  name?: string
+}

--- a/generators/src/model-extension/schema.json
+++ b/generators/src/model-extension/schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "$id": "ModelExtension",
+  "title": "Model API Extension",
+  "type": "object",
+  "properties": {
+    "model": {
+      "type": "string",
+      "description": "Prisma model to target",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "Which Prisma model should the extension target?"
+    },
+    "name": {
+      "type": "string",
+      "description": "Optional artifact name; defaults to the Prisma model name"
+    }
+  },
+  "required": ["model"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

Prepares **`@nestledjs/generators` 2.0.0** — a breaking change to how generated resolvers are registered, plus a new generator.

- **`crud`: register generated resolvers through one canonical feature module.** The populated module is now written to `api-generated-crud-feature.module.ts`, imported into the API's `coreModules`, and exported from the generated feature barrel. The legacy `api-admin-crud-feature.module.ts` is deleted during generation. This removes the duplicate `ApiGeneratedCrudFeatureModule` class created by the old scaffold-plus-alternate-file flow.
- **`custom`: stop generating an inheriting resolver/service/module shell for every Prisma model.** Generated CRUD no longer depends on custom resolver inheritance for registration. The generator now maintains only the custom API library and its stable barrels, preserving every explicit extension already present.
- **New `model-extension` generator.** `nx g @nestledjs/generators:model-extension <Model>` creates an additive model-specific resolver module on demand. The artifact name defaults to the Prisma model; `--name` supports a more specific feature name without changing the target GraphQL type.

## Migration (consumers)

This changes resolver registration and requires a coordinated consumer update:

1. Upgrade the template wiring so `ApiGeneratedCrudFeatureModule` is in `coreModules`.
2. Remove `extends Generated<Model>Resolver`, generated resolver imports, generated data-access constructor injection, and `super(...)` from custom resolvers.
3. Delete empty legacy default-model shells; preserve modules that contain real custom behavior.
4. Run `pnpm db-update`, then verify the GraphQL root fields and authorization guards.

⚠️ Do not import the generated feature module while leaving inheriting custom resolvers registered: Nest scans inherited resolver methods, so that temporarily registers duplicate callbacks for every generated GraphQL field.

## Review focus

- `generators/src/custom/generator.ts` — ~250 lines removed; confirm no explicit consumer extension is dropped.
- `generators/src/crud/generator.ts` — deletion of the legacy module file during generation.
- `generators/src/model-extension/` — new generator, schema, and templates.

## Verification

- `nx test generators` — 160/160 passing
- `nx lint generators` — clean

The version bump, tag, and publish happen after merge via `nx release version major --projects=generators` on `develop`; `package.json` is still at `1.1.6` in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)