### PR TITLE
fix(generators): restore bounded filter composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,16 @@ query {
 }
 ```
 
-Operators are chosen per scalar type — strings get `equals`/`in`/`contains`/`startsWith`/`endsWith`, numbers and dates get `equals`/`in`/`lt`/`lte`/`gt`/`gte`, booleans and enums get `equals`/`in`. List relations get `some`/`every`/`none` over the related model's filter input, and to-one relations nest that input directly. `@graphqlOmit` columns are absent from the filter inputs entirely, and `Json` columns and scalar lists are not filterable.
+Operators are chosen per scalar type — all scalar filters get `equals`/`in`/`not`, strings also get `contains`/`startsWith`/`endsWith`, and numbers and dates also get `lt`/`lte`/`gt`/`gte`. List relations get `some`/`every`/`none` over the related model's filter input. To-one relations get `is`/`isNot`, including `is: null`, while retaining the direct nested shorthand emitted by 1.1.5. `@graphqlOmit` columns are absent from the filter inputs entirely, and `Json` columns and scalar lists are not filterable.
+
+Generated data access normalizes the direct to-one shorthand into Prisma's `is` form. If a caller
+supplies both styles, direct predicates are combined with a non-null `is` predicate using `AND`;
+combining direct predicates with `is: null` is contradictory and returns `BadRequestException`
+before Prisma executes.
 
 Every model's list input overrides `filters`, including models with no filterable column at all — those map to a shared `UnfilterableInput` placeholder. An explicit override is the only thing that removes an inherited field from a code-first schema, so a model left without one would keep exposing the untyped blob.
 
-Relation nesting is bounded: each level emits its own set of input types (`UserFilterInput` → `PostFilterInput2` → `UserFilterInput3`), and the deepest level carries scalar fields only, which terminates the recursion. The default is 3 levels; pass `--filterDepth` to the `crud` generator to change it. `AND`/`OR`/`NOT` are deliberately not emitted, since they are self-referencing and would reintroduce unbounded nesting.
+All nesting is bounded: each level emits its own set of input types, and a relation or logical operator points only at the next level (`UserFilterInput` → `PostFilterInput2` or `UserFilterInput2` → `UserFilterInput3`). The deepest level carries scalar fields only, which terminates recursion. The default is 3 levels; pass `--filterDepth` to the `crud` generator to change it. `AND`/`OR`/`NOT` therefore remain useful without becoming self-referencing or allowing unbounded input depth.
 
 These filters exist for the admin data browser. Do not accept generated list/filter inputs from a
 user-facing resolver; define only the specific filter fields that workflow supports.

--- a/generators/CHANGELOG.md
+++ b/generators/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to `@nestledjs/generators` are documented here. This project
 uses independent semantic versioning; the current version is resolved from the npm
 registry (see `nx.json` → `release`).
 
+## 3.0.1
+
+### Fixed
+
+- **`crud`: restore bounded Prisma filter composition.** Typed model filters now emit
+  `AND`/`OR`/`NOT`, with every logical operator pointing at the next generated depth instead of
+  self-referencing. Logical composition and relation traversal therefore share the existing
+  `filterDepth` budget, and the deepest input remains scalars-only. Scalar filters also expose
+  `not`, and to-one relation filters expose `is`/`isNot` (including `is: null`) while preserving
+  the direct nested shape generated since 1.1.5. Generated data access normalizes that compatibility
+  shape into Prisma's relation-filter form; mixed direct and non-null `is` predicates are combined
+  with `AND`, while the contradictory `is: null` plus direct-predicate shape fails before Prisma.
+- **`crud`: compile legacy filter overrides with ES2022 class-field semantics.** Generated
+  `List<Model>Input.filters` properties now have an explicit `undefined` initializer. This avoids
+  TS2612 when a consumer regenerates before removing the old `filters` declaration from
+  `CorePagingInput` and has `useDefineForClassFields` enabled. Consumers should still remove the
+  opaque base field; changing their workspace-wide TypeScript setting is not required.
+
+### Migration
+
+Regenerate CRUD and the GraphQL SDK. Audit preserved application documents and runtime-built
+variables that use `AND`/`OR`/`NOT`, scalar `not`, or relation `is`/`isNot`; generator 1.1.5 through
+3.0.0 did not expose those fields, so TypeScript success alone did not prove that GraphQL would
+accept them at runtime.
+
 ## 3.0.0
 
 ### Changed
@@ -277,8 +302,9 @@ generated GraphQL field.
 
 ### Changed
 
-- **Consolidation.** The former `@nestledjs/api | shared | utils | config | plugins |
-  web | helpers` packages were collapsed into this single package containing the
+- **Consolidation.** The former
+  `@nestledjs/api | shared | utils | config | plugins | web | helpers` packages were collapsed into
+  this single package containing the
   `crud`, `custom`, `sdk`, and `models` generators, with the shared engine inlined
   under `src/lib/engine/`. The old packages were deprecated on npm (not unpublished —
   existing installs keep working). See the repository `README.md` → "Consolidation".

--- a/generators/src/crud/files/data-access/src/lib/api-crud-data-access.service.ts__tmpl__
+++ b/generators/src/crud/files/data-access/src/lib/api-crud-data-access.service.ts__tmpl__
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common'
+import { BadRequestException, Injectable } from '@nestjs/common'
 import { ApiCoreDataAccessService } from '@<%= npmScope %>/api/core/data-access'
 import graphqlFields from 'graphql-fields'
 import type { GraphQLResolveInfo } from 'graphql'
@@ -210,7 +210,115 @@ function generateRelationHandling(model, operation) {
 
   return code;
 }
+
+const generatedModelNames = new Set(models.map(model => model.modelName));
+const filterRelations = Object.fromEntries(models.map(model => [
+  model.modelName,
+  Object.fromEntries(model.fields
+    .filter(field => field.relationName && generatedModelNames.has(field.type))
+    .map(field => [field.name, { targetModel: field.type, isList: Boolean(field.isList) }]))
+]));
 %>
+
+interface FilterRelation {
+  targetModel: string
+  isList: boolean
+}
+
+type FilterObject = Record<string, unknown>
+
+const FILTER_RELATIONS = <%- JSON.stringify(filterRelations, null, 2) %> as Record<
+  string,
+  Record<string, FilterRelation>
+>
+
+const LOGICAL_FILTER_OPERATORS = ['AND', 'OR', 'NOT'] as const
+const LIST_RELATION_OPERATORS = ['some', 'every', 'none'] as const
+
+function isFilterObject(value: unknown): value is FilterObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeLogicalFilters(modelName: string, filter: FilterObject, normalized: FilterObject): void {
+  for (const operator of LOGICAL_FILTER_OPERATORS) {
+    const operands = filter[operator]
+    if (Array.isArray(operands)) {
+      normalized[operator] = operands.map(operand => normalizeModelFilter(modelName, operand))
+    }
+  }
+}
+
+function normalizeListRelationFilter(targetModel: string, filter: FilterObject): FilterObject {
+  const normalized = { ...filter }
+  for (const operator of LIST_RELATION_OPERATORS) {
+    if (filter[operator] !== undefined) {
+      normalized[operator] = normalizeModelFilter(targetModel, filter[operator])
+    }
+  }
+  return normalized
+}
+
+function directRelationEntries(filter: FilterObject): [string, unknown][] {
+  return Object.entries(filter).filter(
+    ([name, value]) => name !== 'is' && name !== 'isNot' && value !== undefined,
+  )
+}
+
+function normalizeNullableModelFilter(modelName: string, value: unknown): unknown {
+  return value === null ? null : normalizeModelFilter(modelName, value)
+}
+
+function normalizeToOneRelationFilter(targetModel: string, filter: FilterObject): FilterObject {
+  const hasIs = filter.is !== undefined
+  const hasIsNot = filter.isNot !== undefined
+  const directEntries = directRelationEntries(filter)
+  const directFilter = Object.fromEntries(directEntries)
+
+  if (!hasIs && !hasIsNot) {
+    return directEntries.length === 0 ? {} : { is: normalizeModelFilter(targetModel, directFilter) }
+  }
+
+  const normalized: FilterObject = {}
+  if (hasIs) normalized.is = normalizeNullableModelFilter(targetModel, filter.is)
+  if (hasIsNot) normalized.isNot = normalizeNullableModelFilter(targetModel, filter.isNot)
+  if (directEntries.length === 0) return normalized
+
+  if (filter.is === null) {
+    throw new BadRequestException('A to-one relation filter cannot combine is: null with direct field predicates')
+  }
+
+  const normalizedDirect = normalizeModelFilter(targetModel, directFilter)
+  normalized.is = hasIs ? { AND: [normalized.is, normalizedDirect] } : normalizedDirect
+  return normalized
+}
+
+function normalizeRelationFilters(modelName: string, filter: FilterObject, normalized: FilterObject): void {
+  for (const [fieldName, relation] of Object.entries(FILTER_RELATIONS[modelName] ?? {})) {
+    const relationFilter = filter[fieldName]
+    if (!isFilterObject(relationFilter)) continue
+
+    normalized[fieldName] = relation.isList
+      ? normalizeListRelationFilter(relation.targetModel, relationFilter)
+      : normalizeToOneRelationFilter(relation.targetModel, relationFilter)
+  }
+}
+
+function normalizeModelFilter(modelName: string, value: unknown): unknown {
+  if (!isFilterObject(value)) return value
+
+  const normalized = { ...value }
+  normalizeLogicalFilters(modelName, value, normalized)
+  normalizeRelationFilters(modelName, value, normalized)
+  return normalized
+}
+
+function normalizeListInputFilters<T extends { filters?: unknown }>(
+  modelName: string,
+  input?: T,
+): T | undefined {
+  if (!input || input.filters === undefined) return input
+  return { ...input, filters: normalizeModelFilter(modelName, input.filters) } as T
+}
 
 @Injectable()
 export class ApiCrudDataAccessService {
@@ -228,14 +336,16 @@ export class ApiCrudDataAccessService {
 
   async <%= (model.pluralModelName === model.modelName ? model.pluralModelName + 'List' : model.pluralModelName).charAt(0).toLowerCase() + (model.pluralModelName === model.modelName ? model.pluralModelName + 'List' : model.pluralModelName).slice(1) %>(info: GraphQLResolveInfo, input?: dto.List<%= model.modelName %>Input) {
     return this.data['<%= model.modelPropertyName %>'].findMany({
-      ...this.data.filter(input),
+      ...this.data.filter(normalizeListInputFilters('<%= model.modelName %>', input)),
       select: buildAdminSelect(info),
     });
   }
 
   async <%= (model.pluralModelName === model.modelName ? model.pluralModelName + 'List' : model.pluralModelName).charAt(0).toLowerCase() + (model.pluralModelName === model.modelName ? model.pluralModelName + 'List' : model.pluralModelName).slice(1) %>Count(input?: dto.List<%= model.modelName %>Input) {
     const total = await this.data['<%= model.modelPropertyName %>'].count()
-    const { where, take = 10, skip = 0 } = this.data.filter(input)
+    const { where, take = 10, skip = 0 } = this.data.filter(
+      normalizeListInputFilters('<%= model.modelName %>', input),
+    )
     const filteredTotal = await this.data['<%= model.modelPropertyName %>'].count({ where })
     const page = Math.floor(skip / take)
     const pages = take > 0 ? Math.ceil(filteredTotal / take) : 0

--- a/generators/src/crud/files/data-access/src/lib/dto/index.ts__tmpl__
+++ b/generators/src/crud/files/data-access/src/lib/dto/index.ts__tmpl__
@@ -194,8 +194,11 @@ export class List<%= model.modelName %>Input extends CorePagingInput {
     CorePagingInput's untyped blob. Models with no filterable column map to UnfilterableInput. %>
 <% const filterInputName = locals.filterInputNames && locals.filterInputNames[model.modelName]; %>
 <% if (filterInputName) { %>
+<%# The initializer is intentional. With target >= ES2022, useDefineForClassFields defaults to true
+    and TypeScript reports TS2612 when this transitional override has no initializer. It remains
+    harmless after consumers remove the legacy base filters field. %>
   @Field(() => <%= filterInputName %>, { nullable: true })
-  filters?: <%= filterInputName %>
+  filters?: <%= filterInputName %> = undefined
 <% } %>
 <% for (const field of allFields) { %>
   <%

--- a/generators/src/crud/filter-inputs.spec.ts
+++ b/generators/src/crud/filter-inputs.spec.ts
@@ -63,7 +63,7 @@ describe('generateFilterInputs', () => {
       const { source } = generateFilterInputs([model('User', [field('email', 'String')])])
 
       expect(source).toContain('export class StringFilterInput')
-      for (const op of ['equals', 'in', 'contains', 'startsWith', 'endsWith']) {
+      for (const op of ['equals', 'in', 'not', 'contains', 'startsWith', 'endsWith']) {
         expect(source).toContain(`${op}?:`)
       }
       // Ordering comparisons are meaningless for strings and would widen the oracle surface.
@@ -83,7 +83,7 @@ describe('generateFilterInputs', () => {
       expect(source).not.toContain('startsWith?:')
     })
 
-    it('gives boolean and enum fields equality only', () => {
+    it('gives boolean and enum fields equality and negation operators only', () => {
       const { source } = generateFilterInputs([
         model('User', [field('isActive', 'Boolean'), field('role', 'Role', { kind: 'enum' })]),
       ])
@@ -92,6 +92,8 @@ describe('generateFilterInputs', () => {
       expect(source).toContain('export class RoleFilterInput')
       expect(source).toContain('@Field(() => Role, { nullable: true })\n  equals?: Role')
       expect(source).toContain('@Field(() => [Role], { nullable: true })\n  in?: Role[]')
+      expect(source).toContain('@Field(() => Boolean, { nullable: true })\n  not?: boolean')
+      expect(source).toContain('@Field(() => Role, { nullable: true })\n  not?: Role')
       expect(source).not.toContain('gt?:')
       expect(source).not.toContain('contains?:')
     })
@@ -121,12 +123,18 @@ describe('generateFilterInputs', () => {
       expect(source).not.toContain('tags?:')
     })
 
-    it('never emits AND/OR/NOT, which would allow unbounded nesting', () => {
+    it('emits AND/OR/NOT against the next depth instead of self-referencing', () => {
       const { source } = generateFilterInputs(buildModels())
+      const level1 = classBody(source, 'UserFilterInput')
+      const level2 = classBody(source, 'UserFilterInput2')
+      const level3 = classBody(source, 'UserFilterInput3')
 
-      expect(source).not.toContain('AND')
-      expect(source).not.toContain('OR?:')
-      expect(source).not.toContain('NOT')
+      for (const op of ['AND', 'OR', 'NOT']) {
+        expect(level1).toContain(`${op}?: UserFilterInput2[]`)
+        expect(level2).toContain(`${op}?: UserFilterInput3[]`)
+        expect(level3).not.toContain(`${op}?:`)
+      }
+      expect(level1).not.toContain('AND?: UserFilterInput[]')
     })
   })
 
@@ -153,10 +161,14 @@ describe('generateFilterInputs', () => {
       }
     })
 
-    it('references the related filter input directly for to-one relations', () => {
+    it('supports is/isNot and the existing direct shorthand for to-one relations', () => {
       const { source } = generateFilterInputs(buildModels())
+      const wrapper = classBody(source, 'ProfileRelationFilterInput')
 
-      expect(source).toContain('profile?: ProfileFilterInput2')
+      expect(source).toContain('profile?: ProfileRelationFilterInput')
+      expect(wrapper).toContain('is?: ProfileFilterInput2 | null')
+      expect(wrapper).toContain('isNot?: ProfileFilterInput2 | null')
+      expect(wrapper).toContain('bio?: StringFilterInput')
       expect(source).not.toContain('ProfileListRelationFilterInput')
     })
 
@@ -180,6 +192,9 @@ describe('generateFilterInputs', () => {
       expect(level3).toContain('email?: StringFilterInput')
       expect(level3).not.toContain('posts?:')
       expect(level3).not.toContain('profile?:')
+      expect(level3).not.toContain('AND?:')
+      expect(level3).not.toContain('OR?:')
+      expect(level3).not.toContain('NOT?:')
       expect(source).not.toContain('FilterInput4')
     })
 
@@ -196,6 +211,9 @@ describe('generateFilterInputs', () => {
       expect(source).toContain('export class UserFilterInput')
       expect(source).not.toContain('FilterInput2')
       expect(source).not.toContain('ListRelationFilterInput')
+      expect(source).not.toContain('AND?:')
+      expect(source).not.toContain('OR?:')
+      expect(source).not.toContain('NOT?:')
       expect(source).toContain('email?: StringFilterInput')
     })
 
@@ -332,7 +350,7 @@ describe('dto template rendering', () => {
     const dto = renderDto(buildModels())
 
     expect(dto).toContain('export class ListUserInput extends CorePagingInput {')
-    expect(dto).toContain('@Field(() => UserFilterInput, { nullable: true })\n  filters?: UserFilterInput')
+    expect(dto).toContain('@Field(() => UserFilterInput, { nullable: true })\n  filters?: UserFilterInput = undefined')
     // The blob type must not reappear anywhere in the generated DTOs.
     expect(dto).not.toContain('GraphQLJSONObject')
   })
@@ -362,8 +380,16 @@ describe('dto template rendering', () => {
 
     // Without an explicit override this model would keep inheriting CorePagingInput's blob.
     const unfilterable = renderDto([model('Blob', [field('payload', 'Json')])])
-    expect(unfilterable).toContain('@Field(() => UnfilterableInput, { nullable: true })\n  filters?: UnfilterableInput')
+    expect(unfilterable).toContain(
+      '@Field(() => UnfilterableInput, { nullable: true })\n  filters?: UnfilterableInput = undefined',
+    )
     expect(unfilterable).toContain('export class UnfilterableInput')
+  })
+
+  it('initializes the legacy filters override for ES2022 class-field semantics', () => {
+    const dto = renderDto(buildModels())
+
+    expect(dto).toContain('filters?: UserFilterInput = undefined')
   })
 
   it('still renders for callers that do not pass the filter variables', () => {
@@ -417,5 +443,14 @@ describe('admin data-access template rendering', () => {
     expect(service).not.toContain('export function buildAdminSelect')
     expect(service).not.toContain('/api/core/helpers')
     expect(index).not.toContain('buildAdminSelect')
+  })
+
+  it('normalizes compatible to-one filter shapes before passing them to Prisma', () => {
+    const { service } = renderDataAccess()
+
+    expect(service).toContain('"profile": {\n      "targetModel": "Profile",\n      "isList": false')
+    expect(service).toContain("normalizeListInputFilters('User', input)")
+    expect(service).toContain('normalized.is = hasIs')
+    expect(service).toContain("throw new BadRequestException('A to-one relation filter cannot combine is: null")
   })
 })

--- a/generators/src/crud/filter-inputs.ts
+++ b/generators/src/crud/filter-inputs.ts
@@ -16,18 +16,22 @@ import { ModelField, ModelType } from '../lib/engine'
  * generator strips them from `model.fields` before we see them — so an omitted column is
  * unfilterable by construction rather than by a second exclusion list that could drift.
  *
- * Operator and field names deliberately mirror Prisma's own filter grammar, so the emitted object
- * remains a valid Prisma `where` subset and consuming template code can keep merging it directly.
+ * Operator and field names deliberately mirror Prisma's own filter grammar. The generated data
+ * access service normalizes the compatibility shape for to-one relations into Prisma's relation
+ * filter form before merging it into `where`; every other emitted object is already a direct
+ * Prisma subset.
  *
- * Two deliberate omissions:
- * - `AND`/`OR`/`NOT` are not emitted. They are self-referencing, so they would reintroduce
- *   unbounded nesting depth that the depth cap below exists to prevent.
- * - Scalar list fields (`String[]`) are not filterable. Prisma models those with
+ * Logical operators and relation traversal share one depth budget. Each level points only at the
+ * next generated level, so callers can compose useful filters without regaining an unbounded,
+ * self-referencing input type.
+ *
+ * One deliberate omission remains: scalar list fields (`String[]`) are not filterable. Prisma
+ * models those with
  *   `has`/`hasEvery`/`hasSome` rather than the operators here, and nothing downstream filters on
  *   them today.
  */
 
-/** Relation nesting levels to emit. Level `maxDepth` carries scalars only, which terminates recursion. */
+/** Filter nesting levels to emit. Level `maxDepth` carries scalars only, which terminates recursion. */
 export const DEFAULT_FILTER_DEPTH = 3
 
 const COMPARABLE_OPERATORS = ['lt', 'lte', 'gt', 'gte'] as const
@@ -147,6 +151,10 @@ function listRelationFilterInputName(modelName: string, depth: number): string {
   return `${modelName}ListRelationFilterInput${depthSuffix(depth)}`
 }
 
+function toOneRelationFilterInputName(modelName: string, depth: number): string {
+  return `${modelName}RelationFilterInput${depthSuffix(depth)}`
+}
+
 function renderField(gqlType: string, name: string, tsType: string): string {
   return `  @Field(() => ${gqlType}, { nullable: true })\n  ${name}?: ${tsType}\n`
 }
@@ -155,6 +163,7 @@ function renderScalarFilterClass(def: ScalarFilterDef): string {
   const fields = [
     renderField(def.gqlType, 'equals', def.tsType),
     renderField(`[${def.gqlType}]`, 'in', `${def.tsType}[]`),
+    renderField(def.gqlType, 'not', def.tsType),
     ...def.extraOperators.map((op) => renderField(def.gqlType, op, def.tsType)),
   ]
   return `@InputType()\nexport class ${def.className} {\n${fields.join('\n')}}\n`
@@ -163,6 +172,24 @@ function renderScalarFilterClass(def: ScalarFilterDef): string {
 function renderListRelationFilterClass(className: string, targetType: string): string {
   const fields = ['some', 'every', 'none'].map((op) => renderField(targetType, op, targetType))
   return `@InputType()\nexport class ${className} {\n${fields.join('\n')}}\n`
+}
+
+interface RenderedFilterField {
+  name: string
+  source: string
+}
+
+function renderToOneRelationFilterClass(
+  className: string,
+  targetType: string,
+  directFields: readonly RenderedFilterField[],
+): string {
+  const relationOperators = ['is', 'isNot'].map((name) => renderField(targetType, name, `${targetType} | null`))
+  const compatibleDirectFields = directFields
+    .filter((field) => field.name !== 'is' && field.name !== 'isNot')
+    .map((field) => field.source)
+
+  return `@InputType()\nexport class ${className} {\n${[...relationOperators, ...compatibleDirectFields].join('\n')}}\n`
 }
 
 /**
@@ -177,8 +204,12 @@ function renderListRelationFilterClass(className: string, targetType: string): s
  */
 const INDEX_SIGNATURE_SHIM = '  [key: string]: unknown\n'
 
-function renderModelFilterClass(className: string, fields: string[], includeShim: boolean): string {
-  const body = (includeShim ? INDEX_SIGNATURE_SHIM + '\n' : '') + fields.join('\n')
+function renderModelFilterClass(
+  className: string,
+  fields: readonly RenderedFilterField[],
+  includeShim: boolean,
+): string {
+  const body = (includeShim ? INDEX_SIGNATURE_SHIM + '\n' : '') + fields.map((field) => field.source).join('\n')
   return `@InputType()\nexport class ${className} {\n${body}}\n`
 }
 
@@ -198,22 +229,25 @@ interface ScanContext {
   modelNames: Set<string>
   /** Operator inputs actually referenced, keyed by class name so each is emitted once. */
   neededScalarFilters: Map<string, ScalarFilterDef>
-  /** Rendered field lines per model, per depth. Populated deepest level first. */
-  fieldsByDepth: Map<number, Map<string, string[]>>
+  /** Rendered fields per model, per depth. Populated deepest level first. */
+  fieldsByDepth: Map<number, Map<string, RenderedFilterField[]>>
   /** Related models needing a list-relation wrapper at each depth. */
-  wrappersByDepth: Map<number, Set<string>>
+  listWrappersByDepth: Map<number, Set<string>>
+  /** Related models needing an is/isNot wrapper at each depth. */
+  toOneWrappersByDepth: Map<number, Set<string>>
 }
 
 /**
  * A relation field is only emitted when its target actually has a filter input one level down.
- * `wrappers` collects the related models that need a list-relation wrapper at this depth.
+ * The wrapper sets collect related models that need relation operator inputs at this depth.
  */
 function relationFieldLine(
   field: ModelField,
   depth: number,
   ctx: ScanContext,
-  wrappers: Set<string>,
-): string | null {
+  listWrappers: Set<string>,
+  toOneWrappers: Set<string>,
+): RenderedFilterField | null {
   // The deepest level is scalars-only — that is what terminates the recursion.
   if (depth === ctx.maxDepth) return null
   if (!ctx.modelNames.has(field.type)) return null
@@ -221,15 +255,16 @@ function relationFieldLine(
 
   if (field.isList) {
     const wrapper = listRelationFilterInputName(field.type, depth)
-    wrappers.add(field.type)
-    return renderField(wrapper, field.name, wrapper)
+    listWrappers.add(field.type)
+    return { name: field.name, source: renderField(wrapper, field.name, wrapper) }
   }
 
-  const target = modelFilterInputName(field.type, depth + 1)
-  return renderField(target, field.name, target)
+  const wrapper = toOneRelationFilterInputName(field.type, depth)
+  toOneWrappers.add(field.type)
+  return { name: field.name, source: renderField(wrapper, field.name, wrapper) }
 }
 
-function scalarFieldLine(field: ModelField, ctx: ScanContext): string | null {
+function scalarFieldLine(field: ModelField, ctx: ScanContext): RenderedFilterField | null {
   // Scalar lists use a different Prisma grammar (has/hasEvery/hasSome); not modelled.
   if (field.isList) return null
 
@@ -237,36 +272,55 @@ function scalarFieldLine(field: ModelField, ctx: ScanContext): string | null {
   if (!def) return null
 
   ctx.neededScalarFilters.set(def.className, def)
-  return renderField(def.className, field.name, def.className)
+  return { name: field.name, source: renderField(def.className, field.name, def.className) }
 }
 
-function fieldLine(field: ModelField, depth: number, ctx: ScanContext, wrappers: Set<string>): string | null {
+function fieldLine(
+  field: ModelField,
+  depth: number,
+  ctx: ScanContext,
+  listWrappers: Set<string>,
+  toOneWrappers: Set<string>,
+): RenderedFilterField | null {
   return isRelationField(field)
-    ? relationFieldLine(field, depth, ctx, wrappers)
+    ? relationFieldLine(field, depth, ctx, listWrappers, toOneWrappers)
     : scalarFieldLine(field, ctx)
+}
+
+function logicalFields(modelName: string, depth: number, ctx: ScanContext): RenderedFilterField[] {
+  if (depth === ctx.maxDepth || !ctx.fieldsByDepth.get(depth + 1)?.has(modelName)) return []
+
+  const target = modelFilterInputName(modelName, depth + 1)
+  return ['AND', 'OR', 'NOT'].map((name) => ({
+    name,
+    source: renderField(`[${target}]`, name, `${target}[]`),
+  }))
 }
 
 /** Records, for one nesting level, which models have filterable content and what it renders to. */
 function scanDepth(models: readonly ModelType[], depth: number, ctx: ScanContext): void {
-  const fieldsForDepth = new Map<string, string[]>()
-  const wrappers = new Set<string>()
+  const fieldsForDepth = new Map<string, RenderedFilterField[]>()
+  const listWrappers = new Set<string>()
+  const toOneWrappers = new Set<string>()
 
   for (const model of models) {
-    const lines = model.fields
-      .map((field) => fieldLine(field, depth, ctx, wrappers))
-      .filter((line): line is string => line !== null)
+    const fields = model.fields
+      .map((field) => fieldLine(field, depth, ctx, listWrappers, toOneWrappers))
+      .filter((field): field is RenderedFilterField => field !== null)
+    fields.push(...logicalFields(model.modelName, depth, ctx))
 
     // An @InputType with no fields is invalid in GraphQL, so a model with nothing filterable
     // simply has no filter input at this depth.
-    if (lines.length > 0) fieldsForDepth.set(model.modelName, lines)
+    if (fields.length > 0) fieldsForDepth.set(model.modelName, fields)
   }
 
   ctx.fieldsByDepth.set(depth, fieldsForDepth)
-  ctx.wrappersByDepth.set(depth, wrappers)
+  ctx.listWrappersByDepth.set(depth, listWrappers)
+  ctx.toOneWrappersByDepth.set(depth, toOneWrappers)
 }
 
 function renderDepth(models: readonly ModelType[], depth: number, ctx: ScanContext): string[] {
-  const wrappers = [...(ctx.wrappersByDepth.get(depth) ?? [])]
+  const listWrappers = [...(ctx.listWrappersByDepth.get(depth) ?? [])]
     .sort((a, b) => a.localeCompare(b))
     .map((target) =>
       renderListRelationFilterClass(
@@ -275,12 +329,24 @@ function renderDepth(models: readonly ModelType[], depth: number, ctx: ScanConte
       ),
     )
 
-  const modelClasses = models
-    .map((model) => ({ model, lines: ctx.fieldsByDepth.get(depth)?.get(model.modelName) }))
-    .filter((entry): entry is { model: ModelType; lines: string[] } => Boolean(entry.lines))
-    .map(({ model, lines }) => renderModelFilterClass(modelFilterInputName(model.modelName, depth), lines, depth === 1))
+  const toOneWrappers = [...(ctx.toOneWrappersByDepth.get(depth) ?? [])]
+    .sort((a, b) => a.localeCompare(b))
+    .map((target) =>
+      renderToOneRelationFilterClass(
+        toOneRelationFilterInputName(target, depth),
+        modelFilterInputName(target, depth + 1),
+        ctx.fieldsByDepth.get(depth + 1)?.get(target) ?? [],
+      ),
+    )
 
-  return [...wrappers, ...modelClasses]
+  const modelClasses = models
+    .map((model) => ({ model, fields: ctx.fieldsByDepth.get(depth)?.get(model.modelName) }))
+    .filter((entry): entry is { model: ModelType; fields: RenderedFilterField[] } => Boolean(entry.fields))
+    .map(({ model, fields }) =>
+      renderModelFilterClass(modelFilterInputName(model.modelName, depth), fields, depth === 1),
+    )
+
+  return [...listWrappers, ...toOneWrappers, ...modelClasses]
 }
 
 function normaliseDepth(maxDepth: number): number {
@@ -290,13 +356,14 @@ function normaliseDepth(maxDepth: number): number {
 /**
  * Builds the filter input classes for the given models.
  *
- * Relation nesting is capped by generating a distinct type per level rather than a single
- * self-referencing type: `UserFilterInput` points at `PostFilterInput2`, which points at
- * `UserFilterInput3`, which carries scalars only. A recursive input type would let a caller nest
- * relation filters arbitrarily deep at query time, which typing alone would not prevent.
+ * Filter nesting is capped by generating a distinct type per level rather than a single
+ * self-referencing type: `UserFilterInput` points at `PostFilterInput2` for a relation, or at
+ * `UserFilterInput2` for a logical operator. Level 3 carries scalars only. A recursive input type
+ * would let a caller nest filters arbitrarily deep at query time, which typing alone would not
+ * prevent.
  *
  * @param models Models to emit filters for, already stripped of `@skipCrud` and `@graphqlOmit`.
- * @param maxDepth Relation nesting levels to emit; values below 1 fall back to the default.
+ * @param maxDepth Filter nesting levels to emit; values below 1 fall back to the default.
  */
 export function generateFilterInputs(
   models: readonly ModelType[],
@@ -308,7 +375,8 @@ export function generateFilterInputs(
     modelNames: new Set(models.map((m) => m.modelName)),
     neededScalarFilters: new Map(),
     fieldsByDepth: new Map(),
-    wrappersByDepth: new Map(),
+    listWrappersByDepth: new Map(),
+    toOneWrappersByDepth: new Map(),
   }
 
   // Walk deepest level first: whether a relation field can be emitted at depth d depends on


### PR DESCRIPTION
## Summary

- emit depth-bounded `AND`/`OR`/`NOT` filter fields
- add scalar `not` and to-one `is`/`isNot`, including `is: null`
- preserve the existing direct to-one filter shorthand
- initialize generated `filters` overrides so ES2022 consumers do not hit TS2612 during a staged migration

## Root cause

The typed-filter security fix removed arbitrary Prisma JSON but omitted legitimate parts of the bounded filter grammar. Runtime-built variables could therefore typecheck and still fail GraphQL validation. The transitional DTO override also lacked an initializer, which ES2022 class-field semantics reject when the legacy base property is still present.

Logical and relation steps now share the existing finite `filterDepth` budget; the deepest generated input remains scalars-only. Consumers do not need to change workspace-wide `useDefineForClassFields`.

## Validation

- `pnpm nx run generators:test --skip-nx-cache`
- `pnpm nx run generators:typecheck --skip-nx-cache`
- `pnpm nx run generators:lint --skip-nx-cache`
- `pnpm nx run generators:build --skip-nx-cache`

All 141 tests pass.