### PR TITLE
fix(generators): support strict filter index access

### DIFF
--- a/generators/CHANGELOG.md
+++ b/generators/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `@nestledjs/generators` are documented here. This project
 uses independent semantic versioning; the current version is resolved from the npm
 registry (see `nx.json` → `release`).
 
+## 3.0.2
+
+### Fixed
+
+- **`crud`: compile relation-filter normalization with strict index-signature access.** Generated
+  data access now uses bracket notation for keys on its generic filter map, so consumers with
+  `noPropertyAccessFromIndexSignature` enabled no longer receive TS4111 errors after regeneration.
+
 ## 3.0.1
 
 ### Fixed

--- a/generators/src/crud/files/data-access/src/lib/api-crud-data-access.service.ts__tmpl__
+++ b/generators/src/crud/files/data-access/src/lib/api-crud-data-access.service.ts__tmpl__
@@ -269,8 +269,8 @@ function normalizeNullableModelFilter(modelName: string, value: unknown): unknow
 }
 
 function normalizeToOneRelationFilter(targetModel: string, filter: FilterObject): FilterObject {
-  const hasIs = filter.is !== undefined
-  const hasIsNot = filter.isNot !== undefined
+  const hasIs = filter['is'] !== undefined
+  const hasIsNot = filter['isNot'] !== undefined
   const directEntries = directRelationEntries(filter)
   const directFilter = Object.fromEntries(directEntries)
 
@@ -279,16 +279,18 @@ function normalizeToOneRelationFilter(targetModel: string, filter: FilterObject)
   }
 
   const normalized: FilterObject = {}
-  if (hasIs) normalized.is = normalizeNullableModelFilter(targetModel, filter.is)
-  if (hasIsNot) normalized.isNot = normalizeNullableModelFilter(targetModel, filter.isNot)
+  if (hasIs) normalized['is'] = normalizeNullableModelFilter(targetModel, filter['is'])
+  if (hasIsNot) normalized['isNot'] = normalizeNullableModelFilter(targetModel, filter['isNot'])
   if (directEntries.length === 0) return normalized
 
-  if (filter.is === null) {
+  if (filter['is'] === null) {
     throw new BadRequestException('A to-one relation filter cannot combine is: null with direct field predicates')
   }
 
   const normalizedDirect = normalizeModelFilter(targetModel, directFilter)
-  normalized.is = hasIs ? { AND: [normalized.is, normalizedDirect] } : normalizedDirect
+  normalized['is'] = hasIs
+    ? { AND: [normalized['is'], normalizedDirect] }
+    : normalizedDirect
   return normalized
 }
 

--- a/generators/src/crud/filter-inputs.spec.ts
+++ b/generators/src/crud/filter-inputs.spec.ts
@@ -450,7 +450,9 @@ describe('admin data-access template rendering', () => {
 
     expect(service).toContain('"profile": {\n      "targetModel": "Profile",\n      "isList": false')
     expect(service).toContain("normalizeListInputFilters('User', input)")
-    expect(service).toContain('normalized.is = hasIs')
+    expect(service).toContain("normalized['is'] = hasIs")
+    expect(service).not.toContain('filter.is')
+    expect(service).not.toContain('normalized.is')
     expect(service).toContain("throw new BadRequestException('A to-one relation filter cannot combine is: null")
   })
 })


### PR DESCRIPTION
## Summary

- emit bracket notation for keys on the generated generic relation-filter map
- prevent TS4111 failures when consumers enable noPropertyAccessFromIndexSignature
- add regression assertions and document the 3.0.2 patch

## Root cause

The 3.0.1 relation-filter normalizer correctly constrained its internal maps as Record<string, unknown>, but accessed is and isNot with dot notation. Strict downstream TypeScript configurations require bracket notation for keys originating from an index signature.

## Impact

Consumers can regenerate the bounded filter grammar without changing workspace-wide TypeScript settings.

## Validation

- 142 generator tests passed
- generator typecheck passed
- generator lint passed
- generator build passed
- reproduced downstream as TS4111 in nestled-dev-template before this fix