### PR TITLE
fix(generators): remove stale lint directive

### DIFF
--- a/generators/src/lib/engine/generator-utils.ts
+++ b/generators/src/lib/engine/generator-utils.ts
@@ -830,7 +830,6 @@ export function addToGitignore(tree: Tree, entry: string) {
     // If logger is available, log info
     try {
       // Dynamically import logger if available
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const { logger } = require('@nx/devkit')
       logger.info(`✅ Added '${entry}' to .gitignore`)
     } catch {


### PR DESCRIPTION
## Summary

Remove an obsolete ESLint suppression for a rule that no longer exists in the configured plugin version.

## Why

The stale directive causes the scoped generator lint target to fail even though the underlying require call is accepted by the current configuration. This surfaced during the 3.0.2 release verification.

## Impact

No runtime or generated-output behavior changes. The generator package can pass its full lint, test, typecheck, and build release checks.

## Validation

- pnpm nx run-many -t eslint:lint test typecheck build -p generators --parallel=1 --skipNxCache
- 142 generator tests passed