### PR TITLE
fix(generators): keep public SDK application-owned

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ This runs:
 1. **`prisma:generate`** — Generates the Prisma client from your schema
 2. **`generators:crud`** — Generates CRUD resolvers and services from your Prisma models
 3. **`generators:models`** — Generates GraphQL `@ObjectType` models and enums from your Prisma models
-4. **`generators:sdk`** — Generates the GraphQL client SDK (fragments, mutations, queries)
+4. **`generators:sdk`** — Regenerates admin CRUD documents and maintains the GraphQL SDK source;
+   user-facing documents remain application-owned and are compiled separately by `pnpm sdk`
 5. **`generators:custom`** — Creates or maintains the custom API library shell. Model-specific
    extensions are created explicitly with `model-extension`, not automatically for every model.
 
@@ -44,7 +45,7 @@ Most one-time project scaffolding (the initial NestJS/web apps, library layout) 
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@nestledjs/generators:crud`            | Generate CRUD resolvers/services from Prisma models                                                                                            |
 | `@nestledjs/generators:models`          | Generate GraphQL `@ObjectType` models and enums from Prisma models                                                                             |
-| `@nestledjs/generators:sdk`             | Generate the GraphQL client SDK (fragments, mutations, queries)                                                                                |
+| `@nestledjs/generators:sdk`             | Regenerate admin CRUD documents and maintain SDK source/configuration while preserving application-owned GraphQL documents                     |
 | `@nestledjs/generators:custom`          | Create or maintain the custom API library shell                                                                                                |
 | `@nestledjs/generators:model-extension` | Scaffold an additive resolver module for one Prisma model                                                                                      |
 | `@nestledjs/generators:workspace-setup` | One-time bootstrap of a freshly cloned workspace: rename the project, ensure `.env`/Docker, apply Prisma migrations, generate models, and seed |
@@ -81,6 +82,21 @@ nx g @nestledjs/generators:model-extension User --name=UserProfile
 
 Generated CRUD names remain reserved. Custom operations must use additive names such as
 `myOrganizations`, `userCreateOrganization`, or `currentSubscription`.
+
+### GraphQL SDK ownership
+
+The SDK has two intentionally different source areas:
+
+- `libs/shared/sdk/src/__admin/<model>` is generated from Prisma and replaced on every SDK run. It
+  contains the complete client surface for the admin-only generated CRUD API.
+- `libs/shared/sdk/src/graphql/<feature>` is application-owned. Add purpose-built queries,
+  mutations, and fragments here only after the corresponding explicit resolver exists. The SDK
+  generator preserves this tree and does not seed generic CRUD documents for new models.
+
+The generated `graphql/core/core.graphql` document establishes the public source tree and provides
+the shared paging fragment, so empty per-model directories or placeholder `.graphql` files are not
+needed. Empty GraphQL documents are invalid syntax. Organize real operations by application feature
+or model as appropriate, then run `pnpm sdk` to compile them with the admin documents.
 
 ### Schema annotations
 

--- a/generators/CHANGELOG.md
+++ b/generators/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to `@nestledjs/generators` are documented here. This project
 uses independent semantic versioning; the current version is resolved from the npm
 registry (see `nx.json` → `release`).
 
+## 3.0.3
+
+### Fixed
+
+- **`sdk`: stop scaffolding public copies of generated admin CRUD operations.** The SDK generator
+  now recreates only `libs/shared/sdk/src/__admin/<model>` from the Prisma schema. Documents under
+  `libs/shared/sdk/src/graphql` are application-owned and are never created or deleted based on
+  Prisma models. This keeps the client surface aligned with the 3.0 admin-only generated CRUD
+  boundary without disturbing purpose-built user-facing operations.
+
+### Migration
+
+Regenerate the SDK, then audit the preserved `libs/shared/sdk/src/graphql` tree. Delete legacy
+per-model documents that call generated CRUD root fields (`create<Model>`, `update<Model>`,
+`delete<Model>`, `<model>`, `<models>`, and `<models>Count`) and keep purpose-built documents for
+explicit application resolvers. Do not create empty `.graphql` placeholders; organize real public
+operations by feature or model and run `pnpm sdk` after adding them.
+
 ## 3.0.2
 
 ### Fixed

--- a/generators/src/sdk/generator.spec.ts
+++ b/generators/src/sdk/generator.spec.ts
@@ -86,7 +86,7 @@ describe('sdk generator', () => {
     await expect(sdkGeneratorLogic(tree, {}, mockDependencies)).rejects.toThrow('Prisma schema not found at')
   })
 
-  it('generates files and scripts for models in schema, including admin SDK', async () => {
+  it('generates the admin SDK without scaffolding public CRUD operations', async () => {
     const callback = await sdkGeneratorLogic(tree, {}, mockDependencies)
     expect(mockDependencies.generateFiles).toHaveBeenCalled()
     expect(mockDependencies.addScriptToPackageJson).toHaveBeenCalledWith(tree, 'sdk', expect.any(String))
@@ -96,22 +96,46 @@ describe('sdk generator', () => {
     if (callback) callback()
     expect(mockDependencies.installPackagesTask).toHaveBeenCalledWith(tree)
 
-    // Check that generateFiles is called for both user and admin SDK
+    // Model-derived documents belong only to the regenerated admin namespace.
     const calls = vi.mocked(mockDependencies.generateFiles).mock.calls
-    // There should be at least one call for user and one for admin
-    const userCall = calls.find(
-      ([_, __, modelDir, context]) =>
-        typeof modelDir === 'string' && modelDir.includes('graphql') && !modelDir.includes('__admin'),
+    const publicModelCall = calls.find(
+      ([_, templateDir, modelDir]) =>
+        typeof templateDir === 'string' &&
+        templateDir.includes('/sdk/graphql') &&
+        typeof modelDir === 'string' &&
+        !modelDir.includes('__admin'),
     )
     const adminCall = calls.find(
       ([_, __, modelDir, context]) =>
         typeof modelDir === 'string' && modelDir.includes('__admin') && context?.adminPrefix === '__Admin',
     )
-    expect(userCall).toBeTruthy()
+    expect(publicModelCall).toBeUndefined()
     expect(adminCall).toBeTruthy()
-    // Check that adminPrefix is empty string for user SDK and '__Admin' for admin SDK
-    expect(userCall[3].adminPrefix).toBe('')
     expect(adminCall[3].adminPrefix).toBe('__Admin')
+  })
+
+  it('preserves hand-written public SDK operations', async () => {
+    mockDependencies.readFileSync = vi.fn().mockReturnValue(`
+generator client {
+  provider = "prisma-client"
+}
+
+datasource db {
+  provider = "sqlite"
+}
+
+/// @skipCrud
+model PasswordHistory {
+  id Int @id
+}
+`)
+    const publicOperationPath = 'libs/shared/sdk/src/graphql/password-history/account-security.graphql'
+    const publicOperation = 'query MyProfile { me { id } }\n'
+    tree.write(publicOperationPath, publicOperation)
+
+    await sdkGeneratorLogic(tree, {}, mockDependencies)
+
+    expect(tree.read(publicOperationPath, 'utf-8')).toBe(publicOperation)
   })
 
   describe('database-models.ts security metadata', () => {
@@ -173,21 +197,14 @@ model Session {
       expect(fragmentFields).toContain('role') // Single-select enum
       expect(fragmentFields).toContain('permissions') // Multi-select enum
 
-      // Find the client SDK call for User model
-      const clientCall = calls.find(
-        ([_, __, modelDir, context]) =>
+      const publicModelCall = calls.find(
+        ([_, templateDir, modelDir]) =>
+          typeof templateDir === 'string' &&
+          templateDir.includes('/sdk/graphql') &&
           typeof modelDir === 'string' &&
-          modelDir.includes('graphql/user') &&
-          !modelDir.includes('__admin') &&
-          context?.adminPrefix === '',
+          !modelDir.includes('__admin'),
       )
-      expect(clientCall).toBeTruthy()
-
-      // Check that client fragmentFields also includes enum fields
-      const clientFragmentFields = clientCall![3].fragmentFields as string
-      expect(clientFragmentFields).toContain('name')
-      expect(clientFragmentFields).toContain('role') // Single-select enum
-      expect(clientFragmentFields).toContain('permissions') // Multi-select enum
+      expect(publicModelCall).toBeUndefined()
     })
   })
 

--- a/generators/src/sdk/generator.spec.ts
+++ b/generators/src/sdk/generator.spec.ts
@@ -99,11 +99,8 @@ describe('sdk generator', () => {
     // Model-derived documents belong only to the regenerated admin namespace.
     const calls = vi.mocked(mockDependencies.generateFiles).mock.calls
     const publicModelCall = calls.find(
-      ([_, templateDir, modelDir]) =>
-        typeof templateDir === 'string' &&
-        templateDir.includes('/sdk/graphql') &&
-        typeof modelDir === 'string' &&
-        !modelDir.includes('__admin'),
+      ([_, __, modelDir, context]) =>
+        typeof modelDir === 'string' && !modelDir.includes('__admin') && context?.adminPrefix === '',
     )
     const adminCall = calls.find(
       ([_, __, modelDir, context]) =>
@@ -198,11 +195,8 @@ model Session {
       expect(fragmentFields).toContain('permissions') // Multi-select enum
 
       const publicModelCall = calls.find(
-        ([_, templateDir, modelDir]) =>
-          typeof templateDir === 'string' &&
-          templateDir.includes('/sdk/graphql') &&
-          typeof modelDir === 'string' &&
-          !modelDir.includes('__admin'),
+        ([_, __, modelDir, context]) =>
+          typeof modelDir === 'string' && !modelDir.includes('__admin') && context?.adminPrefix === '',
       )
       expect(publicModelCall).toBeUndefined()
     })

--- a/generators/src/sdk/generator.ts
+++ b/generators/src/sdk/generator.ts
@@ -175,8 +175,8 @@ export async function sdkGeneratorLogic(
   const databaseModelContent = generateDatabaseModelContent(allModelsForDbFiltered)
   tree.write('libs/shared/sdk/src/lib/database-models.ts', databaseModelContent)
 
-  // 5. For each model, generate admin files (always overwrite). Public operations under
-  // `src/graphql` are application-owned: the generator neither creates nor deletes them.
+  // 5. For each model, generate admin files (always overwrite). Per-model and feature operations
+  // under `src/graphql` are application-owned; the shared core document is still generated below.
   // Clean up the __admin directory before generating new files
   deleteDirectory(tree, 'libs/shared/sdk/src/__admin')
   console.log(

--- a/generators/src/sdk/generator.ts
+++ b/generators/src/sdk/generator.ts
@@ -134,15 +134,11 @@ const defaultDependencies = {
 }
 export type SdkGeneratorDependencies = typeof defaultDependencies
 
-function getSdkModels(models: ReadonlyArray<any>): {
-  skippedModelNames: Set<string>
-  visibleModels: any[]
-} {
+function getSdkModels(models: ReadonlyArray<any>): any[] {
   const skippedModelNames = getSkippedModelNames(models)
-  const visibleModels = models
-    .filter(m => !skippedModelNames.has(m.name))
-    .map(m => ({ ...m, fields: filterSkippedRelationFields(m.fields, skippedModelNames) }))
-  return { skippedModelNames, visibleModels }
+  return models
+    .filter((m) => !skippedModelNames.has(m.name))
+    .map((m) => ({ ...m, fields: filterSkippedRelationFields(m.fields, skippedModelNames) }))
 }
 
 export async function sdkGeneratorLogic(
@@ -164,7 +160,7 @@ export async function sdkGeneratorLogic(
   // 2. Parse models using Prisma DMMF for doc comments
   const dmmf = await getDMMF({ datamodel: schemaContent })
   const allModels = dmmf.datamodel.models
-  const { skippedModelNames, visibleModels } = getSdkModels(allModels)
+  const visibleModels = getSdkModels(allModels)
   const enumNames = new Set(dmmf.datamodel.enums.map((e: any) => e.name))
 
   // 3. Ensure sdk library exists
@@ -179,59 +175,8 @@ export async function sdkGeneratorLogic(
   const databaseModelContent = generateDatabaseModelContent(allModelsForDbFiltered)
   tree.write('libs/shared/sdk/src/lib/database-models.ts', databaseModelContent)
 
-  for (const skippedName of skippedModelNames) {
-    deleteDirectory(tree, `libs/shared/sdk/src/graphql/${kebabCase(skippedName)}`)
-  }
-
-  // 5. For each model, generate client files (existing logic)
-  for (const model of visibleModels) {
-    const modelName = model.name
-    const kebabName = kebabCase(modelName)
-    const modelDir = `libs/shared/sdk/src/graphql/${kebabName}`
-    if (tree.exists(modelDir)) continue
-
-    const className = modelName
-    const propertyName = modelName.charAt(0).toLowerCase() + modelName.slice(1)
-    const pluralClassName = dependencies.getPluralName(className)
-    const pluralPropertyName = dependencies.getPluralName(propertyName)
-    const fragmentFields = model.fields
-      .filter((f: any) => {
-        // Exclude id fields, relations, and @graphqlOmit fields
-        if (f.name === 'id' || f.name.endsWith('Id') || f.relationName) return false
-        if (f.documentation?.includes('@graphqlOmit')) return false
-        // Include scalar types (non-list)
-        if (!f.isList && SCALAR_TYPES.includes(f.type)) return true
-        // Include enum types (both single and multi-select)
-        return enumNames.has(f.type)
-      })
-      .map((f: any) => f.name)
-      .join('\n  ')
-
-    // Get ID field type for GraphQL type definitions
-    const idField = model.fields.find((f: any) => f.isId)
-    const idGraphQLType = idField?.type || 'String'
-
-    dependencies.generateFiles(tree, dependencies.joinPathFragments(__dirname, './graphql'), modelDir, {
-      className,
-      propertyName,
-      pluralClassName,
-      pluralPropertyName,
-      fragmentFields,
-      kebabName,
-      adminPrefix: '',
-      idGraphQLType,
-      tmpl: '',
-    })
-    ;['fragments', 'mutations', 'queries'].forEach((type) => {
-      const oldPath = dependencies.join(modelDir, `__name__-${type}.graphql`)
-      const newPath = dependencies.join(modelDir, `${kebabName}-${type}.graphql`)
-      if (tree.exists(oldPath)) {
-        tree.rename(oldPath, newPath)
-      }
-    })
-  }
-
-  // 6. For each model, generate admin files (always overwrite)
+  // 5. For each model, generate admin files (always overwrite). Public operations under
+  // `src/graphql` are application-owned: the generator neither creates nor deletes them.
   // Clean up the __admin directory before generating new files
   deleteDirectory(tree, 'libs/shared/sdk/src/__admin')
   console.log(
@@ -276,15 +221,15 @@ export async function sdkGeneratorLogic(
     })
   }
 
-  // 7. Handle codegen.yml generation with existence check
+  // 6. Handle codegen.yml generation with existence check
   const sdkSrcDir = 'libs/shared/sdk/src'
   const codegenPath = 'libs/shared/sdk/src/codegen.yml'
-  
+
   // Check if codegen.yml exists before generation
   const codegenExists = tree.exists(codegenPath)
   const shouldPreserveCodegen = codegenExists && !schema.forceCodegen
   let existingCodegenContent = ''
-  
+
   if (shouldPreserveCodegen) {
     // Backup existing codegen.yml content
     existingCodegenContent = tree.read(codegenPath, 'utf-8') || ''
@@ -293,10 +238,10 @@ export async function sdkGeneratorLogic(
   } else if (codegenExists && schema.forceCodegen) {
     console.log('🔄 Forcing regeneration of codegen.yml as requested.')
   }
-  
+
   // Generate all files from template
   dependencies.generateFiles(tree, dependencies.joinPathFragments(__dirname, './files'), sdkSrcDir, { tmpl: '' })
-  
+
   // Restore existing codegen.yml if it existed and we should preserve it
   if (shouldPreserveCodegen) {
     tree.write(codegenPath, existingCodegenContent)
@@ -307,11 +252,11 @@ export async function sdkGeneratorLogic(
     console.log('⚙️  Force-regenerated codegen.yml file.')
   }
 
-  // 8. Add scripts to package.json
+  // 7. Add scripts to package.json
   dependencies.addScriptToPackageJson(tree, 'sdk', 'graphql-codegen --config libs/shared/sdk/src/codegen.yml')
   dependencies.addScriptToPackageJson(tree, 'sdk:watch', 'pnpm sdk --watch')
 
-  // 9. Add GraphQL Codegen packages as devDependencies
+  // 8. Add GraphQL Codegen packages as devDependencies
   dependencies.addDependenciesToPackageJson(
     tree,
     {},


### PR DESCRIPTION
## Summary

- stop the SDK generator from seeding generic public CRUD documents for every Prisma model
- keep regenerating the complete `__admin` SDK surface for admin-only generated CRUD
- preserve all application-owned documents under `libs/shared/sdk/src/graphql`, including directories named after `@skipCrud` models
- document the SDK ownership boundary and downstream cleanup

## Why

Generator 3.x made generated CRUD permanently admin-only, but the SDK generator still created unprefixed public copies of those same CRUD operations. Those documents did not bypass server authorization, but they presented a misleading client surface and encouraged application code to call the admin API.

Public SDK operations should exist only for explicit, purpose-built application resolvers. Empty `.graphql` placeholders are not generated because empty GraphQL documents are invalid; the generated `graphql/core` document already establishes the source tree.

## Migration

After upgrading, regenerate the SDK and audit the preserved public GraphQL tree. Delete legacy documents that call generated CRUD root fields and retain purpose-built operations for explicit resolvers.

## Validation

- `pnpm nx run-many -t lint test typecheck build -p generators --skipNxCache`
- 143 tests passed
- `npm pack --dry-run ./dist/generators`
- `git diff --check`