### PR TITLE
docs(generators): filterDepth also drops AND/OR/NOT at the deepest level

### DIFF
--- a/generators/src/crud/schema.json
+++ b/generators/src/crud/schema.json
@@ -28,7 +28,7 @@
       "default": false
     },
     "filterDepth": {
-      "description": "How many levels of relation nesting the generated filter inputs allow. Each level emits a distinct set of input types, and the deepest level carries scalar fields only, which bounds how deeply a caller can nest relation filters.",
+      "description": "How many levels of relation nesting the generated filter inputs allow. Each level emits a distinct set of input types; the deepest level carries scalar fields only — it omits nested relation filters AND the AND/OR/NOT logical operators (so logical grouping is unavailable there) — which bounds how deeply a caller can nest relation filters.",
       "type": "number",
       "default": 3,
       "minimum": 1

--- a/generators/src/crud/schema.json
+++ b/generators/src/crud/schema.json
@@ -28,7 +28,7 @@
       "default": false
     },
     "filterDepth": {
-      "description": "How many levels of relation nesting the generated filter inputs allow. Each level emits a distinct set of input types; the deepest level carries scalar fields only — it omits nested relation filters AND the AND/OR/NOT logical operators (so logical grouping is unavailable there) — which bounds how deeply a caller can nest relation filters.",
+      "description": "How many levels of relation nesting the generated filter inputs allow. Each level emits a distinct set of input types; the deepest level carries scalar fields only — no nested relation filters and no AND/OR/NOT logical operators, so logical grouping is unavailable there — which bounds how deeply a caller can nest relation filters.",
       "type": "number",
       "default": 3,
       "minimum": 1


### PR DESCRIPTION
Addresses **nestledjs/nestled-dev-template#124** (found during mi-core convergence).

`filterDepth`'s option description said the deepest level *"carries scalar fields only"*, which reads as "only nested relations are bounded." But the deepest level **also omits the `AND`/`OR`/`NOT` logical operators**, so a filter that relies on logical grouping at that depth silently loses it — which is what actually broke mi-core's deep filters.

The default (3) means the limit itself is **by design, not a bug** — the docs just understated the consequence. One-line description change; `schema.json` still valid JSON.

Cross-repo, so nestledjs/nestled-dev-template#124 gets closed on merge (I'll close it referencing this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
