### PR TITLE
feat(crud): generator reads the guard-posture file; emits declared tier, fails closed

### DIFF
--- a/generators/src/crud/generator.spec.ts
+++ b/generators/src/crud/generator.spec.ts
@@ -239,6 +239,16 @@ describe('generate-crud generator', () => {
       warn.mockRestore()
     })
 
+    it('fails closed to admin and warns on a wrong-typed posture value', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+      tree.write(posturePath, JSON.stringify({ posture: 1 }))
+      await generateCrudLogic(tree, { name: 'crud' } as any, mockDependencies)
+
+      expect(tree.read(resolverPath, 'utf-8')).toContain('@UseGuards(GqlAuthAdminGuard)\n@AdminOnly()')
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('a non-string posture (1)'))
+      warn.mockRestore()
+    })
+
     it('fails closed to admin and warns when the posture key is absent', async () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
       tree.write(posturePath, JSON.stringify({ reason: 'forgot the key' }))

--- a/generators/src/crud/generator.spec.ts
+++ b/generators/src/crud/generator.spec.ts
@@ -192,6 +192,64 @@ describe('generate-crud generator', () => {
     })
   })
 
+  // The posture file is the same single source of truth the downstream doctor and guard-posture
+  // spec read (nestled-dev-template#140): the generator must emit what the repo declares, so
+  // `db-update` is idempotent mid-migration instead of silently re-tightening rolled-back guards.
+  describe('guard posture', () => {
+    const posturePath = '.nestled-updates/security/generated-crud-posture.json'
+    const resolverPath = 'libs/api/crud/feature/src/lib/user.resolver.ts'
+
+    it('emits the authenticated tier when the posture file declares it', async () => {
+      tree.write(posturePath, JSON.stringify({ posture: 'authenticated', reason: 'staged rollback' }))
+      await generateCrudLogic(tree, { name: 'crud' } as any, mockDependencies)
+
+      const source = tree.read(resolverPath, 'utf-8')!
+      expect(source).toContain("import { Authenticated, GqlAuthGuard } from '@testscope/api/utils'")
+      expect(source).toContain('@UseGuards(GqlAuthGuard)\n@Authenticated()')
+      expect(source).not.toContain('AdminOnly')
+      expect(source).not.toContain('GqlAuthAdminGuard')
+    })
+
+    it('defaults to admin, quietly, when no posture file exists', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+      await generateCrudLogic(tree, { name: 'crud' } as any, mockDependencies)
+
+      expect(tree.read(resolverPath, 'utf-8')).toContain('@UseGuards(GqlAuthAdminGuard)\n@AdminOnly()')
+      expect(warn).not.toHaveBeenCalled()
+      warn.mockRestore()
+    })
+
+    it('fails closed to admin and warns on unparseable JSON', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+      tree.write(posturePath, '{ not json')
+      await generateCrudLogic(tree, { name: 'crud' } as any, mockDependencies)
+
+      expect(tree.read(resolverPath, 'utf-8')).toContain('@UseGuards(GqlAuthAdminGuard)\n@AdminOnly()')
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('unparseable JSON'))
+      warn.mockRestore()
+    })
+
+    it('fails closed to admin and warns on an unrecognized posture value', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+      tree.write(posturePath, JSON.stringify({ posture: 'authetnicated' }))
+      await generateCrudLogic(tree, { name: 'crud' } as any, mockDependencies)
+
+      expect(tree.read(resolverPath, 'utf-8')).toContain('@UseGuards(GqlAuthAdminGuard)\n@AdminOnly()')
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('unrecognized posture "authetnicated"'))
+      warn.mockRestore()
+    })
+
+    it('fails closed to admin and warns when the posture key is absent', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+      tree.write(posturePath, JSON.stringify({ reason: 'forgot the key' }))
+      await generateCrudLogic(tree, { name: 'crud' } as any, mockDependencies)
+
+      expect(tree.read(resolverPath, 'utf-8')).toContain('@UseGuards(GqlAuthAdminGuard)\n@AdminOnly()')
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('no "posture" key'))
+      warn.mockRestore()
+    })
+  })
+
   describe('filter inputs', () => {
     // Prisma's `where` is built from the database model, so before typed filter inputs any column
     // was filterable whether or not it was queryable — @graphqlOmit gave no protection, and

--- a/generators/src/crud/generator.ts
+++ b/generators/src/crud/generator.ts
@@ -67,10 +67,13 @@ export function readGeneratedCrudPosture(tree: Tree): { posture: GeneratedCrudPo
   if (typeof declared === 'string' && (GENERATED_CRUD_POSTURES as readonly string[]).includes(declared)) {
     return { posture: declared as GeneratedCrudPosture }
   }
-  return {
-    posture: 'admin',
-    invalid: typeof declared === 'string' ? `an unrecognized posture "${declared}"` : 'no "posture" key',
-  }
+  const described =
+    typeof declared === 'string'
+      ? `an unrecognized posture "${declared}"`
+      : declared === undefined
+      ? 'no "posture" key'
+      : `a non-string posture (${JSON.stringify(declared)})`
+  return { posture: 'admin', invalid: described }
 }
 
 export function generateResolverContent(

--- a/generators/src/crud/generator.ts
+++ b/generators/src/crud/generator.ts
@@ -67,13 +67,9 @@ export function readGeneratedCrudPosture(tree: Tree): { posture: GeneratedCrudPo
   if (typeof declared === 'string' && (GENERATED_CRUD_POSTURES as readonly string[]).includes(declared)) {
     return { posture: declared as GeneratedCrudPosture }
   }
-  const described =
-    typeof declared === 'string'
-      ? `an unrecognized posture "${declared}"`
-      : declared === undefined
-      ? 'no "posture" key'
-      : `a non-string posture (${JSON.stringify(declared)})`
-  return { posture: 'admin', invalid: described }
+  if (typeof declared === 'string') return { posture: 'admin', invalid: `an unrecognized posture "${declared}"` }
+  if (declared === undefined) return { posture: 'admin', invalid: 'no "posture" key' }
+  return { posture: 'admin', invalid: `a non-string posture (${JSON.stringify(declared)})` }
 }
 
 export function generateResolverContent(

--- a/generators/src/crud/generator.ts
+++ b/generators/src/crud/generator.ts
@@ -38,7 +38,46 @@ function toKebabCase(str: string): string {
   return str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
 }
 
-export function generateResolverContent(model: ModelType, npmScope: string): string {
+// The guard posture of the generated CRUD resolvers. Normally `admin`; `authenticated` only while
+// a repo has a deliberate rollback in effect, declared in the posture file below. That file is the
+// single source of truth — the same one the repo's doctor and guard-posture spec read — so the
+// generator, doctor and spec agree by construction and `db-update` is safe to run at any point of
+// a staged migration instead of only at the endpoints (nestled-dev-template#140).
+//
+// Anything not positively readable as a KNOWN posture resolves to `admin`: a missing file,
+// unparseable JSON, an absent key, or a typo. This decides what guard gets written onto every
+// generated resolver, so the default has to be the strict one. A present-but-invalid file is
+// additionally reported, because failing closed *silently* would leave a config nobody realises
+// has stopped meaning anything. (Semantics mirror the downstream doctor's reader — keep in step.)
+export const GENERATED_CRUD_POSTURES = ['admin', 'authenticated'] as const
+export type GeneratedCrudPosture = (typeof GENERATED_CRUD_POSTURES)[number]
+export const GENERATED_CRUD_POSTURE_PATH = '.nestled-updates/security/generated-crud-posture.json'
+
+export function readGeneratedCrudPosture(tree: Tree): { posture: GeneratedCrudPosture; invalid?: string } {
+  if (!tree.exists(GENERATED_CRUD_POSTURE_PATH)) return { posture: 'admin' }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(tree.read(GENERATED_CRUD_POSTURE_PATH, 'utf-8') ?? '')
+  } catch {
+    return { posture: 'admin', invalid: 'unparseable JSON' }
+  }
+
+  const declared = (parsed as { posture?: unknown })?.posture
+  if (typeof declared === 'string' && (GENERATED_CRUD_POSTURES as readonly string[]).includes(declared)) {
+    return { posture: declared as GeneratedCrudPosture }
+  }
+  return {
+    posture: 'admin',
+    invalid: typeof declared === 'string' ? `an unrecognized posture "${declared}"` : 'no "posture" key',
+  }
+}
+
+export function generateResolverContent(
+  model: ModelType,
+  npmScope: string,
+  posture: GeneratedCrudPosture = 'admin',
+): string {
   const readManyMethodName = model.pluralModelPropertyName
   const countMethodName = `${model.pluralModelPropertyName}Count`
   const readOneMethodName = model.modelPropertyName
@@ -48,6 +87,11 @@ export function generateResolverContent(model: ModelType, npmScope: string): str
   const idTsType = model.idFieldType === 'BigInt' ? 'bigint' : 'string'
   const idArgsType = model.idFieldType === 'BigInt' ? ', { type: () => GraphQLBigInt }' : ''
   const graphqlScalarImport = model.idFieldType === 'BigInt' ? "\nimport { GraphQLBigInt } from 'graphql-scalars'" : ''
+
+  const guard =
+    posture === 'authenticated'
+      ? { imports: 'Authenticated, GqlAuthGuard', guardClass: 'GqlAuthGuard', decorator: '@Authenticated()' }
+      : { imports: 'AdminOnly, GqlAuthAdminGuard', guardClass: 'GqlAuthAdminGuard', decorator: '@AdminOnly()' }
 
   return `import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, Query, Resolver, Info } from '@nestjs/graphql'
@@ -60,11 +104,11 @@ import {
     List${model.modelName}Input,
     Update${model.modelName}Input
     } from '@${npmScope}/api/generated-crud/data-access'${graphqlScalarImport}
-import { AdminOnly, GqlAuthAdminGuard } from '@${npmScope}/api/utils'
+import { ${guard.imports} } from '@${npmScope}/api/utils'
 
 @Resolver(() => ${model.modelName})
-@UseGuards(GqlAuthAdminGuard)
-@AdminOnly()
+@UseGuards(${guard.guardClass})
+${guard.decorator}
 export class Generated${model.modelName}Resolver {
   constructor(private readonly generatedService: ApiCrudDataAccessService) {}
 
@@ -223,6 +267,7 @@ export async function generateCrudLogic(
     dataAccessLibraryRoot: string,
     featureLibraryRoot: string,
     models: ModelType[],
+    posture: GeneratedCrudPosture,
   ) {
     const npmScope = dependencies.getNpmScope(tree)
 
@@ -270,7 +315,7 @@ export async function generateCrudLogic(
         featureLibraryRoot,
         `src/lib/${toKebabCase(model.modelName)}.resolver.ts`,
       )
-      const resolverContent = generateResolverContent(model, npmScope)
+      const resolverContent = generateResolverContent(model, npmScope, posture)
       tree.write(resolverFilePath, resolverContent)
     }
   }
@@ -283,8 +328,18 @@ export async function generateCrudLogic(
     return // Return early for the test case
   }
 
+  const { posture, invalid } = readGeneratedCrudPosture(tree)
+  if (invalid) {
+    // Fail closed AND say so at emission time: a typo'd posture file silently emitting admin would
+    // regress a declared `authenticated` rollback with nothing but the downstream spec to catch it.
+    console.warn(
+      `⚠️  ${GENERATED_CRUD_POSTURE_PATH} declares ${invalid}; emitting "admin" guards. ` +
+        `Valid values: ${GENERATED_CRUD_POSTURES.join(', ')}.`,
+    )
+  }
+
   const { dataAccessLibraryRoot, featureLibraryRoot } = await createLibraries(tree, name, models)
-  await generateModelFiles(tree, dataAccessLibraryRoot, featureLibraryRoot, models)
+  await generateModelFiles(tree, dataAccessLibraryRoot, featureLibraryRoot, models, posture)
   await dependencies.formatFiles(tree)
 
   return () => {


### PR DESCRIPTION
Fixes nestledjs/nestled-dev-template#140.

## What

The CRUD generator hard-coded `GqlAuthAdminGuard` + `@AdminOnly()` into every emitted resolver. It now reads `.nestled-updates/security/generated-crud-posture.json` — the same single source of truth the downstream doctor and guard-posture spec read — and emits the declared tier:

- `admin` (and every fail-closed case) → `GqlAuthAdminGuard` + `@AdminOnly()` — unchanged output
- `authenticated` → `GqlAuthGuard` + `@Authenticated()` (both exported from the template's `api/utils` barrel)

**Fail-closed rules mirror mi-core's doctor reader exactly**: missing file → admin, quiet (the normal declared-nothing state); present but unparseable / unknown value / no `posture` key → admin **+ a warning at emission time**, since silently failing closed would regress a declared rollback with only the downstream spec as a tripwire.

## Why now

`db-update`'s idempotence contract breaks mid-migration: on mi-core, `generators:crud` alone rewrites 103 files / 202 lines, flipping every resolver back to admin — the exact change that denied 2,915 users in a day and is currently rolled back. With this, generator, doctor, and spec agree by construction and `db-update` is safe at any point of a staged migration.

Backwards-safe: repos with no posture file (all of them except mi-core today) get byte-identical output.

## Tests

5 new cases (authenticated emission, quiet missing-file default, and the three fail-closed-with-warning paths); 148/148 pass, lint + Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)