### PR TITLE
feat(doctor): ship the enforcement checks as @nestledjs/doctor

### DIFF
--- a/doctor/README.md
+++ b/doctor/README.md
@@ -1,0 +1,32 @@
+# @nestledjs/doctor
+
+Nestled's enforcement checks — the doctor and its verifiers — shipped as a package so every repo
+runs provably identical rules.
+
+Previously these were ~7,400 lines copied verbatim into every repo. A copy can be edited, and an
+edited check reports clean while enforcing less; drift was only discoverable by hashing files
+against the template. As a package, the version a repo runs is a line in its lockfile.
+
+## Commands
+
+| bin | replaces |
+| --- | --- |
+| `nestled-doctor` | `tsx scripts/doctor.ts` |
+| `nestled-verify-selects` | `node tools/verify-selects.mjs` |
+| `nestled-verify-select-coverage` | `node tools/verify-select-coverage.mjs` |
+| `nestled-verify-fragments` | `tsx tools/verify-fragment-coverage.ts` |
+| `nestled-verify-prisma-client` | `tsx scripts/verify-prisma-client.ts` |
+
+All read the repo they are run in, from `process.cwd()`. Nothing about a repo is compiled in.
+
+## What stays in the repo
+
+The declarations, not the rules:
+
+- `.nestled-updates/security/*.json` — guard baseline, public operations, permission exemptions,
+  generated-crud posture
+- `.nestled-updates/sdk-contract-*.json` — SDK contract baseline and exceptions
+- `.nestled-updates/doctor.config.json` — repo layout, e.g. `selectFileSuffixes`
+
+A repo declares **where to look** and **what it has been let off**. It does not get to change
+**what the rules are** — that is the point of packaging them.

--- a/doctor/bin/nestled-doctor.js
+++ b/doctor/bin/nestled-doctor.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+// The doctor runs on load — importing it IS running it. Kept as a thin bin so the package's entry
+// points are declared in one place rather than depending on which module happens to self-invoke.
+require('../src/doctor.js')

--- a/doctor/bin/nestled-verify-fragments.js
+++ b/doctor/bin/nestled-verify-fragments.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+const { runCli } = require('../src/verify-fragment-coverage.js')
+void runCli()

--- a/doctor/bin/nestled-verify-prisma-client.js
+++ b/doctor/bin/nestled-verify-prisma-client.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../src/verify-prisma-client.js')

--- a/doctor/bin/nestled-verify-select-coverage.js
+++ b/doctor/bin/nestled-verify-select-coverage.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import('../src/verify-select-coverage.mjs').then((module) => (module.runCli ?? module.default)())

--- a/doctor/bin/nestled-verify-selects.js
+++ b/doctor/bin/nestled-verify-selects.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+// .mjs stays ESM regardless of the package type, so reach it with a dynamic import.
+import('../src/verify-selects.mjs').then(({ runCli }) => runCli())

--- a/doctor/package.json
+++ b/doctor/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@nestledjs/doctor",
+  "version": "0.1.0",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "description": "Nestled's enforcement checks \u2014 the doctor and its verifiers, shipped as a package so every repo runs provably identical rules",
+  "keywords": [
+    "nestled",
+    "doctor",
+    "lint",
+    "architecture",
+    "enforcement",
+    "security"
+  ],
+  "author": "Nestled Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nestledjs/nestled.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "bin": {
+    "nestled-doctor": "bin/nestled-doctor.js",
+    "nestled-verify-selects": "bin/nestled-verify-selects.js",
+    "nestled-verify-select-coverage": "bin/nestled-verify-select-coverage.js",
+    "nestled-verify-fragments": "bin/nestled-verify-fragments.js",
+    "nestled-verify-prisma-client": "bin/nestled-verify-prisma-client.js"
+  },
+  "dependencies": {
+    "graphql": "^16.9.0",
+    "typescript": "^5.9.0",
+    "tsx": "^4.19.0"
+  },
+  "peerDependencies": {
+    "@prisma/internals": ">=6"
+  },
+  "peerDependenciesMeta": {
+    "@prisma/internals": {
+      "optional": true
+    }
+  }
+}

--- a/doctor/project.json
+++ b/doctor/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "doctor",
+  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "doctor/src",
+  "projectType": "library",
+  "tags": [],
+  "publishable": true,
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/doctor",
+        "main": "doctor/src/index.ts",
+        "tsConfig": "doctor/tsconfig.lib.json",
+        "assets": [
+          "doctor/*.md",
+          { "input": "./doctor/src", "glob": "**/*.mjs", "output": "./src" },
+          { "input": "./doctor/bin", "glob": "**/*.js", "output": "./bin" }
+        ]
+      }
+    }
+  }
+}

--- a/doctor/project.json
+++ b/doctor/project.json
@@ -8,17 +8,39 @@
   "targets": {
     "build": {
       "executor": "@nx/js:tsc",
-      "outputs": ["{options.outputPath}"],
+      "outputs": [
+        "{options.outputPath}"
+      ],
       "options": {
         "outputPath": "dist/doctor",
         "main": "doctor/src/index.ts",
         "tsConfig": "doctor/tsconfig.lib.json",
         "assets": [
           "doctor/*.md",
-          { "input": "./doctor/src", "glob": "**/*.mjs", "output": "./src" },
-          { "input": "./doctor/bin", "glob": "**/*.js", "output": "./bin" }
+          {
+            "input": "./doctor/src",
+            "glob": "**/!(*.spec).mjs",
+            "output": "./src"
+          },
+          {
+            "input": "./doctor/bin",
+            "glob": "**/*.js",
+            "output": "./bin"
+          }
         ]
       }
+    },
+    "test": {
+      "executor": "@nx/vite:test",
+      "outputs": [
+        "{options.reportsDirectory}"
+      ],
+      "options": {
+        "reportsDirectory": "../coverage/doctor"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
     }
   }
 }

--- a/doctor/src/doctor-access-policy-analysis.spec.ts
+++ b/doctor/src/doctor-access-policy-analysis.spec.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getUndeclaredAccessOperations,
+  analyzeAccessPolicies,
+  readStringObjectArray,
+} from './doctor-access-policy-analysis'
+
+describe('analyzeAccessPolicies', () => {
+  it('extracts platform and organization permission literals without option prose', () => {
+    const report = analyzeAccessPolicies(`
+      @Resolver()
+      class ResolverUnderTest {
+        @Query(() => Boolean)
+        @RequirePlatformPermission('platform.users.read', 'platform.users.manage')
+        users() {}
+
+        @Mutation(() => Boolean)
+        @RequireOrganizationPermission(['member:update'], {
+          organizationIdPath: 'input.organizationId',
+        })
+        updateMember() {}
+      }
+    `)
+
+    expect(report.declarations.map(item => item.permissions)).toEqual([
+      ['platform.users.read', 'platform.users.manage'],
+      ['member:update'],
+    ])
+  })
+
+  it('reports inline permission helpers on an operation with no declarative policy', () => {
+    const report = analyzeAccessPolicies(`
+      @Controller('reports')
+      class ReportController {
+        @Post()
+        @Authenticated()
+        async create() {
+          await this.assertPermission('reports:create')
+          return this.service.create()
+        }
+      }
+    `)
+
+    expect(report.inlineViolations).toEqual([
+      expect.objectContaining({
+        className: 'ReportController',
+        name: 'create',
+        calls: ['assertPermission'],
+      }),
+    ])
+  })
+
+  it('accepts a class-level policy as the declaration for its operations', () => {
+    const report = analyzeAccessPolicies(`
+      @Resolver()
+      @RequirePlatformPermission('platform.audit.read')
+      class AuditResolver {
+        @Query(() => Boolean)
+        audit() {
+          return this.hasPermission('platform.audit.read')
+        }
+      }
+    `)
+
+    expect(report.inlineViolations).toEqual([])
+    expect(report.declarations).toHaveLength(1)
+  })
+})
+
+describe('readStringObjectArray', () => {
+  it('reads only the named catalog and ignores similarly shaped role metadata', () => {
+    const entries = readStringObjectArray(
+      `
+        export const permissions = [
+          { key: 'platform.users.read', namespace: 'platform.users' },
+        ] as const
+        export const rootRole = { key: 'system.super-administrator' }
+      `,
+      'permissions',
+      ['key'],
+    )
+
+    expect(entries).toEqual([{ key: 'platform.users.read' }])
+  })
+
+  it('finds the catalog when it is declared inside a function rather than at the top level (#120)', () => {
+    // A repo that seeds permissions from a builder must not be handed an empty catalog (which would
+    // then report every declared permission as "unknown").
+    const entries = readStringObjectArray(
+      `
+        export function buildCatalog() {
+          const permissions = [
+            { key: 'platform.users.read' },
+            { key: 'platform.users.manage' },
+          ]
+          return permissions
+        }
+      `,
+      'permissions',
+      ['key'],
+    )
+
+    expect(entries).toEqual([{ key: 'platform.users.read' }, { key: 'platform.users.manage' }])
+  })
+
+  it('skips a same-named non-array binding and finds the actual array literal (#54 review)', () => {
+    // The first `permissions` is a call, not the catalog — the walk must keep going to the literal.
+    const entries = readStringObjectArray(
+      `
+        export function build() {
+          const permissions = derivePermissions()
+          return permissions
+        }
+        export const permissions = [
+          { key: 'platform.users.read' },
+        ]
+      `,
+      'permissions',
+      ['key'],
+    )
+
+    expect(entries).toEqual([{ key: 'platform.users.read' }])
+  })
+})
+
+describe('getUndeclaredAccessOperations', () => {
+  it('reports an operation with neither a permission nor caller scoping', () => {
+    const undeclared = getUndeclaredAccessOperations(`
+      @Resolver()
+      class FileResolver {
+        @Query(() => String)
+        async getSignedUrl(@Args('uploadId') uploadId: string): Promise<string> {
+          return this.service.getSignedUrl(uploadId)
+        }
+      }
+    `)
+
+    expect(undeclared.map(operation => operation.name)).toEqual(['getSignedUrl'])
+    expect(undeclared[0].callerScoped).toBe(false)
+  })
+
+  // @CtxUser() is a PARAMETER decorator, so detection has to read the whole method — a scan of the
+  // method's own decorators, or of its body alone, misses it.
+  it('treats a @CtxUser() parameter as caller scoping', () => {
+    const undeclared = getUndeclaredAccessOperations(`
+      @Resolver()
+      class FileResolver {
+        @Query(() => [String])
+        async userFiles(@CtxUser() user: User): Promise<string[]> {
+          return this.service.getUserFiles(user.id)
+        }
+      }
+    `)
+
+    expect(undeclared[0].callerScoped).toBe(true)
+  })
+
+  it('sees caller scoping even when an @Args object literal precedes the caller parameter', () => {
+    const undeclared = getUndeclaredAccessOperations(`
+      @Resolver()
+      class FileResolver {
+        @Mutation(() => Boolean)
+        async deleteFile(
+          @Args('uploadId', { type: () => String }) uploadId: string,
+          @CtxUser() user: User,
+        ): Promise<boolean> {
+          await this.service.deleteFile(uploadId, user.id)
+          return true
+        }
+      }
+    `)
+
+    expect(undeclared[0].callerScoped).toBe(true)
+  })
+
+  it('treats a declared permission as authorization and reports nothing', () => {
+    expect(
+      getUndeclaredAccessOperations(`
+        @Resolver()
+        class AdminResolver {
+          @Mutation(() => Boolean)
+          @RequirePlatformPermission('platform.users.manage')
+          async unlockAccount(@Args('userId') userId: string): Promise<boolean> {
+            return true
+          }
+        }
+      `),
+    ).toEqual([])
+  })
+
+  it('treats a class-wide permission as covering its operations', () => {
+    expect(
+      getUndeclaredAccessOperations(`
+        @Resolver()
+        @RequirePlatformPermission('platform.users.read')
+        class AdminResolver {
+          @Query(() => String)
+          async anything(@Args('id') id: string): Promise<string> {
+            return id
+          }
+        }
+      `),
+    ).toEqual([])
+  })
+
+  it('respects the guarded filter, so public operations are out of scope', () => {
+    expect(
+      getUndeclaredAccessOperations(
+        `
+          @Resolver()
+          class AuthResolver {
+            @Mutation(() => String)
+            async login(@Args('email') email: string): Promise<string> {
+              return email
+            }
+          }
+        `,
+        'auth.resolver.ts',
+        () => false,
+      ),
+    ).toEqual([])
+  })
+})

--- a/doctor/src/doctor-access-policy-analysis.ts
+++ b/doctor/src/doctor-access-policy-analysis.ts
@@ -1,0 +1,278 @@
+import ts from 'typescript'
+import { decoratorName, decoratorsOf, unwrapExpression } from './doctor-typescript-analysis'
+
+export type AccessPolicyScope = 'platform' | 'organization'
+
+export type AccessPolicyDeclaration = {
+  className: string
+  decorator: string
+  line: number
+  name: string
+  permissions: string[]
+  scope: AccessPolicyScope
+}
+
+export type InlineAccessCheckViolation = {
+  calls: string[]
+  className: string
+  line: number
+  name: string
+}
+
+const graphqlOperationDecorators = new Set(['Mutation', 'Query', 'ResolveField', 'Subscription'])
+const httpOperationDecorators = new Set([
+  'All',
+  'Delete',
+  'Get',
+  'Head',
+  'Options',
+  'Patch',
+  'Post',
+  'Put',
+  'Sse',
+])
+const policyDecorators = new Map<string, AccessPolicyScope>([
+  ['RequirePlatformPermission', 'platform'],
+  ['RequireAllPlatformPermissions', 'platform'],
+  ['RequireOrganizationPermission', 'organization'],
+  ['RequireAllOrganizationPermissions', 'organization'],
+])
+const inlineAccessCalls = new Set([
+  'assertPermission',
+  'hasAnyPermissionInNamespace',
+  'hasPermission',
+  'requirePermission',
+])
+
+const methodName = (method: ts.MethodDeclaration, sourceFile: ts.SourceFile): string =>
+  ts.isIdentifier(method.name) || ts.isStringLiteral(method.name)
+    ? method.name.text
+    : method.name.getText(sourceFile)
+
+const isApiClass = (statement: ts.ClassDeclaration): boolean =>
+  decoratorsOf(statement).some(decorator =>
+    ['Controller', 'Resolver'].includes(decoratorName(decorator)),
+  )
+
+const isApiOperation = (method: ts.MethodDeclaration): boolean =>
+  decoratorsOf(method).some(decorator => {
+    const name = decoratorName(decorator)
+    return graphqlOperationDecorators.has(name) || httpOperationDecorators.has(name)
+  })
+
+const stringLiterals = (node: ts.Node): string[] => {
+  const values: string[] = []
+  const visit = (current: ts.Node) => {
+    if (ts.isStringLiteral(current) || ts.isNoSubstitutionTemplateLiteral(current)) {
+      values.push(current.text)
+      return
+    }
+    ts.forEachChild(current, visit)
+  }
+  visit(node)
+  return values
+}
+
+const permissionArguments = (decorator: ts.Decorator, scope: AccessPolicyScope): string[] => {
+  if (!ts.isCallExpression(decorator.expression)) return []
+  const args = decorator.expression.arguments
+  if (scope === 'organization') return args[0] ? stringLiterals(args[0]) : []
+  return args.flatMap(argument => stringLiterals(argument))
+}
+
+const policyDeclarations = (
+  decorators: readonly ts.Decorator[],
+  sourceFile: ts.SourceFile,
+  className: string,
+  name: string,
+): AccessPolicyDeclaration[] =>
+  decorators.flatMap(decorator => {
+    const nameOfDecorator = decoratorName(decorator)
+    const scope = policyDecorators.get(nameOfDecorator)
+    if (!scope) return []
+    return [
+      {
+        className,
+        decorator: nameOfDecorator,
+        line: sourceFile.getLineAndCharacterOfPosition(decorator.getStart(sourceFile)).line + 1,
+        name,
+        permissions: permissionArguments(decorator, scope),
+        scope,
+      },
+    ]
+  })
+
+const calledAccessHelpers = (method: ts.MethodDeclaration): string[] => {
+  const calls = new Set<string>()
+  if (!method.body) return []
+
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node)) {
+      const expression = node.expression
+      let name = ''
+      if (ts.isIdentifier(expression)) name = expression.text
+      if (ts.isPropertyAccessExpression(expression)) name = expression.name.text
+      if (inlineAccessCalls.has(name)) calls.add(name)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(method.body)
+  return [...calls].sort((left, right) => left.localeCompare(right))
+}
+
+/** Read literal string properties only from one named top-level object-array declaration. */
+export const readStringObjectArray = (
+  source: string,
+  variableName: string,
+  properties: readonly string[],
+): Array<Record<string, string>> => {
+  const sourceFile = ts.createSourceFile(
+    'catalog.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  )
+
+  // Find the array-literal declaration ANYWHERE in the tree, not only among top-level statements — a
+  // repo may declare the catalog inside a function, module, or block (fleet-upstream #120). Require the
+  // initializer to BE an array literal, so a same-named non-array binding (e.g.
+  // `const permissions = buildPermissions()`) doesn't shadow the literal we actually want (#54 review).
+  let initializer: ts.ArrayLiteralExpression | undefined
+  const visit = (node: ts.Node): void => {
+    if (initializer) return
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === variableName &&
+      node.initializer
+    ) {
+      const unwrapped = unwrapExpression(node.initializer)
+      if (ts.isArrayLiteralExpression(unwrapped)) {
+        initializer = unwrapped
+        return
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+
+  if (!initializer) return []
+
+  return initializer.elements.flatMap(element => {
+    const value = unwrapExpression(element)
+    if (!ts.isObjectLiteralExpression(value)) return []
+    const entry: Record<string, string> = {}
+    for (const member of value.properties) {
+      if (!ts.isPropertyAssignment(member)) continue
+      const name =
+        ts.isIdentifier(member.name) || ts.isStringLiteral(member.name) ? member.name.text : ''
+      if (!properties.includes(name)) continue
+      const propertyValue = unwrapExpression(member.initializer)
+      if (ts.isStringLiteral(propertyValue) || ts.isNoSubstitutionTemplateLiteral(propertyValue)) {
+        entry[name] = propertyValue.text
+      }
+    }
+    return properties.every(property => entry[property]) ? [entry] : []
+  })
+}
+
+/**
+ * Evidence that an operation answers "is this row yours" rather than "do you hold permission X":
+ * it takes the caller, or reaches for the caller's identity when querying. Mirrors the anchor the
+ * resolver-scope review uses.
+ */
+const CALLER_SCOPE_ANCHOR =
+  /@CtxUser\s*\(\)|@CtxOrganization\s*\(\)|\buser\.(?:id|organizationId|currentOrganizationId)\b|currentUser|organizationScoped/i
+
+export type UndeclaredAccessOperation = {
+  className: string
+  name: string
+  line: number
+  /** The operation takes the caller and scopes its data access to them. */
+  callerScoped: boolean
+}
+
+/**
+ * Guarded API operations that declare no permission — neither on the method nor class-wide.
+ *
+ * Authentication says *someone* is calling; it never says *this* caller may do *this*. Many
+ * operations legitimately need nothing more (anything acting on the caller's own row), but the
+ * repo cannot tell "deliberately self-service" from "forgotten" unless every one of them is
+ * written down. That is what this feeds: declare a permission, or record the exemption and why.
+ *
+ * Unauthenticated operations are out of scope — they are governed by the public-operations
+ * allowlist, which already demands a reason for each.
+ */
+export const getUndeclaredAccessOperations = (
+  source: string,
+  fileName = 'source.ts',
+  isGuarded: (operationName: string) => boolean = () => true,
+): UndeclaredAccessOperation[] => {
+  const { declarations, operations } = analyzeAccessPolicies(source, fileName)
+  const classWide = declarations.some(declaration => declaration.name === '(class)')
+  if (classWide) return []
+
+  const declared = new Set(declarations.map(declaration => declaration.name))
+
+  return operations
+    .filter(operation => !declared.has(operation.name) && isGuarded(operation.name))
+    .map(operation => ({
+      className: operation.className,
+      name: operation.name,
+      line: operation.line,
+      callerScoped: operation.callerScoped,
+    }))
+}
+
+export const analyzeAccessPolicies = (source: string, fileName = 'source.ts') => {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  )
+  const declarations: AccessPolicyDeclaration[] = []
+  const inlineViolations: InlineAccessCheckViolation[] = []
+  const operations: UndeclaredAccessOperation[] = []
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isClassDeclaration(statement) || !isApiClass(statement)) continue
+    const className = statement.name?.text ?? '(anonymous class)'
+    const classPolicies = policyDeclarations(
+      decoratorsOf(statement),
+      sourceFile,
+      className,
+      '(class)',
+    )
+    declarations.push(...classPolicies)
+
+    for (const member of statement.members) {
+      if (!ts.isMethodDeclaration(member) || !isApiOperation(member)) continue
+      const name = methodName(member, sourceFile)
+      const methodPolicies = policyDeclarations(decoratorsOf(member), sourceFile, className, name)
+      declarations.push(...methodPolicies)
+      // Whole method text, parameters included: @CtxUser() is a PARAMETER decorator, so any
+      // detection that reads only the method's own decorators or its body misses it.
+      operations.push({
+        className,
+        name,
+        line: sourceFile.getLineAndCharacterOfPosition(member.name.getStart(sourceFile)).line + 1,
+        callerScoped: CALLER_SCOPE_ANCHOR.test(member.getText(sourceFile)),
+      })
+
+      const calls = calledAccessHelpers(member)
+      if (calls.length > 0 && classPolicies.length === 0 && methodPolicies.length === 0) {
+        inlineViolations.push({
+          calls,
+          className,
+          line: sourceFile.getLineAndCharacterOfPosition(member.name.getStart(sourceFile)).line + 1,
+          name,
+        })
+      }
+    }
+  }
+
+  return { declarations, inlineViolations, operations }
+}

--- a/doctor/src/doctor-auth-analysis.spec.ts
+++ b/doctor/src/doctor-auth-analysis.spec.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import {
+  declaresAuthLevel,
+  getAuthOperations,
+  getGuardRank,
+  getOperationGuardNames,
+  hasAuthenticationGuard,
+} from './doctor-auth-analysis'
+
+describe('getAuthOperations', () => {
+  it('attributes class-level access declarations and guards to every REST route', () => {
+    const operations = getAuthOperations(`
+      @Authenticated()
+      @UseGuards(
+        GqlAuthGuard,
+        GqlThrottlerGuard,
+      )
+      @Controller('reports')
+      export class ReportsController {
+        @Get()
+        list() {}
+
+        @Post(':id')
+        @AdminOnly()
+        @UseGuards(GqlAuthAdminGuard)
+        update() {}
+
+        helper() {}
+      }
+    `)
+
+    expect(operations).toHaveLength(2)
+    expect(operations[0]).toMatchObject({
+      className: 'ReportsController',
+      kind: 'http',
+      name: 'list',
+    })
+    expect(operations[0].classDecorators).toContain('@Authenticated()')
+    expect(operations[0].classDecorators).toContain('GqlAuthGuard')
+    expect(operations[1].decorators).toContain('@AdminOnly()')
+    expect(operations[1].decorators).toContain('GqlAuthAdminGuard')
+    expect(operations.every(declaresAuthLevel)).toBe(true)
+    expect(operations.every(hasAuthenticationGuard)).toBe(true)
+    expect(getOperationGuardNames(operations[1])).toEqual([
+      'GqlAuthAdminGuard',
+      'GqlAuthGuard',
+      'GqlThrottlerGuard',
+    ])
+  })
+
+  it('keeps access metadata isolated when a file contains multiple classes', () => {
+    const operations = getAuthOperations(`
+      @Public()
+      @Controller('public')
+      class PublicController {
+        @Get()
+        publicRoute() {}
+      }
+
+      @Controller('private')
+      class PrivateController {
+        @Delete(':id')
+        privateRoute() {}
+      }
+    `)
+
+    expect(operations.map(operation => operation.name)).toEqual(['publicRoute', 'privateRoute'])
+    expect(operations[0].classDecorators).toContain('@Public()')
+    expect(operations[1].classDecorators).not.toContain('@Public()')
+    expect(declaresAuthLevel(operations[0])).toBe(true)
+    expect(declaresAuthLevel(operations[1])).toBe(false)
+    expect(hasAuthenticationGuard(operations[1])).toBe(false)
+  })
+
+  it('recognizes GraphQL and every supported Nest HTTP method decorator', () => {
+    const operations = getAuthOperations(`
+      @Resolver(() => User)
+      class UserResolver {
+        @Query(() => User)
+        user() {}
+      }
+
+      @Controller('health')
+      class HealthController {
+        @Options()
+        options() {}
+
+        @Head()
+        head() {}
+
+        @Sse('events')
+        events() {}
+      }
+    `)
+
+    expect(operations.map(operation => [operation.kind, operation.name])).toEqual([
+      ['graphql', 'user'],
+      ['http', 'options'],
+      ['http', 'head'],
+      ['http', 'events'],
+    ])
+  })
+
+  it('does not count a throttler as authentication', () => {
+    const [operation] = getAuthOperations(`
+      @Controller('login')
+      class LoginController {
+        @Public()
+        @UseGuards(GqlThrottlerGuard)
+        @Post()
+        login() {}
+      }
+    `)
+
+    expect(declaresAuthLevel(operation)).toBe(true)
+    expect(getOperationGuardNames(operation)).toEqual(['GqlThrottlerGuard'])
+    expect(hasAuthenticationGuard(operation)).toBe(false)
+    expect(getGuardRank(['GqlAuthGuard'])).toBe(1)
+    expect(getGuardRank(['GqlAuthGuard', 'GqlThrottlerGuard'])).toBe(1)
+    expect(getGuardRank(['GqlThrottlerGuard'])).toBe(0)
+  })
+
+  it('parses nested guard calls and property-access decorators through the AST', () => {
+    const [operation] = getAuthOperations(`
+      @auth.Authenticated()
+      @nest.UseGuards(AuthGuard('jwt'), guards.RolesGuard)
+      @nest.Controller('reports')
+      class ReportsController {
+        @nest.Get()
+        list() {}
+      }
+    `)
+
+    expect(declaresAuthLevel(operation)).toBe(true)
+    expect(getOperationGuardNames(operation)).toEqual(['AuthGuard', 'RolesGuard'])
+    expect(hasAuthenticationGuard(operation)).toBe(true)
+  })
+
+  it('understands that scoped policy decorators compose authentication and enforcement', () => {
+    const operations = getAuthOperations(`
+      @Resolver()
+      class AccessResolver {
+        @Query(() => [String])
+        @RequirePlatformPermission('platform.users.read')
+        platformUsers() {}
+
+        @Mutation(() => Boolean)
+        @RequireOrganizationPermission(['member:update'], {
+          organizationIdPath: 'input.organizationId',
+        })
+        updateMember() {}
+      }
+    `)
+
+    expect(operations.every(declaresAuthLevel)).toBe(true)
+    expect(operations.every(hasAuthenticationGuard)).toBe(true)
+    expect(getOperationGuardNames(operations[0])).toEqual(['AccessPolicyGuard', 'GqlAuthGuard'])
+    expect(getGuardRank(getOperationGuardNames(operations[0]))).toBe(3)
+  })
+})

--- a/doctor/src/doctor-auth-analysis.ts
+++ b/doctor/src/doctor-auth-analysis.ts
@@ -1,0 +1,171 @@
+import ts from 'typescript'
+import {
+  decoratorName as getDecoratorName,
+  decoratorsOf as getDecorators,
+} from './doctor-typescript-analysis'
+
+export type AuthOperationKind = 'graphql' | 'http'
+
+export type AuthOperation = {
+  authLevelDeclared: boolean
+  classDecorators: string
+  className: string
+  decorators: string
+  guardNames: string[]
+  kind: AuthOperationKind
+  line: number
+  name: string
+}
+
+const graphqlOperationDecorators = new Set(['Mutation', 'Query', 'ResolveField', 'Subscription'])
+
+const httpOperationDecorators = new Set([
+  'All',
+  'Delete',
+  'Get',
+  'Head',
+  'Options',
+  'Patch',
+  'Post',
+  'Put',
+  'Sse',
+])
+
+const accessPolicyDecorators = new Set([
+  'RequirePlatformPermission',
+  'RequireAllPlatformPermissions',
+  'RequireOrganizationPermission',
+  'RequireAllOrganizationPermissions',
+])
+const authLevelDecorators = new Set([
+  'Public',
+  'Authenticated',
+  'AdminOnly',
+  ...accessPolicyDecorators,
+])
+const nonAuthGuardPattern = /Throttler|RateLimit/
+const guardNamePattern = /^[A-Z]\w*Guard$/
+
+const getDecoratorSource = (
+  decorators: readonly ts.Decorator[],
+  sourceFile: ts.SourceFile,
+): string => decorators.map(decorator => decorator.getText(sourceFile)).join('\n')
+
+const getClassKind = (decoratorNames: Set<string>): AuthOperationKind | undefined => {
+  if (decoratorNames.has('Controller')) return 'http'
+  if (decoratorNames.has('Resolver')) return 'graphql'
+  return undefined
+}
+
+const isOperationDecorator = (name: string, kind: AuthOperationKind): boolean =>
+  kind === 'http' ? httpOperationDecorators.has(name) : graphqlOperationDecorators.has(name)
+
+const getMethodName = (method: ts.MethodDeclaration, sourceFile: ts.SourceFile): string => {
+  if (ts.isIdentifier(method.name) || ts.isStringLiteral(method.name)) return method.name.text
+  return method.name.getText(sourceFile)
+}
+
+const collectGuardNames = (node: ts.Node, guards: Set<string>) => {
+  if (ts.isIdentifier(node) && guardNamePattern.test(node.text)) {
+    guards.add(node.text)
+  }
+  ts.forEachChild(node, child => collectGuardNames(child, guards))
+}
+
+const getGuardNames = (decorators: readonly ts.Decorator[]): string[] => {
+  const guards = new Set<string>()
+
+  for (const decorator of decorators) {
+    const decoratorName = getDecoratorName(decorator)
+    if (accessPolicyDecorators.has(decoratorName)) {
+      guards.add('GqlAuthGuard')
+      guards.add('AccessPolicyGuard')
+      continue
+    }
+    if (decoratorName !== 'UseGuards') continue
+    if (!ts.isCallExpression(decorator.expression)) continue
+
+    for (const argument of decorator.expression.arguments) {
+      collectGuardNames(argument, guards)
+    }
+  }
+
+  return [...guards].sort((left, right) => left.localeCompare(right))
+}
+
+const hasAuthLevelDecorator = (decorators: readonly ts.Decorator[]): boolean =>
+  decorators.some(decorator => authLevelDecorators.has(getDecoratorName(decorator)))
+
+export const isAuthenticationGuardName = (guard: string): boolean =>
+  !nonAuthGuardPattern.test(guard)
+
+export const getGuardRank = (guards: string[]): number => {
+  const authenticationGuards = guards.filter(isAuthenticationGuardName)
+  if (authenticationGuards.includes('AccessPolicyGuard')) return 3
+  if (authenticationGuards.includes('GqlAuthAdminGuard')) return 3
+  if (authenticationGuards.some(guard => guard.includes('Scoped') || guard.includes('Owner'))) {
+    return 2
+  }
+  if (authenticationGuards.includes('GqlAuthGuard')) return 1
+  return authenticationGuards.length > 0 ? 1 : 0
+}
+
+export const getOperationGuardNames = (operation: AuthOperation): string[] => operation.guardNames
+
+export const hasAuthenticationGuard = (operation: AuthOperation): boolean =>
+  operation.guardNames.some(isAuthenticationGuardName)
+
+export const declaresAuthLevel = (operation: AuthOperation): boolean => operation.authLevelDeclared
+
+export const getAuthOperations = (source: string, fileName = 'source.ts'): AuthOperation[] => {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  )
+  const operations: AuthOperation[] = []
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isClassDeclaration(statement)) continue
+
+    const classDecorators = getDecorators(statement)
+    const classDecoratorNames = new Set(classDecorators.map(getDecoratorName))
+    const kind = getClassKind(classDecoratorNames)
+    if (!kind) continue
+
+    const className = statement.name?.text ?? '(anonymous class)'
+    const classDecoratorSource = getDecoratorSource(classDecorators, sourceFile)
+    const classGuardNames = getGuardNames(classDecorators)
+    const classDeclaresAuthLevel = hasAuthLevelDecorator(classDecorators)
+
+    for (const member of statement.members) {
+      if (!ts.isMethodDeclaration(member)) continue
+
+      const methodDecorators = getDecorators(member)
+      if (
+        !methodDecorators.some(decorator => isOperationDecorator(getDecoratorName(decorator), kind))
+      ) {
+        continue
+      }
+
+      const line =
+        sourceFile.getLineAndCharacterOfPosition(member.name.getStart(sourceFile)).line + 1
+      operations.push({
+        authLevelDeclared: classDeclaresAuthLevel || hasAuthLevelDecorator(methodDecorators),
+        classDecorators: classDecoratorSource,
+        className,
+        decorators: getDecoratorSource(methodDecorators, sourceFile),
+        guardNames: [...new Set([...classGuardNames, ...getGuardNames(methodDecorators)])].sort(
+          (left, right) => left.localeCompare(right),
+        ),
+        kind,
+        line,
+        name: getMethodName(member, sourceFile),
+      })
+    }
+  }
+
+  return operations
+}

--- a/doctor/src/doctor-crud-boundary-analysis.spec.ts
+++ b/doctor/src/doctor-crud-boundary-analysis.spec.ts
@@ -1,0 +1,400 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getCrudAuthAnnotationLines,
+  getCustomResolverNameViolations,
+  getGeneratedCrudImportViolations,
+  getGraphqlRootFieldNames,
+  getLegacyCoreHelpersImportViolations,
+  getNonAdminOperationViolations,
+  getNonAuthenticatedOperationViolations,
+  getInlineClientGeneratedCrudViolations,
+  getPublicSdkGeneratedCrudViolations,
+  isHandwrittenApiFile,
+  supportsAdminOnlyGeneratorBoundary,
+} from './doctor-crud-boundary-analysis'
+
+describe('generated CRUD boundary analysis', () => {
+  it('requires the strict-compatible Generator 3 admin-only contract', () => {
+    expect(supportsAdminOnlyGeneratorBoundary('2.0.0')).toBe(false)
+    expect(supportsAdminOnlyGeneratorBoundary('3.0.0')).toBe(false)
+    expect(supportsAdminOnlyGeneratorBoundary('3.0.1')).toBe(false)
+    expect(supportsAdminOnlyGeneratorBoundary('3.0.2')).toBe(false)
+    expect(supportsAdminOnlyGeneratorBoundary('3.0.3')).toBe(true)
+    expect(supportsAdminOnlyGeneratorBoundary('3.1.0')).toBe(true)
+    expect(supportsAdminOnlyGeneratorBoundary('4.1.0-beta.1')).toBe(true)
+    expect(supportsAdminOnlyGeneratorBoundary('workspace:*')).toBe(false)
+  })
+
+  it('rejects generated CRUD imports from application API code', () => {
+    const violations = getGeneratedCrudImportViolations(`
+      import type { ListUserInput } from '@example/api/generated-crud/data-access'
+      const service = require('@example/api/generated-crud/feature')
+    `)
+
+    expect(violations).toHaveLength(2)
+    expect(violations[0].message).toContain('explicit input and Prisma query')
+    expect(violations[0].message).toContain('no admin-only exception')
+  })
+
+  it('does not reject the normal explicit Prisma data-access wrapper', () => {
+    expect(
+      getGeneratedCrudImportViolations(`
+        import { ApiCoreDataAccessService } from '@example/api/core/data-access'
+      `),
+    ).toEqual([])
+  })
+
+  it('classifies handwritten API files with POSIX and Windows separators', () => {
+    expect(isHandwrittenApiFile('libs/api/custom/src/lib/user.resolver.ts')).toBe(true)
+    expect(isHandwrittenApiFile('libs\\api\\custom\\src\\lib\\user.resolver.ts')).toBe(true)
+    expect(isHandwrittenApiFile('apps\\api\\src\\app.module.ts')).toBe(false)
+    expect(
+      isHandwrittenApiFile('libs\\api\\generated-crud\\feature\\src\\lib\\user.resolver.ts'),
+    ).toBe(false)
+    expect(isHandwrittenApiFile('libs\\api\\custom\\src\\lib\\user.resolver.spec.ts')).toBe(false)
+  })
+
+  it('rejects every form of import from the removed core-helper library', () => {
+    expect(
+      getLegacyCoreHelpersImportViolations(`
+        import { createSelect } from '@example/api/core/helpers'
+        const helpers = require('@example/api/core/helpers/testing')
+      `),
+    ).toHaveLength(2)
+  })
+
+  it('finds every deprecated crudAuth annotation', () => {
+    expect(
+      getCrudAuthAnnotationLines(`
+        /// @crudAuth: { "readOne": "user" }
+        model User {}
+        /// @crudAuth: { "readMany": "public" }
+      `),
+    ).toEqual([2, 4])
+  })
+
+  it('allows explicit admin-prefixed operations but rejects generated CRUD collisions', () => {
+    expect(
+      getCustomResolverNameViolations(
+        `
+          @Resolver(() => User)
+          class UserResolver {
+            @Mutation(() => User)
+            adminDeleteUser() {}
+
+            @Mutation(() => User)
+            updateUser() {}
+          }
+        `,
+        new Set(['updateUser', 'deleteUser']),
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        message: 'Custom resolver method "updateUser" collides with a generated CRUD field name',
+      }),
+    ])
+  })
+
+  it('rejects application SDK operations that call generated admin CRUD fields', () => {
+    const generatedFields = getGraphqlRootFieldNames(`
+      query __AdminUsers($input: ListUserInput) {
+        users(input: $input) { id }
+        count: usersCount(input: $input) { count }
+      }
+    `)
+
+    expect(
+      getPublicSdkGeneratedCrudViolations(
+        `
+          query ActiveUsers {
+            results: users(input: { filters: { isActive: { equals: true } } }) { id }
+          }
+        `,
+        generatedFields,
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        line: 3,
+        message: expect.stringContaining('ActiveUsers calls generated admin CRUD field users'),
+      }),
+    ])
+  })
+
+  it('rejects generated admin CRUD fields behind root-level inline fragments', () => {
+    expect(
+      getPublicSdkGeneratedCrudViolations(
+        `
+          query ActiveUsers {
+            ... on Query {
+              users { id }
+            }
+          }
+        `,
+        new Set(['users']),
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        line: 4,
+        message: expect.stringContaining('ActiveUsers calls generated admin CRUD field users'),
+      }),
+    ])
+  })
+
+  it('rejects generated admin CRUD fields behind root-level named fragments', () => {
+    expect(
+      getPublicSdkGeneratedCrudViolations(
+        `
+          query ActiveUsers {
+            ...GeneratedUsers
+          }
+          fragment GeneratedUsers on Query {
+            users { id }
+          }
+        `,
+        new Set(['users']),
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        line: 3,
+        message: expect.stringContaining('ActiveUsers calls generated admin CRUD field users'),
+      }),
+    ])
+  })
+
+  it('rejects generated admin CRUD fields from root fragments in another SDK file', () => {
+    expect(
+      getPublicSdkGeneratedCrudViolations(
+        `
+          query ActiveUsers {
+            ...GeneratedUsers
+          }
+        `,
+        new Set(['users']),
+        [
+          `
+            fragment GeneratedUsers on Query {
+              users { id }
+            }
+          `,
+        ],
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        line: 3,
+        message: expect.stringContaining('ActiveUsers calls generated admin CRUD field users'),
+      }),
+    ])
+  })
+
+  it('accepts purpose-built application SDK operations and fragments', () => {
+    const generatedFields = new Set(['users', 'usersCount', 'updateUser'])
+    expect(
+      getPublicSdkGeneratedCrudViolations(
+        `
+          query MyProfile { me { ...UserDetails } }
+          mutation UpdateMyProfile($input: UpdateMyProfileInput!) {
+            updateMyProfile(input: $input) { ...UserDetails }
+          }
+          fragment UserDetails on User { id }
+        `,
+        generatedFields,
+      ),
+    ).toEqual([])
+  })
+
+  it('accepts class-level admin protection for every resolver operation', () => {
+    expect(
+      getNonAdminOperationViolations(`
+        @Resolver(() => Email)
+        @UseGuards(GqlAuthAdminGuard)
+        @AdminOnly()
+        class AdminEmailResolver {
+          @Mutation(() => Email)
+          update() {}
+        }
+      `),
+    ).toEqual([])
+  })
+
+  it('reports both a missing admin guard and missing admin declaration', () => {
+    const violations = getNonAdminOperationViolations(`
+      @Resolver(() => User)
+      class UserResolver {
+        @Query(() => User)
+        @UseGuards(GqlAuthGuard)
+        @Authenticated()
+        user() {}
+      }
+    `)
+
+    expect(violations.map(violation => violation.message)).toEqual([
+      'UserResolver.user must use GqlAuthAdminGuard',
+      'UserResolver.user must declare @AdminOnly()',
+    ])
+  })
+})
+
+describe('getInlineClientGeneratedCrudViolations', () => {
+  const generatedRootFields = new Set(['plans', 'subscriptions', 'subscriptionsCount'])
+
+  it('reports a generated CRUD root queried from an inline gql template', () => {
+    const violations = getInlineClientGeneratedCrudViolations(
+      `
+        const DOC = gql\`
+          query AdminPlans {
+            plans {
+              id
+            }
+          }
+        \`
+      `,
+      generatedRootFields,
+      'apps/web/app/routes/admin/billing/_index.tsx',
+    )
+
+    expect(violations).toHaveLength(1)
+    expect(violations[0].message).toContain('plans')
+  })
+
+  // The bug this check exists for: a .tsx parsed as ScriptKind.TS is a syntax-error tree that
+  // walks as EMPTY, so the files most likely to hold an inline document scanned clean.
+  it('sees inline documents in a .tsx file containing JSX', () => {
+    const violations = getInlineClientGeneratedCrudViolations(
+      `
+        const DOC = gql\`
+          query AdminSubscriptions {
+            subscriptions {
+              id
+            }
+          }
+        \`
+        export function Page() {
+          return <div className="p-4">{DOC ? <span>ok</span> : null}</div>
+        }
+      `,
+      generatedRootFields,
+      'apps/web/app/routes/admin/billing/subscriptions.tsx',
+    )
+
+    expect(violations).toHaveLength(1)
+    expect(violations[0].message).toContain('subscriptions')
+  })
+
+  it('reports every generated root in one document', () => {
+    const violations = getInlineClientGeneratedCrudViolations(
+      `
+        const DOC = gql\`
+          query AdminSubscriptions {
+            subscriptions {
+              id
+            }
+            subscriptionsCount {
+              total
+            }
+          }
+        \`
+      `,
+      generatedRootFields,
+      'page.tsx',
+    )
+
+    expect(violations).toHaveLength(2)
+  })
+
+  it('ignores documents that call no generated root', () => {
+    expect(
+      getInlineClientGeneratedCrudViolations(
+        `
+          const DOC = gql\`
+            query AdminBillingPlans {
+              adminBillingPlans {
+                id
+              }
+            }
+          \`
+        `,
+        generatedRootFields,
+        'page.tsx',
+      ),
+    ).toEqual([])
+  })
+
+  it('ignores tagged templates that are not gql', () => {
+    expect(
+      getInlineClientGeneratedCrudViolations(
+        'const styles = css`.plans { color: red }`',
+        generatedRootFields,
+        'page.tsx',
+      ),
+    ).toEqual([])
+  })
+
+  it('skips an interpolated template that is not a document on its own', () => {
+    expect(() =>
+      getInlineClientGeneratedCrudViolations(
+        'const DOC = gql`${FRAGMENT} not a document`',
+        generatedRootFields,
+        'page.tsx',
+      ),
+    ).not.toThrow()
+  })
+
+  it('reports at the line the tagged template starts on', () => {
+    const violations = getInlineClientGeneratedCrudViolations(
+      ['// leading comment', '', 'const DOC = gql`', '  query A { plans { id } }', '`'].join('\n'),
+      generatedRootFields,
+      'page.tsx',
+    )
+
+    expect(violations[0].line).toBe(3)
+  })
+})
+
+describe('getNonAuthenticatedOperationViolations', () => {
+  it('accepts a resolver carrying GqlAuthGuard and @Authenticated', () => {
+    expect(
+      getNonAuthenticatedOperationViolations(`
+        @Resolver(() => User)
+        @UseGuards(GqlAuthGuard)
+        @Authenticated()
+        class GeneratedUserResolver {
+          @Query(() => User)
+          user() {}
+        }
+      `),
+    ).toEqual([])
+  })
+
+  // A repo at `authenticated` posture is mid-migration, not unprotected — an operation with no
+  // guard at all is still drift and must still be reported.
+  it('reports an operation with no guard at all', () => {
+    const violations = getNonAuthenticatedOperationViolations(`
+      @Resolver(() => User)
+      class GeneratedUserResolver {
+        @Query(() => User)
+        user() {}
+      }
+    `)
+
+    expect(violations.map(violation => violation.message)).toEqual([
+      'GeneratedUserResolver.user must use GqlAuthGuard (or the stricter GqlAuthAdminGuard) while generated-crud posture is authenticated',
+      'GeneratedUserResolver.user must declare @Authenticated() (or the stricter @AdminOnly()) while generated-crud posture is authenticated',
+    ])
+  })
+
+  // The stricter tier is never drift against the looser one: a repo part-way through restoring
+  // admin should not be nagged for the operations it has already restored.
+  it('accepts an operation that is still admin-only', () => {
+    expect(
+      getNonAuthenticatedOperationViolations(`
+        @Resolver(() => User)
+        @UseGuards(GqlAuthAdminGuard)
+        @AdminOnly()
+        class GeneratedUserResolver {
+          @Query(() => User)
+          user() {}
+        }
+      `),
+    ).toEqual([])
+  })
+})

--- a/doctor/src/doctor-crud-boundary-analysis.ts
+++ b/doctor/src/doctor-crud-boundary-analysis.ts
@@ -1,0 +1,374 @@
+import ts from 'typescript'
+import {
+  GraphQLError,
+  Kind,
+  parse,
+  type FragmentDefinitionNode,
+  type SelectionSetNode,
+} from 'graphql'
+import { getAuthOperations } from './doctor-auth-analysis'
+
+export type CrudBoundaryViolation = {
+  line: number
+  message: string
+}
+
+type ModuleReference = {
+  line: number
+  moduleName: string
+}
+
+// Script kind follows the extension: parsing a .tsx file as TS makes every JSX construct a syntax
+// error, and `createSourceFile` does not throw — it returns a tree the walkers traverse as empty.
+// A hardcoded TS kind therefore reads as "nothing to report" on exactly the client files most
+// likely to hold an inline GraphQL document.
+const sourceFileFor = (source: string, fileName: string): ts.SourceFile =>
+  ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    fileName.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  )
+
+const lineFor = (sourceFile: ts.SourceFile, node: ts.Node): number =>
+  sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1
+
+const moduleNameFrom = (node: ts.Expression | undefined): string | undefined =>
+  node && ts.isStringLiteralLike(node) ? node.text : undefined
+
+const getModuleReferences = (source: string, fileName: string): ModuleReference[] => {
+  const sourceFile = sourceFileFor(source, fileName)
+  const references: ModuleReference[] = []
+
+  const addReference = (node: ts.Node, expression: ts.Expression | undefined) => {
+    const moduleName = moduleNameFrom(expression)
+    if (moduleName) references.push({ line: lineFor(sourceFile, node), moduleName })
+  }
+
+  const visit = (node: ts.Node) => {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      addReference(node, node.moduleSpecifier)
+    } else if (
+      ts.isCallExpression(node) &&
+      (node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(node.expression) && node.expression.text === 'require'))
+    ) {
+      addReference(node, node.arguments[0])
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return references
+}
+
+const isGeneratedCrudModule = (moduleName: string): boolean =>
+  moduleName.includes('/generated-crud/') || moduleName.endsWith('/generated-crud')
+
+export const isHandwrittenApiFile = (filePath: string): boolean => {
+  const normalizedPath = filePath.replaceAll('\\', '/')
+
+  return (
+    normalizedPath.endsWith('.ts') &&
+    normalizedPath !== 'apps/api/src/app.module.ts' &&
+    !normalizedPath.includes('libs/api/generated-crud/') &&
+    !normalizedPath.endsWith('.spec.ts') &&
+    !normalizedPath.endsWith('.test.ts')
+  )
+}
+
+export const supportsAdminOnlyGeneratorBoundary = (version: string): boolean => {
+  const versionMatch = /^(\d+)\.(\d+)\.(\d+)/.exec(version)
+  if (versionMatch === null) return false
+
+  const [, major, minor, patch] = versionMatch.map(Number)
+  return major > 3 || (major === 3 && (minor > 0 || (minor === 0 && patch >= 3)))
+}
+
+export const getGraphqlRootFieldNames = (source: string): Set<string> => {
+  const names = new Set<string>()
+
+  for (const definition of parse(source).definitions) {
+    if (definition.kind !== Kind.OPERATION_DEFINITION) continue
+    for (const selection of definition.selectionSet.selections) {
+      if (selection.kind === Kind.FIELD) names.add(selection.name.value)
+    }
+  }
+
+  return names
+}
+
+type RootFieldAnalysis = {
+  fragments: ReadonlyMap<string, FragmentDefinitionNode>
+  generatedRootFields: ReadonlySet<string>
+  operationName: string
+  operationSource: string
+  violations: CrudBoundaryViolation[]
+}
+
+const lineAtOffset = (source: string, offset: number): number =>
+  source.slice(0, offset).split('\n').length
+
+const getFragments = (sources: readonly string[]): Map<string, FragmentDefinitionNode> => {
+  const fragments = new Map<string, FragmentDefinitionNode>()
+
+  for (const source of sources) {
+    for (const definition of parse(source).definitions) {
+      if (definition.kind === Kind.FRAGMENT_DEFINITION) {
+        fragments.set(definition.name.value, definition)
+      }
+    }
+  }
+
+  return fragments
+}
+
+const addGeneratedRootFieldViolation = (
+  fieldName: string,
+  offset: number,
+  analysis: RootFieldAnalysis,
+) => {
+  analysis.violations.push({
+    line: lineAtOffset(analysis.operationSource, offset),
+    message:
+      `Application SDK operation ${analysis.operationName} calls generated admin CRUD field ` +
+      `${fieldName}; use the generated __Admin* document or call an explicit application resolver`,
+  })
+}
+
+const checkRootSelections = (
+  selectionSet: SelectionSetNode,
+  analysis: RootFieldAnalysis,
+  fragmentPath: ReadonlySet<string>,
+  reportOffset?: number,
+) => {
+  for (const selection of selectionSet.selections) {
+    if (selection.kind === Kind.FIELD) {
+      if (analysis.generatedRootFields.has(selection.name.value)) {
+        addGeneratedRootFieldViolation(
+          selection.name.value,
+          reportOffset ?? selection.loc?.start ?? 0,
+          analysis,
+        )
+      }
+      continue
+    }
+
+    if (selection.kind === Kind.INLINE_FRAGMENT) {
+      checkRootSelections(selection.selectionSet, analysis, fragmentPath, reportOffset)
+      continue
+    }
+
+    const fragmentName = selection.name.value
+    const fragment = analysis.fragments.get(fragmentName)
+    if (!fragment || fragmentPath.has(fragmentName)) continue
+
+    const nextPath = new Set(fragmentPath)
+    nextPath.add(fragmentName)
+    const nextReportOffset = reportOffset ?? selection.loc?.start ?? 0
+    checkRootSelections(fragment.selectionSet, analysis, nextPath, nextReportOffset)
+  }
+}
+
+export const getPublicSdkGeneratedCrudViolations = (
+  source: string,
+  generatedRootFields: ReadonlySet<string>,
+  fragmentSources: readonly string[] = [],
+): CrudBoundaryViolation[] => {
+  const violations: CrudBoundaryViolation[] = []
+  const document = parse(source)
+  const fragments = getFragments([source, ...fragmentSources])
+
+  for (const definition of document.definitions) {
+    if (definition.kind !== Kind.OPERATION_DEFINITION) continue
+    checkRootSelections(
+      definition.selectionSet,
+      {
+        fragments,
+        generatedRootFields,
+        operationName: definition.name?.value ?? '(anonymous operation)',
+        operationSource: source,
+        violations,
+      },
+      new Set(),
+    )
+  }
+
+  return violations
+}
+
+const flattenGqlTemplate = (template: ts.TemplateLiteral): string =>
+  ts.isNoSubstitutionTemplateLiteral(template)
+    ? template.text
+    : [template.head.text, ...template.templateSpans.map(span => span.literal.text)].join(' ')
+
+/**
+ * Generated-CRUD roots called from GraphQL written inline in client code as `gql\`...\`` — the
+ * same boundary `getPublicSdkGeneratedCrudViolations` enforces over SDK `.graphql` documents.
+ *
+ * Without this, a route or component can query a generated CRUD root straight from the browser and
+ * the check stays green, because it only ever read the SDK documents. That is not hypothetical: it
+ * is how a Billing page reached the generated `plans` / `subscriptions` / `subscriptionsCount`
+ * roots with no boundary finding.
+ *
+ * An inline template that does not parse as GraphQL is skipped rather than thrown on: interpolated
+ * documents flatten to text that is often not a valid document on its own, and a boundary check
+ * must not be the thing that crashes the doctor. That fails toward not reporting — the same
+ * direction the surrounding scans take. Only GraphQL parse failures are swallowed; any other error
+ * is a defect here and is rethrown, because silently reporting "no findings" is the worst outcome
+ * for a security check.
+ */
+export const getInlineClientGeneratedCrudViolations = (
+  source: string,
+  generatedRootFields: ReadonlySet<string>,
+  fileName = 'source.tsx',
+  fragmentSources: readonly string[] = [],
+): CrudBoundaryViolation[] => {
+  const sourceFile = sourceFileFor(source, fileName)
+  const violations: CrudBoundaryViolation[] = []
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isTaggedTemplateExpression(node) &&
+      ts.isIdentifier(node.tag) &&
+      node.tag.text === 'gql'
+    ) {
+      const line = lineFor(sourceFile, node)
+
+      try {
+        for (const violation of getPublicSdkGeneratedCrudViolations(
+          flattenGqlTemplate(node.template),
+          generatedRootFields,
+          fragmentSources,
+        )) {
+          violations.push({ line, message: violation.message })
+        }
+      } catch (error) {
+        // A document that does not parse on its own is expected (see the note above) and skipped.
+        // Anything else is a defect in this checker, and a boundary check that reports "no
+        // findings" because it crashed is worse than one that fails loudly — so rethrow.
+        if (!(error instanceof GraphQLError)) throw error
+      }
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return violations
+}
+
+export const getGeneratedCrudImportViolations = (
+  source: string,
+  fileName = 'source.ts',
+): CrudBoundaryViolation[] =>
+  getModuleReferences(source, fileName)
+    .filter(reference => isGeneratedCrudModule(reference.moduleName))
+    .map(reference => ({
+      line: reference.line,
+      message:
+        `Handwritten resolvers and services must not import generated admin CRUD (${reference.moduleName}); ` +
+        'define an explicit input and Prisma query instead; there is no admin-only exception',
+    }))
+
+export const getLegacyCoreHelpersImportViolations = (
+  source: string,
+  fileName = 'source.ts',
+): CrudBoundaryViolation[] =>
+  getModuleReferences(source, fileName)
+    .filter(reference => reference.moduleName.includes('/api/core/helpers'))
+    .map(reference => ({
+      line: reference.line,
+      message:
+        'Application API code must not import the removed core-helper library; build an explicit Prisma select instead',
+    }))
+
+export const getCrudAuthAnnotationLines = (schema: string): number[] =>
+  schema
+    .split('\n')
+    .map((line, index) => (line.includes('@crudAuth') ? index + 1 : undefined))
+    .filter((line): line is number => line !== undefined)
+
+export const getCustomResolverNameViolations = (
+  source: string,
+  generatedMethodNames: ReadonlySet<string>,
+  fileName = 'source.ts',
+): CrudBoundaryViolation[] =>
+  getAuthOperations(source, fileName)
+    .filter(operation => operation.kind === 'graphql' && generatedMethodNames.has(operation.name))
+    .map(operation => ({
+      line: operation.line,
+      message: `Custom resolver method "${operation.name}" collides with a generated CRUD field name`,
+    }))
+
+const declaresAdminOnly = (classDecorators: string, methodDecorators: string): boolean =>
+  `${classDecorators}\n${methodDecorators}`.includes('@AdminOnly')
+
+const declaresAuthenticated = (classDecorators: string, methodDecorators: string): boolean =>
+  `${classDecorators}\n${methodDecorators}`.includes('@Authenticated')
+
+/**
+ * The inverse of getNonAdminOperationViolations, for a repo that has declared generated-crud
+ * posture `authenticated`.
+ *
+ * Such a repo is mid-migration, not unprotected: its generated resolvers should carry
+ * GqlAuthGuard + @Authenticated, and an operation missing those is drift regardless of posture.
+ * Without this the doctor has nothing to say about generated CRUD in a relaxed repo — every
+ * operation reports as a violation of a rule the repo has deliberately suspended, which is how
+ * 1,213 findings buried the 195 that mattered.
+ */
+export const getNonAuthenticatedOperationViolations = (
+  source: string,
+  fileName = 'source.ts',
+): CrudBoundaryViolation[] =>
+  getAuthOperations(source, fileName).flatMap(operation => {
+    const violations: CrudBoundaryViolation[] = []
+
+    if (
+      !operation.guardNames.includes('GqlAuthGuard') &&
+      !operation.guardNames.includes('GqlAuthAdminGuard')
+    ) {
+      violations.push({
+        line: operation.line,
+        message: `${operation.className}.${operation.name} must use GqlAuthGuard (or the stricter GqlAuthAdminGuard) while generated-crud posture is authenticated`,
+      })
+    }
+
+    if (
+      !declaresAuthenticated(operation.classDecorators, operation.decorators) &&
+      !declaresAdminOnly(operation.classDecorators, operation.decorators)
+    ) {
+      violations.push({
+        line: operation.line,
+        message: `${operation.className}.${operation.name} must declare @Authenticated() (or the stricter @AdminOnly()) while generated-crud posture is authenticated`,
+      })
+    }
+
+    return violations
+  })
+
+export const getNonAdminOperationViolations = (
+  source: string,
+  fileName = 'source.ts',
+): CrudBoundaryViolation[] =>
+  getAuthOperations(source, fileName).flatMap(operation => {
+    const violations: CrudBoundaryViolation[] = []
+
+    if (!operation.guardNames.includes('GqlAuthAdminGuard')) {
+      violations.push({
+        line: operation.line,
+        message: `${operation.className}.${operation.name} must use GqlAuthAdminGuard`,
+      })
+    }
+
+    if (!declaresAdminOnly(operation.classDecorators, operation.decorators)) {
+      violations.push({
+        line: operation.line,
+        message: `${operation.className}.${operation.name} must declare @AdminOnly()`,
+      })
+    }
+
+    return violations
+  })

--- a/doctor/src/doctor-generated-crud-posture.spec.ts
+++ b/doctor/src/doctor-generated-crud-posture.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, writeFileSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -79,10 +79,21 @@ describe('readGeneratedCrudPosture', () => {
 // Nx Tree). If the generator ever changes them, the doctor would silently assert a tier the
 // generator no longer emits — so pin them against the installed package's own source.
 describe('stays in step with @nestledjs/generators', () => {
-  const generatorSource = readFileSync(
+  // The generator lives in two shapes depending on where these tests run: a dependency in a
+  // consuming repo, or the workspace source in the repo that publishes it. Check both, and fail
+  // loudly if neither is present — silently skipping would retire the drift check without saying so.
+  const generatorCandidates = [
     'node_modules/@nestledjs/generators/src/crud/generator.js',
-    'utf8',
-  )
+    '../generators/src/crud/generator.ts',
+    'generators/src/crud/generator.ts',
+  ]
+  const generatorPath = generatorCandidates.find(candidate => existsSync(candidate))
+  if (!generatorPath) {
+    throw new Error(
+      `Could not find @nestledjs/generators' crud generator in any of: ${generatorCandidates.join(', ')}`,
+    )
+  }
+  const generatorSource = readFileSync(generatorPath, 'utf8')
 
   it('uses the same posture file path', () => {
     expect(generatorSource).toContain(GENERATED_CRUD_POSTURE_PATH)

--- a/doctor/src/doctor-generated-crud-posture.spec.ts
+++ b/doctor/src/doctor-generated-crud-posture.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  GENERATED_CRUD_POSTURES,
+  GENERATED_CRUD_POSTURE_PATH,
+  readGeneratedCrudPosture,
+} from './doctor-generated-crud-posture'
+
+const writePostureFile = (contents: string): string => {
+  const file = join(mkdtempSync(join(tmpdir(), 'posture-')), 'generated-crud-posture.json')
+  writeFileSync(file, contents, 'utf8')
+  return file
+}
+
+describe('readGeneratedCrudPosture', () => {
+  it('defaults to admin when no file exists', () => {
+    expect(readGeneratedCrudPosture(join(tmpdir(), 'definitely-absent-posture.json'))).toEqual({
+      posture: 'admin',
+    })
+  })
+
+  it('reads a declared posture and its reason', () => {
+    const file = writePostureFile(
+      JSON.stringify({ posture: 'authenticated', reason: 'Emergency rollback' }),
+    )
+
+    expect(readGeneratedCrudPosture(file)).toEqual({
+      posture: 'authenticated',
+      reason: 'Emergency rollback',
+    })
+  })
+
+  it('reads an explicit admin posture', () => {
+    expect(
+      readGeneratedCrudPosture(writePostureFile(JSON.stringify({ posture: 'admin' }))),
+    ).toEqual({ posture: 'admin', reason: undefined })
+  })
+
+  // Every rejection path must land on admin. A relaxed tier may only come from a positively
+  // recognized declaration — anything else and the doctor could assert a weaker tier than the
+  // generator actually emitted.
+  it.each([
+    ['unparseable JSON', '{ not json', 'unparseable JSON'],
+    ['a JSON array', '["admin"]', 'not a JSON object'],
+    ['a JSON string', '"admin"', 'not a JSON object'],
+    ['null', 'null', 'not a JSON object'],
+    ['no posture key', '{"reason":"x"}', 'no "posture" key'],
+    ['a non-string posture', '{"posture":123}', 'a non-string posture (123)'],
+    ['an unknown posture', '{"posture":"public"}', 'an unrecognized posture "public"'],
+    ['an empty posture', '{"posture":""}', 'an unrecognized posture ""'],
+  ])('falls back to admin on %s', (_label, contents, invalid) => {
+    const reading = readGeneratedCrudPosture(writePostureFile(contents))
+
+    expect(reading.posture).toBe('admin')
+    expect(reading.invalid).toBe(invalid)
+  })
+
+  it('distinguishes an unreadable file from unparseable JSON', () => {
+    // A directory at the posture path exists but cannot be read as a file — the same shape as a
+    // permissions or transient filesystem error, and it must not be reported as bad JSON.
+    const directory = mkdtempSync(join(tmpdir(), 'posture-dir-'))
+    const reading = readGeneratedCrudPosture(directory)
+
+    expect(reading.posture).toBe('admin')
+    expect(reading.invalid).toBe('a file that exists but could not be read')
+  })
+
+  it('is case-sensitive — "Authenticated" is not a posture', () => {
+    const reading = readGeneratedCrudPosture(writePostureFile('{"posture":"Authenticated"}'))
+
+    expect(reading.posture).toBe('admin')
+    expect(reading.invalid).toContain('unrecognized')
+  })
+})
+
+// These constants are mirrored from @nestledjs/generators rather than imported (its reader takes an
+// Nx Tree). If the generator ever changes them, the doctor would silently assert a tier the
+// generator no longer emits — so pin them against the installed package's own source.
+describe('stays in step with @nestledjs/generators', () => {
+  const generatorSource = readFileSync(
+    'node_modules/@nestledjs/generators/src/crud/generator.js',
+    'utf8',
+  )
+
+  it('uses the same posture file path', () => {
+    expect(generatorSource).toContain(GENERATED_CRUD_POSTURE_PATH)
+  })
+
+  it('recognizes the same posture values', () => {
+    for (const posture of GENERATED_CRUD_POSTURES) {
+      expect(generatorSource).toContain(`'${posture}'`)
+    }
+  })
+
+  it('agrees that admin is the fallback', () => {
+    expect(generatorSource).toContain("{ posture: 'admin' }")
+  })
+})

--- a/doctor/src/doctor-generated-crud-posture.ts
+++ b/doctor/src/doctor-generated-crud-posture.ts
@@ -1,0 +1,79 @@
+import { existsSync, readFileSync } from 'node:fs'
+
+/**
+ * The guard tier the CRUD generator emits on every generated resolver.
+ *
+ * `admin` is the correct state and the default. `authenticated` exists ONLY so a repo whose
+ * application still reaches generated CRUD from non-superadmin surfaces can declare that fact
+ * deliberately, with a reason and an exit condition, instead of either shipping a rollback nobody
+ * can see or denying its own users. Declaring it is an incident, not a configuration preference.
+ *
+ * These mirror `@nestledjs/generators`' own constants. They are duplicated rather than imported
+ * because the generator's reader takes an Nx `Tree` and its module pulls in @nx/devkit and
+ * @prisma/internals — far too heavy for a doctor script. The spec asserts the two stay in step.
+ */
+export const GENERATED_CRUD_POSTURES = ['admin', 'authenticated'] as const
+
+export type GeneratedCrudPosture = (typeof GENERATED_CRUD_POSTURES)[number]
+
+export const GENERATED_CRUD_POSTURE_PATH = '.nestled-updates/security/generated-crud-posture.json'
+
+export type GeneratedCrudPostureReading = {
+  posture: GeneratedCrudPosture
+  /** Why a declared value was rejected. Absent when the file is absent or the value is valid. */
+  invalid?: string
+  /** The repo's stated reason for a non-default posture, for reporting. */
+  reason?: string
+}
+
+/**
+ * Fail-closed in every direction: a missing file, unreadable file, unparseable JSON, a missing
+ * `posture` key, a non-string, or an unrecognized value all resolve to `admin`. Only a positively
+ * recognized posture relaxes anything — matching the generator, so the doctor can never assert a
+ * weaker tier than the one actually emitted.
+ */
+export const readGeneratedCrudPosture = (
+  postureFilePath: string = GENERATED_CRUD_POSTURE_PATH,
+): GeneratedCrudPostureReading => {
+  if (!existsSync(postureFilePath)) return { posture: 'admin' }
+
+  let contents: string
+  try {
+    contents = readFileSync(postureFilePath, 'utf8')
+  } catch {
+    // Distinct from unparseable JSON on purpose: "fix the file or delete it" is the wrong advice
+    // for a permissions or transient filesystem error, and the two need different responses.
+    return { posture: 'admin', invalid: 'a file that exists but could not be read' }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(contents)
+  } catch {
+    return { posture: 'admin', invalid: 'unparseable JSON' }
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return { posture: 'admin', invalid: 'not a JSON object' }
+  }
+
+  const declared = (parsed as { posture?: unknown }).posture
+  const reason =
+    typeof (parsed as { reason?: unknown }).reason === 'string'
+      ? (parsed as { reason: string }).reason
+      : undefined
+
+  if (declared === undefined) return { posture: 'admin', invalid: 'no "posture" key', reason }
+  if (typeof declared !== 'string') {
+    return {
+      posture: 'admin',
+      invalid: `a non-string posture (${JSON.stringify(declared)})`,
+      reason,
+    }
+  }
+  if (!(GENERATED_CRUD_POSTURES as readonly string[]).includes(declared)) {
+    return { posture: 'admin', invalid: `an unrecognized posture "${declared}"`, reason }
+  }
+
+  return { posture: declared as GeneratedCrudPosture, reason }
+}

--- a/doctor/src/doctor-module-analysis.spec.ts
+++ b/doctor/src/doctor-module-analysis.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { getRegisteredModuleClasses, type NestModuleSource } from './doctor-module-analysis'
+
+const moduleSource = (file: string, source: string): NestModuleSource => ({ file, source })
+
+describe('getRegisteredModuleClasses', () => {
+  it('follows module imports transitively from the application root', () => {
+    const registered = getRegisteredModuleClasses(
+      [
+        moduleSource(
+          'apps/api/src/app.module.ts',
+          `
+            const pluginModules = [ConsumerModule] as const
+            const appModules = [...pluginModules] satisfies unknown[]
+            @Module({ imports: [...appModules] })
+            export class AppModule {}
+          `,
+        ),
+        moduleSource(
+          'libs/api/consumer.module.ts',
+          `
+            @Module({ imports: [SharedPluginModule] })
+            export class ConsumerModule {}
+          `,
+        ),
+        moduleSource(
+          'libs/api/shared-plugin.module.ts',
+          `
+            @Module({})
+            export class SharedPluginModule {}
+          `,
+        ),
+      ],
+      'apps/api/src/app.module.ts',
+    )
+
+    expect(registered).toEqual(new Set(['AppModule', 'ConsumerModule', 'SharedPluginModule']))
+  })
+
+  it('does not treat imports from a disconnected module as application registration', () => {
+    const registered = getRegisteredModuleClasses(
+      [
+        moduleSource(
+          'apps/api/src/app.module.ts',
+          `
+            @Module({ imports: [] })
+            export class AppModule {}
+          `,
+        ),
+        moduleSource(
+          'libs/api/detached.module.ts',
+          `
+            @Module({ imports: [OrphanPluginModule] })
+            export class DetachedModule {}
+          `,
+        ),
+        moduleSource(
+          'libs/api/orphan-plugin.module.ts',
+          `
+            @Module({})
+            export class OrphanPluginModule {}
+          `,
+        ),
+      ],
+      'apps/api/src/app.module.ts',
+    )
+
+    expect(registered).toEqual(new Set(['AppModule']))
+  })
+
+  it('recognizes modules passed through dynamic-module and forwardRef calls', () => {
+    const registered = getRegisteredModuleClasses(
+      [
+        moduleSource(
+          'apps/api/src/app.module.ts',
+          `
+            @Module({ imports: [ConfigModule.forRoot(), forwardRef(() => PluginModule)] })
+            export class RootApiModule {}
+          `,
+        ),
+        moduleSource(
+          'libs/api/config.module.ts',
+          `
+            @Module({})
+            export class ConfigModule {}
+          `,
+        ),
+        moduleSource(
+          'libs/api/plugin.module.ts',
+          `
+            @Module({})
+            export class PluginModule {}
+          `,
+        ),
+      ],
+      'apps/api/src/app.module.ts',
+    )
+
+    expect(registered).toEqual(new Set(['RootApiModule', 'ConfigModule', 'PluginModule']))
+  })
+})

--- a/doctor/src/doctor-module-analysis.ts
+++ b/doctor/src/doctor-module-analysis.ts
@@ -1,0 +1,137 @@
+import ts from 'typescript'
+import { decoratorName, decoratorsOf, unwrapExpression } from './doctor-typescript-analysis'
+
+export type NestModuleSource = {
+  file: string
+  source: string
+}
+
+type NestModuleDeclaration = {
+  className: string
+  importedNames: Set<string>
+}
+
+const propertyName = (property: ts.ObjectLiteralElementLike): string => {
+  if (!('name' in property) || !property.name) return ''
+  if (ts.isIdentifier(property.name) || ts.isStringLiteral(property.name)) {
+    return property.name.text
+  }
+  return ''
+}
+
+const getArrayDeclarations = (
+  sourceFile: ts.SourceFile,
+): Map<string, ts.ArrayLiteralExpression> => {
+  const arrays = new Map<string, ts.ArrayLiteralExpression>()
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue
+    for (const declaration of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || !declaration.initializer) continue
+      const initializer = unwrapExpression(declaration.initializer)
+      if (ts.isArrayLiteralExpression(initializer)) arrays.set(declaration.name.text, initializer)
+    }
+  }
+
+  return arrays
+}
+
+const collectReferences = (
+  node: ts.Node,
+  arrays: Map<string, ts.ArrayLiteralExpression>,
+  references: Set<string>,
+  resolvingArrays: Set<string>,
+) => {
+  if (ts.isIdentifier(node)) {
+    const array = arrays.get(node.text)
+    if (array && !resolvingArrays.has(node.text)) {
+      resolvingArrays.add(node.text)
+      collectReferences(array, arrays, references, resolvingArrays)
+      resolvingArrays.delete(node.text)
+      return
+    }
+    references.add(node.text)
+    return
+  }
+
+  ts.forEachChild(node, child => collectReferences(child, arrays, references, resolvingArrays))
+}
+
+const getModuleImports = (
+  declaration: ts.ClassDeclaration,
+  arrays: Map<string, ts.ArrayLiteralExpression>,
+): Set<string> => {
+  const references = new Set<string>()
+  const moduleDecorator = decoratorsOf(declaration).find(
+    decorator => decoratorName(decorator) === 'Module',
+  )
+  if (!moduleDecorator || !ts.isCallExpression(moduleDecorator.expression)) return references
+
+  const [rawMetadata] = moduleDecorator.expression.arguments
+  if (!rawMetadata) return references
+  const metadata = unwrapExpression(rawMetadata)
+  if (!ts.isObjectLiteralExpression(metadata)) return references
+
+  const importsProperty = metadata.properties.find(property => propertyName(property) === 'imports')
+  if (!importsProperty || !ts.isPropertyAssignment(importsProperty)) return references
+
+  collectReferences(importsProperty.initializer, arrays, references, new Set())
+  return references
+}
+
+const analyzeModuleSource = ({ file, source }: NestModuleSource): NestModuleDeclaration[] => {
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  )
+  const arrays = getArrayDeclarations(sourceFile)
+
+  return sourceFile.statements.flatMap(statement => {
+    if (!ts.isClassDeclaration(statement) || !statement.name) return []
+    if (!decoratorsOf(statement).some(decorator => decoratorName(decorator) === 'Module')) return []
+
+    return [
+      {
+        className: statement.name.text,
+        importedNames: getModuleImports(statement, arrays),
+      },
+    ]
+  })
+}
+
+/** Return Nest module classes transitively reachable from every module declared in the root file. */
+export const getRegisteredModuleClasses = (
+  sources: NestModuleSource[],
+  rootFile: string,
+): Set<string> => {
+  const declarations = sources.flatMap(analyzeModuleSource)
+  const knownClasses = new Set(declarations.map(declaration => declaration.className))
+  const importsByClass = new Map(
+    declarations.map(declaration => [
+      declaration.className,
+      [...declaration.importedNames].filter(name => knownClasses.has(name)),
+    ]),
+  )
+  const roots = sources
+    .filter(source => source.file === rootFile)
+    .flatMap(analyzeModuleSource)
+    .map(declaration => declaration.className)
+  const registered = new Set(roots)
+  const pending = [...roots]
+
+  while (pending.length > 0) {
+    const current = pending.shift()
+    if (!current) continue
+
+    for (const imported of importsByClass.get(current) ?? []) {
+      if (registered.has(imported)) continue
+      registered.add(imported)
+      pending.push(imported)
+    }
+  }
+
+  return registered
+}

--- a/doctor/src/doctor-sdk-contract-analysis.spec.ts
+++ b/doctor/src/doctor-sdk-contract-analysis.spec.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildPrismaSelectFromFragments,
+  buildPrismaSelectFromOperationPaths,
+  getSdkContractReport,
+  normalizeContractPath,
+  type DatabaseModelMetadata,
+} from './doctor-sdk-contract-analysis'
+
+const models: DatabaseModelMetadata[] = [
+  {
+    modelName: 'Group',
+    fields: [
+      { name: 'id', type: 'String' },
+      { name: 'members', type: 'GroupMember' },
+    ],
+  },
+  {
+    modelName: 'GroupMember',
+    fields: [
+      { name: 'id', type: 'String' },
+      { name: 'user', type: 'User' },
+    ],
+  },
+  {
+    modelName: 'User',
+    fields: [
+      { name: 'id', type: 'String' },
+      { name: 'displayName', type: 'String' },
+    ],
+  },
+]
+
+describe('fragment-to-select analysis', () => {
+  it('follows global fragments and skips GraphQL-only resolved fields', () => {
+    const groupSource = {
+      file: 'graphql/group/group-fragments.graphql',
+      source: `
+        fragment GroupDetails on Group {
+          id
+          friendsCount
+          members {
+            isAdmin
+            # This prose must never become Prisma select fields.
+            user { ...UserBasicInfo }
+          }
+        }
+      `,
+    }
+    const result = buildPrismaSelectFromFragments({
+      allSources: [
+        groupSource,
+        {
+          file: 'graphql/user/user-fragments.graphql',
+          source: 'fragment UserBasicInfo on User { id displayName }',
+        },
+      ],
+      models,
+      rootSources: [groupSource],
+      targetModelName: 'Group',
+    })
+
+    expect(result.select).toEqual({
+      id: true,
+      members: {
+        select: {
+          user: { select: { id: true, displayName: true } },
+        },
+      },
+    })
+    expect(result.skippedFields).toEqual(['Group.friendsCount', 'GroupMember.isAdmin'])
+    expect(result.missingFragments).toEqual([])
+  })
+
+  it('reports a missing fragment instead of emitting an empty relation select', () => {
+    const groupSource = {
+      file: 'graphql/group/group-fragments.graphql',
+      source: 'fragment GroupDetails on Group { members { user { ...MissingUser } } }',
+    }
+    const result = buildPrismaSelectFromFragments({
+      allSources: [groupSource],
+      models,
+      rootSources: [groupSource],
+      targetModelName: 'Group',
+    })
+
+    expect(result.select).toEqual({})
+    expect(result.missingFragments).toEqual(['MissingUser'])
+    expect(result.skippedFields).toEqual(['Group.members', 'GroupMember.user'])
+  })
+})
+
+describe('SDK contract analysis', () => {
+  it('normalizes Windows paths for portable baseline and exception keys', () => {
+    expect(normalizeContractPath('libs\\shared\\sdk\\src\\graphql\\user.graphql')).toBe(
+      'libs/shared/sdk/src/graphql/user.graphql',
+    )
+  })
+
+  it('reports uncovered API fields, unused SDK operations, and inline client operations', () => {
+    const report = getSdkContractReport({
+      adminSources: [],
+      applicationSources: [
+        {
+          file: 'graphql/user.graphql',
+          source: `
+            query UserProfile { profile { id } }
+            mutation UpdateProfile { updateProfile { id } }
+          `,
+        },
+      ],
+      clientSources: [
+        {
+          file: 'apps/web/profile.tsx',
+          source: `
+            import { UserProfile, type UserProfileQuery } from '@example/shared/sdk'
+            const inline = gql\`mutation InlineUpdate { hiddenUpdate }\`
+            void UserProfile
+          `,
+        },
+      ],
+      schemaSource: `
+        type User { id: ID! }
+        type Query { profile: User, hidden: User }
+        type Mutation { updateProfile: User, hiddenUpdate: Boolean }
+      `,
+    })
+
+    expect(report.apiWithoutSdk).toEqual(['hidden', 'hiddenUpdate'])
+    expect(report.sdkWithoutApi).toEqual([])
+    expect(report.sdkWithoutConsumer).toEqual([
+      expect.objectContaining({ name: 'UpdateProfile', rootFields: ['updateProfile'] }),
+    ])
+    expect(report.inlineClientOperations).toEqual([
+      expect.objectContaining({ file: 'apps/web/profile.tsx', name: 'InlineUpdate' }),
+    ])
+  })
+
+  it('reports SDK operations whose API root field no longer exists', () => {
+    const report = getSdkContractReport({
+      adminSources: [],
+      applicationSources: [
+        {
+          file: 'graphql/user.graphql',
+          source: 'query RemovedOperation { removedField }',
+        },
+      ],
+      clientSources: [],
+      schemaSource: 'type Query { activeField: String! }',
+    })
+
+    expect(report.sdkWithoutApi).toEqual([
+      {
+        file: 'graphql/user.graphql',
+        operation: 'RemovedOperation',
+        rootFields: ['removedField'],
+      },
+    ])
+  })
+})
+
+describe('operation-path select analysis', () => {
+  const sources = [
+    {
+      file: 'graphql/user/user-queries.graphql',
+      source: `
+        query Me { me { ...SelfUser } }
+        query MyFavorites { me { favorites { id } } }
+        fragment SelfUser on User { id displayName }
+      `,
+    },
+    {
+      file: 'graphql/auth/auth-mutations.graphql',
+      source: `
+        mutation Login($input: LoginInput!) { login(input: $input) { ...TokenDetails } }
+        mutation Register($input: RegisterInput!) { register(input: $input) { ...TokenDetails } }
+      `,
+    },
+    {
+      file: 'graphql/auth/auth-fragments.graphql',
+      source: 'fragment TokenDetails on UserToken { token user { id displayName } }',
+    },
+  ]
+  const pathModels: DatabaseModelMetadata[] = [
+    {
+      modelName: 'User',
+      fields: [
+        { name: 'id', type: 'String' },
+        { name: 'displayName', type: 'String' },
+        { name: 'favorites', type: 'Experience' },
+      ],
+    },
+    { modelName: 'Experience', fields: [{ name: 'id', type: 'String' }] },
+  ]
+
+  it('unions every document selecting an operation root field', () => {
+    // Me contributes the scalar pair, MyFavorites the relation — one resolver
+    // serves both documents, so the select owes the union.
+    const result = buildPrismaSelectFromOperationPaths({
+      allSources: sources,
+      models: pathModels,
+      paths: ['me'],
+      targetModelName: 'User',
+    })
+
+    expect(result.select).toEqual({
+      displayName: true,
+      favorites: { select: { id: true } },
+      id: true,
+    })
+    expect(result.matched.get('me')).toBe(2)
+  })
+
+  it('walks a dotted path through a fragment spread', () => {
+    // login { ...TokenDetails } carries `user` only inside the fragment; the
+    // walker must resolve the spread between segments or the path matches nothing.
+    const result = buildPrismaSelectFromOperationPaths({
+      allSources: sources,
+      models: pathModels,
+      paths: ['login.user'],
+      targetModelName: 'User',
+    })
+
+    expect(result.select).toEqual({ displayName: true, id: true })
+    expect(result.matched.get('login.user')).toBe(1)
+  })
+
+  it('matches a type-scoped path in every fragment on that type', () => {
+    // One field resolver serves user for every operation returning UserToken, so
+    // the annotation names the type once instead of chasing each mutation.
+    const result = buildPrismaSelectFromOperationPaths({
+      allSources: sources,
+      models: pathModels,
+      paths: ['UserToken.user'],
+      targetModelName: 'User',
+    })
+
+    expect(result.select).toEqual({ displayName: true, id: true })
+    expect(result.matched.get('UserToken.user')).toBe(1)
+  })
+
+  it('follows a fragment spread to an inline fragment on the scoped type', () => {
+    // The inline `... on UserToken` lives inside AuthResult (a fragment on AuthPayload, so the
+    // fragment-on-type filter misses it) — the walker must descend through the spread to find it.
+    const spreadSources = [
+      {
+        file: 'graphql/auth/social.graphql',
+        source: `
+          mutation SocialLogin { socialLogin { ...AuthResult } }
+          fragment AuthResult on AuthPayload { ... on UserToken { user { id displayName } } }
+        `,
+      },
+    ]
+    const result = buildPrismaSelectFromOperationPaths({
+      allSources: spreadSources,
+      models: pathModels,
+      paths: ['UserToken.user'],
+      targetModelName: 'User',
+    })
+
+    expect(result.select).toEqual({ displayName: true, id: true })
+    expect(result.matched.get('UserToken.user')).toBe(1)
+  })
+
+  it('counts zero matches for a stale path so the caller can fail on it', () => {
+    const result = buildPrismaSelectFromOperationPaths({
+      allSources: sources,
+      models: pathModels,
+      paths: ['renamedAway.user'],
+      targetModelName: 'User',
+    })
+
+    expect(result.matched.get('renamedAway.user')).toBe(0)
+    expect(result.select).toEqual({})
+  })
+})
+
+describe('sdkWithoutConsumer name matching', () => {
+  it('credits a consumer importing the PascalCased document const of a camelCase operation', () => {
+    // `mutation createThing` generates `export const CreateThing = {...}` — the import
+    // never carries the declared name, and matching it alone deletes live operations.
+    const report = getSdkContractReport({
+      adminSources: [],
+      applicationSources: [
+        {
+          file: 'graphql/thing.graphql',
+          source: 'mutation createThing { createThing } query OrphanThing { thing }',
+        },
+      ],
+      clientSources: [
+        {
+          file: 'apps/web/thing.tsx',
+          source: "import { CreateThing } from '@example/shared/sdk'\nexport const x = CreateThing",
+        },
+      ],
+      schemaSource: 'type Query { thing: String } type Mutation { createThing: String }',
+    })
+
+    expect(report.sdkWithoutConsumer.map(operation => operation.name)).toEqual(['OrphanThing'])
+  })
+
+  it('normalizes acronym runs the way codegen does', () => {
+    // `query FAQS` exports `Faqs`, `mutation deleteCourseFAQ` exports `DeleteCourseFaq`.
+    // The first-letter-only fix missed these and still marked live operations unconsumed.
+    const report = getSdkContractReport({
+      adminSources: [],
+      applicationSources: [
+        {
+          file: 'graphql/faq.graphql',
+          source: 'query FAQS { faqs } mutation deleteCourseFAQ { deleteCourseFAQ }',
+        },
+      ],
+      clientSources: [
+        {
+          file: 'apps/web/faqs.tsx',
+          source:
+            "import { Faqs, DeleteCourseFaq } from '@example/shared/sdk'\nexport const x = [Faqs, DeleteCourseFaq]",
+        },
+      ],
+      schemaSource: 'type Query { faqs: String } type Mutation { deleteCourseFAQ: String }',
+    })
+
+    expect(report.sdkWithoutConsumer).toEqual([])
+  })
+})

--- a/doctor/src/doctor-sdk-contract-analysis.ts
+++ b/doctor/src/doctor-sdk-contract-analysis.ts
@@ -1,0 +1,672 @@
+import ts from 'typescript'
+import {
+  buildSchema,
+  Kind,
+  parse,
+  type FieldNode,
+  type FragmentDefinitionNode,
+  type FragmentSpreadNode,
+  type InlineFragmentNode,
+  type OperationDefinitionNode,
+  type SelectionSetNode,
+} from 'graphql'
+
+export type GraphqlSource = {
+  file: string
+  source: string
+}
+
+export type TypeScriptSource = {
+  file: string
+  source: string
+}
+
+export type DatabaseFieldMetadata = {
+  name: string
+  type: string
+  /**
+   * Prisma's field kind — 'scalar', 'object', 'enum'. Optional because the generated
+   * database-models.ts declares it optional, and consumers must treat its absence as "unknown"
+   * rather than assuming scalar.
+   *
+   * It was missing from this type while the code already read it: correct at runtime, invisible to
+   * the compiler, because these files ran under tsx and were never typechecked.
+   */
+  kind?: string
+}
+
+export type DatabaseModelMetadata = {
+  modelName: string
+  fields: DatabaseFieldMetadata[]
+}
+
+export type PrismaSelect = Record<string, true | { select: PrismaSelect }>
+
+export type FragmentSelectResult = {
+  fragmentNames: string[]
+  missingFragments: string[]
+  select: PrismaSelect
+  skippedFields: string[]
+}
+
+export type SdkOperation = {
+  file: string
+  name: string
+  rootFields: string[]
+}
+
+export type InlineClientOperation = {
+  file: string
+  line: number
+  name: string
+}
+
+export type SdkContractReport = {
+  apiWithoutSdk: string[]
+  inlineClientOperations: InlineClientOperation[]
+  sdkWithoutApi: SdkRootMismatch[]
+  sdkWithoutConsumer: SdkOperation[]
+}
+
+export type SdkRootMismatch = {
+  file: string
+  operation: string
+  rootFields: string[]
+}
+
+export const normalizeContractPath = (file: string): string => file.replaceAll('\\', '/')
+
+type FragmentReference = {
+  definition: FragmentDefinitionNode
+  file: string
+}
+
+const alphabetical = (left: string, right: string): number => left.localeCompare(right)
+
+const mergeSelect = (target: PrismaSelect, addition: PrismaSelect): void => {
+  for (const [fieldName, value] of Object.entries(addition)) {
+    const current = target[fieldName]
+    if (
+      current !== true &&
+      value !== true &&
+      current?.select !== undefined &&
+      value.select !== undefined
+    ) {
+      mergeSelect(current.select, value.select)
+    } else if (current === undefined || (current === true && value !== true)) {
+      target[fieldName] = value
+    }
+  }
+}
+
+const fragmentsFrom = (sources: readonly GraphqlSource[]): Map<string, FragmentReference> => {
+  const fragments = new Map<string, FragmentReference>()
+
+  for (const graphqlSource of sources) {
+    for (const definition of parse(graphqlSource.source).definitions) {
+      if (definition.kind !== Kind.FRAGMENT_DEFINITION) continue
+      const existing = fragments.get(definition.name.value)
+      if (existing) {
+        throw new Error(
+          `Duplicate fragment ${definition.name.value} in ${existing.file} and ${graphqlSource.file}`,
+        )
+      }
+      fragments.set(definition.name.value, { definition, file: graphqlSource.file })
+    }
+  }
+
+  return fragments
+}
+
+type SelectContext = {
+  fragments: ReadonlyMap<string, FragmentReference>
+  missingFragments: Set<string>
+  models: ReadonlyMap<string, DatabaseModelMetadata>
+  skippedFields: Set<string>
+}
+
+const selectForField = (
+  selection: FieldNode,
+  model: DatabaseModelMetadata,
+  context: SelectContext,
+  fragmentPath: ReadonlySet<string>,
+): PrismaSelect => {
+  const fieldName = selection.name.value
+  const field = model.fields.find(candidate => candidate.name === fieldName)
+  if (!field) {
+    context.skippedFields.add(`${model.modelName}.${fieldName}`)
+    return {}
+  }
+
+  const relatedModel = context.models.get(field.type)
+  if (!relatedModel || !selection.selectionSet) return { [fieldName]: true }
+
+  const nestedSelect = selectForSelectionSet(
+    selection.selectionSet,
+    relatedModel,
+    context,
+    fragmentPath,
+  )
+  if (Object.keys(nestedSelect).length > 0) {
+    return { [fieldName]: { select: nestedSelect } }
+  }
+
+  context.skippedFields.add(`${model.modelName}.${fieldName}`)
+  return {}
+}
+
+const selectForInlineFragment = (
+  selection: InlineFragmentNode,
+  model: DatabaseModelMetadata,
+  context: SelectContext,
+  fragmentPath: ReadonlySet<string>,
+): PrismaSelect => {
+  const typeName = selection.typeCondition?.name.value
+  const fragmentModel = (typeName && context.models.get(typeName)) || model
+  return selectForSelectionSet(selection.selectionSet, fragmentModel, context, fragmentPath)
+}
+
+const selectForFragmentSpread = (
+  selection: FragmentSpreadNode,
+  model: DatabaseModelMetadata,
+  context: SelectContext,
+  fragmentPath: ReadonlySet<string>,
+): PrismaSelect => {
+  const fragmentName = selection.name.value
+  if (fragmentPath.has(fragmentName)) return {}
+
+  const fragment = context.fragments.get(fragmentName)
+  if (!fragment) {
+    context.missingFragments.add(fragmentName)
+    return {}
+  }
+
+  const fragmentModel = context.models.get(fragment.definition.typeCondition.name.value) ?? model
+  const nextPath = new Set(fragmentPath)
+  nextPath.add(fragmentName)
+  return selectForSelectionSet(fragment.definition.selectionSet, fragmentModel, context, nextPath)
+}
+
+function selectForSelectionSet(
+  selectionSet: SelectionSetNode,
+  model: DatabaseModelMetadata,
+  context: SelectContext,
+  fragmentPath: ReadonlySet<string>,
+): PrismaSelect {
+  const select: PrismaSelect = {}
+
+  for (const selection of selectionSet.selections) {
+    if (selection.kind === Kind.FIELD) {
+      mergeSelect(select, selectForField(selection, model, context, fragmentPath))
+      continue
+    }
+
+    if (selection.kind === Kind.INLINE_FRAGMENT) {
+      mergeSelect(select, selectForInlineFragment(selection, model, context, fragmentPath))
+      continue
+    }
+
+    mergeSelect(select, selectForFragmentSpread(selection, model, context, fragmentPath))
+  }
+
+  return select
+}
+
+export const buildPrismaSelectFromFragments = (options: {
+  allSources: readonly GraphqlSource[]
+  models: readonly DatabaseModelMetadata[]
+  rootSources: readonly GraphqlSource[]
+  targetModelName: string
+}): FragmentSelectResult => {
+  const fragments = fragmentsFrom(options.allSources)
+  const rootFiles = new Set(options.rootSources.map(source => source.file))
+  const rootFragments = [...fragments.values()].filter(
+    fragment =>
+      rootFiles.has(fragment.file) &&
+      fragment.definition.typeCondition.name.value === options.targetModelName,
+  )
+  if (rootFragments.length === 0) {
+    throw new Error(`No ${options.targetModelName} fragments found in ${[...rootFiles].join(', ')}`)
+  }
+
+  const models = new Map(options.models.map(model => [model.modelName, model]))
+  const targetModel = models.get(options.targetModelName)
+  if (!targetModel) {
+    throw new Error(`No generated database metadata found for ${options.targetModelName}`)
+  }
+
+  const context: SelectContext = {
+    fragments,
+    missingFragments: new Set(),
+    models,
+    skippedFields: new Set(),
+  }
+  const select: PrismaSelect = {}
+
+  for (const fragment of rootFragments) {
+    mergeSelect(
+      select,
+      selectForSelectionSet(
+        fragment.definition.selectionSet,
+        targetModel,
+        context,
+        new Set([fragment.definition.name.value]),
+      ),
+    )
+  }
+
+  return {
+    fragmentNames: rootFragments.map(fragment => fragment.definition.name.value).sort(alphabetical),
+    missingFragments: [...context.missingFragments].sort(alphabetical),
+    select,
+    skippedFields: [...context.skippedFields].sort(alphabetical),
+  }
+}
+
+export type OperationPathSelectResult = {
+  /** Path entry → number of document sites it matched. A zero is a stale annotation. */
+  matched: Map<string, number>
+  select: PrismaSelect
+  skippedFields: string[]
+}
+
+/**
+ * All field nodes named `fieldName` reachable at ONE level of a selection set — directly,
+ * through fragment spreads, or through inline fragments. Spreads are resolved by name across
+ * the whole SDK, so `login { ...UserTokenDetails }` still yields the `user` field the fragment
+ * carries. The path guard stops fragment cycles the same way selectForFragmentSpread does.
+ */
+const fieldNodesNamed = (
+  selectionSet: SelectionSetNode,
+  fieldName: string,
+  fragments: ReadonlyMap<string, FragmentReference>,
+  fragmentPath: ReadonlySet<string>,
+): FieldNode[] => {
+  const nodes: FieldNode[] = []
+
+  for (const selection of selectionSet.selections) {
+    if (selection.kind === Kind.FIELD) {
+      if (selection.name.value === fieldName) nodes.push(selection)
+      continue
+    }
+    if (selection.kind === Kind.INLINE_FRAGMENT) {
+      nodes.push(...fieldNodesNamed(selection.selectionSet, fieldName, fragments, fragmentPath))
+      continue
+    }
+    const fragment = fragments.get(selection.name.value)
+    if (!fragment || fragmentPath.has(selection.name.value)) continue
+    const nextPath = new Set(fragmentPath)
+    nextPath.add(selection.name.value)
+    nodes.push(...fieldNodesNamed(fragment.definition.selectionSet, fieldName, fragments, nextPath))
+  }
+
+  return nodes
+}
+
+/**
+ * Every inline-fragment selection set conditioned on `typeName` reachable from a selection set —
+ * descending through fields AND following fragment spreads by name across the whole SDK (with a
+ * path guard against cycles), so `... on UserToken` nested inside a spread is not missed.
+ */
+const inlineFragmentSetsOn = (
+  selectionSet: SelectionSetNode,
+  typeName: string,
+  fragments: ReadonlyMap<string, FragmentReference>,
+  fragmentPath: ReadonlySet<string>,
+): SelectionSetNode[] => {
+  const sets: SelectionSetNode[] = []
+  for (const selection of selectionSet.selections) {
+    if (selection.kind === Kind.INLINE_FRAGMENT) {
+      if (selection.typeCondition?.name.value === typeName) sets.push(selection.selectionSet)
+      sets.push(...inlineFragmentSetsOn(selection.selectionSet, typeName, fragments, fragmentPath))
+      continue
+    }
+    if (selection.kind === Kind.FIELD) {
+      if (selection.selectionSet) {
+        sets.push(
+          ...inlineFragmentSetsOn(selection.selectionSet, typeName, fragments, fragmentPath),
+        )
+      }
+      continue
+    }
+    const fragment = fragments.get(selection.name.value)
+    if (!fragment || fragmentPath.has(selection.name.value)) continue
+    const nextPath = new Set(fragmentPath)
+    nextPath.add(selection.name.value)
+    sets.push(
+      ...inlineFragmentSetsOn(fragment.definition.selectionSet, typeName, fragments, nextPath),
+    )
+  }
+  return sets
+}
+
+/** Operation definitions across the whole SDK, parsed once so path matching doesn't reparse. */
+const operationDefinitionsOf = (sources: readonly GraphqlSource[]): OperationDefinitionNode[] =>
+  sources.flatMap(source =>
+    parse(source.source).definitions.filter(
+      (definition): definition is OperationDefinitionNode =>
+        definition.kind === Kind.OPERATION_DEFINITION,
+    ),
+  )
+
+/**
+ * Where a path's first segment starts matching, and the segments still to walk. A type-scoped
+ * entry (`UserToken.user`, leading capital) begins in every fragment defined ON that type plus
+ * every inline fragment conditioned on it; a plain entry begins at every operation's root.
+ */
+const pathCursors = (
+  entry: string,
+  operations: readonly OperationDefinitionNode[],
+  fragments: ReadonlyMap<string, FragmentReference>,
+): { cursors: SelectionSetNode[]; remaining: string[] } => {
+  const segments = entry.split('.').map(segment => segment.trim())
+  if (!/^[A-Z]/.test(segments[0] ?? '')) {
+    return { cursors: operations.map(operation => operation.selectionSet), remaining: segments }
+  }
+  const cursors = [...fragments.values()]
+    .filter(fragment => fragment.definition.typeCondition.name.value === segments[0])
+    .map(fragment => fragment.definition.selectionSet)
+  for (const operation of operations) {
+    cursors.push(...inlineFragmentSetsOn(operation.selectionSet, segments[0], fragments, new Set()))
+  }
+  return { cursors, remaining: segments.slice(1) }
+}
+
+/** Walk `remaining` segments from `cursors`, returning the field nodes at the final segment. */
+const walkPathToLeaves = (
+  cursors: readonly SelectionSetNode[],
+  remaining: readonly string[],
+  fragments: ReadonlyMap<string, FragmentReference>,
+): FieldNode[] => {
+  let current: SelectionSetNode[] = [...cursors]
+  for (const [index, segment] of remaining.entries()) {
+    const nodes = current.flatMap(cursor => fieldNodesNamed(cursor, segment, fragments, new Set()))
+    if (index === remaining.length - 1) return nodes
+    current = nodes
+      .map(node => node.selectionSet)
+      .filter((set): set is SelectionSetNode => set !== undefined)
+  }
+  return []
+}
+
+/**
+ * The union of what SDK documents actually request at specific positions, as a Prisma select
+ * on one model — the per-operation counterpart to buildPrismaSelectFromFragments' model-wide
+ * union.
+ *
+ * A path entry is either:
+ *   - an operation root field, dotted for nesting: `me`, `login.user` — matched against every
+ *     operation definition in the SDK, following fragment spreads between segments;
+ *   - a type-scoped field: `UserToken.user` (leading segment capitalized) — matched inside
+ *     every fragment defined ON that type and every inline fragment conditioned on it. Use
+ *     this when one field resolver serves the same field across many operations: any new
+ *     operation returning that type is covered without touching the annotation.
+ *
+ * The selection under each matched field is interpreted against `targetModelName` exactly the
+ * way buildPrismaSelectFromFragments interprets a fragment body: spreads followed across the
+ * whole SDK, GraphQL-only fields dropped through the models metadata.
+ */
+export const buildPrismaSelectFromOperationPaths = (options: {
+  allSources: readonly GraphqlSource[]
+  models: readonly DatabaseModelMetadata[]
+  paths: readonly string[]
+  targetModelName: string
+}): OperationPathSelectResult => {
+  const fragments = fragmentsFrom(options.allSources)
+  const models = new Map(options.models.map(model => [model.modelName, model]))
+  const targetModel = models.get(options.targetModelName)
+  if (!targetModel) {
+    throw new Error(`No generated database metadata found for ${options.targetModelName}`)
+  }
+
+  const context: SelectContext = {
+    fragments,
+    missingFragments: new Set(),
+    models,
+    skippedFields: new Set(),
+  }
+  const operations = operationDefinitionsOf(options.allSources)
+  const select: PrismaSelect = {}
+  const matched = new Map<string, number>()
+
+  for (const entry of options.paths) {
+    const { cursors, remaining } = pathCursors(entry, operations, fragments)
+    const leaves = walkPathToLeaves(cursors, remaining, fragments)
+    matched.set(entry, leaves.length)
+    for (const leaf of leaves) {
+      if (!leaf.selectionSet) continue
+      mergeSelect(select, selectForSelectionSet(leaf.selectionSet, targetModel, context, new Set()))
+    }
+  }
+
+  return { matched, select, skippedFields: [...context.skippedFields].sort(alphabetical) }
+}
+
+const operationRootFields = (
+  selectionSet: SelectionSetNode,
+  fragments: ReadonlyMap<string, FragmentReference>,
+  fragmentPath: ReadonlySet<string>,
+): Set<string> => {
+  const fields = new Set<string>()
+
+  for (const selection of selectionSet.selections) {
+    if (selection.kind === Kind.FIELD) {
+      fields.add(selection.name.value)
+      continue
+    }
+    if (selection.kind === Kind.INLINE_FRAGMENT) {
+      for (const field of operationRootFields(selection.selectionSet, fragments, fragmentPath)) {
+        fields.add(field)
+      }
+      continue
+    }
+
+    const fragmentName = selection.name.value
+    const fragment = fragments.get(fragmentName)
+    if (!fragment || fragmentPath.has(fragmentName)) continue
+    const nextPath = new Set(fragmentPath)
+    nextPath.add(fragmentName)
+    for (const field of operationRootFields(
+      fragment.definition.selectionSet,
+      fragments,
+      nextPath,
+    )) {
+      fields.add(field)
+    }
+  }
+
+  return fields
+}
+
+export const getSdkOperations = (sources: readonly GraphqlSource[]): SdkOperation[] => {
+  const fragments = fragmentsFrom(sources)
+  const operations: SdkOperation[] = []
+
+  for (const graphqlSource of sources) {
+    for (const definition of parse(graphqlSource.source).definitions) {
+      if (definition.kind !== Kind.OPERATION_DEFINITION) continue
+      operations.push({
+        file: graphqlSource.file,
+        name: definition.name?.value ?? '(anonymous operation)',
+        rootFields: [...operationRootFields(definition.selectionSet, fragments, new Set())].sort(
+          alphabetical,
+        ),
+      })
+    }
+  }
+
+  return operations.sort((left, right) => left.name.localeCompare(right.name))
+}
+
+/**
+ * The PascalCase rule graphql-codegen applies to export names: split on case boundaries,
+ * then capitalize each word's first letter and lowercase the rest — which flattens acronym
+ * runs (`FAQS` → `Faqs`, `deleteCourseFAQ` → `DeleteCourseFaq`).
+ */
+export const codegenPascalCase = (name: string): string =>
+  (name.match(/[A-Z]+(?![a-z])|[A-Z]?[a-z0-9]+/g) ?? [name])
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join('')
+
+const sdkModulePattern = /\/shared\/sdk$|\/shared\/sdk\/|^@[^/]+\/shared\/sdk$/
+
+type SdkImportBindings = {
+  imports: Set<string>
+  namespaces: Set<string>
+}
+
+const collectSdkImportDeclaration = (
+  statement: ts.Statement,
+  bindings: SdkImportBindings,
+): void => {
+  if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) return
+  if (!sdkModulePattern.test(statement.moduleSpecifier.text)) return
+
+  const clause = statement.importClause
+  if (!clause || clause.phaseModifier === ts.SyntaxKind.TypeKeyword || !clause.namedBindings) {
+    return
+  }
+
+  if (ts.isNamespaceImport(clause.namedBindings)) {
+    bindings.namespaces.add(clause.namedBindings.name.text)
+    return
+  }
+
+  for (const element of clause.namedBindings.elements) {
+    if (!element.isTypeOnly) bindings.imports.add(element.propertyName?.text ?? element.name.text)
+  }
+}
+
+const collectNamespaceImports = (sourceFile: ts.SourceFile, bindings: SdkImportBindings): void => {
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      bindings.namespaces.has(node.expression.text)
+    ) {
+      bindings.imports.add(node.name.text)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+}
+
+const collectSdkValueImports = (typeScriptSource: TypeScriptSource, imports: Set<string>): void => {
+  const sourceFile = ts.createSourceFile(
+    typeScriptSource.file,
+    typeScriptSource.source,
+    ts.ScriptTarget.Latest,
+    true,
+    typeScriptSource.file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  )
+  const bindings: SdkImportBindings = { imports, namespaces: new Set() }
+
+  for (const statement of sourceFile.statements) collectSdkImportDeclaration(statement, bindings)
+  collectNamespaceImports(sourceFile, bindings)
+}
+
+const getSdkValueImports = (sources: readonly TypeScriptSource[]): Set<string> => {
+  const imports = new Set<string>()
+  for (const typeScriptSource of sources) {
+    collectSdkValueImports(typeScriptSource, imports)
+  }
+
+  return imports
+}
+
+const operationPattern = /\b(?:query|mutation|subscription)\s+([_A-Za-z]\w*)/g
+
+export const getInlineClientOperations = (
+  sources: readonly TypeScriptSource[],
+): InlineClientOperation[] => {
+  const operations: InlineClientOperation[] = []
+
+  for (const typeScriptSource of sources) {
+    const sourceFile = ts.createSourceFile(
+      typeScriptSource.file,
+      typeScriptSource.source,
+      ts.ScriptTarget.Latest,
+      true,
+      typeScriptSource.file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+    )
+
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isTaggedTemplateExpression(node) &&
+        ts.isIdentifier(node.tag) &&
+        node.tag.text === 'gql'
+      ) {
+        const templateText = ts.isNoSubstitutionTemplateLiteral(node.template)
+          ? node.template.text
+          : [
+              node.template.head.text,
+              ...node.template.templateSpans.map(span => span.literal.text),
+            ].join(' ')
+        operationPattern.lastIndex = 0
+        let match: RegExpExecArray | null
+        while ((match = operationPattern.exec(templateText)) !== null) {
+          operations.push({
+            file: typeScriptSource.file,
+            line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
+            name: match[1],
+          })
+        }
+      }
+      ts.forEachChild(node, visit)
+    }
+    visit(sourceFile)
+  }
+
+  return operations.sort(
+    (left, right) => left.file.localeCompare(right.file) || left.line - right.line,
+  )
+}
+
+export const getSdkContractReport = (options: {
+  adminSources: readonly GraphqlSource[]
+  applicationSources: readonly GraphqlSource[]
+  clientSources: readonly TypeScriptSource[]
+  schemaSource: string
+}): SdkContractReport => {
+  const schema = buildSchema(options.schemaSource)
+  const schemaRootFields = new Set([
+    ...Object.keys(schema.getQueryType()?.getFields() ?? {}),
+    ...Object.keys(schema.getMutationType()?.getFields() ?? {}),
+  ])
+  const adminOperations = getSdkOperations(options.adminSources)
+  const applicationOperations = getSdkOperations(options.applicationSources)
+  const coveredFields = new Set(
+    [...adminOperations, ...applicationOperations].flatMap(operation => operation.rootFields),
+  )
+  const consumerImports = getSdkValueImports(options.clientSources)
+  const allOperations = [...adminOperations, ...applicationOperations]
+
+  return {
+    apiWithoutSdk: [...schemaRootFields]
+      .filter(field => !coveredFields.has(field))
+      .sort(alphabetical),
+    inlineClientOperations: getInlineClientOperations(options.clientSources),
+    sdkWithoutApi: allOperations
+      .map(operation => ({
+        file: operation.file,
+        operation: operation.name,
+        rootFields: operation.rootFields.filter(field => !schemaRootFields.has(field)),
+      }))
+      .filter(mismatch => mismatch.rootFields.length > 0)
+      .sort(
+        (left, right) =>
+          left.file.localeCompare(right.file) || left.operation.localeCompare(right.operation),
+      ),
+    // The generated document const is the codegen-PascalCased operation name: `mutation
+    // createPaymentTransaction` exports `CreatePaymentTransaction`, and acronym runs are
+    // normalized (`deleteCourseFAQ` → `DeleteCourseFaq`, `FAQS` → `Faqs`). Consumers import
+    // that const, never the declared name, so matching the declared name alone reported
+    // every such operation as unconsumed — an oracle that, followed blindly, would have
+    // deleted live staff mutations.
+    sdkWithoutConsumer: applicationOperations.filter(
+      operation =>
+        !consumerImports.has(operation.name) &&
+        !consumerImports.has(codegenPascalCase(operation.name)),
+    ),
+  }
+}

--- a/doctor/src/doctor-source-analysis.spec.ts
+++ b/doctor/src/doctor-source-analysis.spec.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest'
+import {
+  blankCommentsAndStrings,
+  getExternalImportSpecifiers,
+  stripComments,
+  getGraphqlOperationMethods,
+} from './doctor-source-analysis'
+
+describe('stripComments', () => {
+  it('preserves comment openers inside string literals', () => {
+    const source = [
+      "route('checkouts/cn/:token/*', './routes/checkout.tsx')",
+      'const url = "https://example.com/path"',
+      'const pattern = `expand/*`',
+      "const escaped = 'it\\'s still /* text */'",
+    ].join('\n')
+
+    expect(stripComments(source)).toBe(source)
+  })
+
+  it('removes actual comments while preserving block-comment line positions', () => {
+    const source = [
+      'const before = true',
+      '/* hidden',
+      'across lines */',
+      '  // hidden line',
+      'const after = true',
+    ].join('\n')
+
+    const stripped = stripComments(source)
+
+    expect(stripped).not.toContain('hidden')
+    expect(stripped).toContain('const before = true')
+    expect(stripped).toContain('const after = true')
+    expect(stripped.split('\n')).toHaveLength(source.split('\n').length)
+  })
+})
+
+describe('blankCommentsAndStrings', () => {
+  it('blanks prose in comments so token scans match only code', () => {
+    // The false positive that motivated this: "…the same two locks as any other write" in a
+    // comment flagged the `as any` gate.
+    const source = [
+      'const value = compute() as any',
+      '// takes the same two locks as any other write',
+      'await write() // holds them as any caller would',
+      '/** treat this as any other helper */',
+      "const message = 'never cast as any'",
+    ].join('\n')
+
+    const blanked = blankCommentsAndStrings(source)
+
+    expect(blanked.split('\n')[0]).toContain('as any')
+    expect([...blanked.matchAll(/\bas\s+any\b/g)]).toHaveLength(1)
+  })
+
+  it('preserves every byte offset and line count', () => {
+    const source = 'const a = 1 // note\nconst b = "text" as const\n/* block */ const c = 2\n'
+    const blanked = blankCommentsAndStrings(source)
+
+    expect(blanked).toHaveLength(source.length)
+    expect(blanked.split('\n')).toHaveLength(source.split('\n').length)
+    expect(blanked.indexOf('const c')).toBe(source.indexOf('const c'))
+  })
+
+  it('does not treat comment openers inside strings as comments', () => {
+    const source = 'const url = "https://example.com" as any'
+    const blanked = blankCommentsAndStrings(source)
+
+    // The string is blanked, but the code after it survives — a // inside a string must not
+    // swallow the rest of the line.
+    expect(blanked).toContain('as any')
+  })
+
+  it('follows a template literal through interpolations with nested templates', () => {
+    // skipStringLiteral stops at the FIRST backtick — for a nested template that is the nested
+    // opener, and the outer tail would be parsed as code. "as any" prose in that tail must stay
+    // blanked, and real code after the closing backtick must survive.
+    const source =
+      'const label = `use ${flag ? `nested` : "plain"} as any other tag`\nconst cast = value as any'
+    const blanked = blankCommentsAndStrings(source)
+
+    expect([...blanked.matchAll(/\bas\s+any\b/g)]).toHaveLength(1)
+    expect(blanked.split('\n')[1]).toContain('as any')
+    expect(blanked).toHaveLength(source.length)
+  })
+
+  it('tracks braces inside interpolations so an object literal does not end the template early', () => {
+    const source =
+      'const text = `count ${format({ max: 3 })} as any left` as const\nconst after = compute() as any'
+    const blanked = blankCommentsAndStrings(source)
+
+    expect([...blanked.matchAll(/\bas\s+any\b/g)]).toHaveLength(1)
+    expect(blanked.split('\n')[0]).toContain('as const')
+    expect(blanked.split('\n')[1]).toContain('as any')
+  })
+})
+
+describe('getGraphqlOperationMethods', () => {
+  // The regression this replaced: the old line scanner took the first `{` after the declaration
+  // line, so a method with an @Args object literal had THAT literal captured as its body. Callers
+  // then tested the wrong text — the resolver-scope check skipped almost every operation.
+  it('captures the real body when a parameter contains an object literal', () => {
+    const [operation] = getGraphqlOperationMethods(`
+      @Resolver()
+      class StorageResolver {
+        @Mutation(() => Boolean)
+        async deleteFile(
+          @Args('uploadId', { type: () => String }) uploadId: string,
+          @CtxUser() user: User,
+        ): Promise<boolean> {
+          await this.storageService.deleteFile(uploadId, user.id)
+          return true
+        }
+      }
+    `)
+
+    expect(operation.name).toBe('deleteFile')
+    expect(operation.body).toContain('this.storageService.deleteFile(uploadId, user.id)')
+    expect(operation.body).not.toContain('type: () => String')
+  })
+
+  // @CtxUser() is a parameter decorator: it appears in neither `decorators` nor `body`.
+  it('exposes the whole method, parameters included, as text', () => {
+    const [operation] = getGraphqlOperationMethods(`
+      @Resolver()
+      class FileResolver {
+        @Query(() => [String])
+        async userFiles(@CtxUser() user: User): Promise<string[]> {
+          return this.service.getUserFiles(user.id)
+        }
+      }
+    `)
+
+    expect(operation.decorators).not.toContain('@CtxUser')
+    expect(operation.body).not.toContain('@CtxUser')
+    expect(operation.text).toContain('@CtxUser()')
+  })
+
+  it('returns only GraphQL operations', () => {
+    const operations = getGraphqlOperationMethods(`
+      @Resolver()
+      class MixedResolver {
+        @Query(() => String)
+        anOperation(): string {
+          return 'x'
+        }
+
+        private aHelper(): string {
+          return 'y'
+        }
+      }
+    `)
+
+    expect(operations.map(operation => operation.name)).toEqual(['anOperation'])
+  })
+
+  it('reports the line of the method name', () => {
+    const [operation] = getGraphqlOperationMethods(
+      [
+        '@Resolver()',
+        'class R {',
+        '  @Query(() => String)',
+        '  thing(): string {',
+        '    return {}',
+        '  }',
+        '}',
+      ].join('\n'),
+    )
+
+    expect(operation.line).toBe(4)
+  })
+
+  it('handles a resolver with no operations', () => {
+    expect(getGraphqlOperationMethods('class Plain { helper() { return 1 } }')).toEqual([])
+  })
+})
+
+describe('getExternalImportSpecifiers', () => {
+  it('returns external specifiers and ignores relative siblings', () => {
+    expect(
+      getExternalImportSpecifiers(`
+        import ts from 'typescript'
+        import { parse } from 'graphql'
+        import { helper } from './doctor-auth-analysis'
+        import { other } from '../tools/thing'
+      `),
+    ).toEqual(['graphql', 'typescript'])
+  })
+
+  it('catches a workspace-scoped import — the one that resolves in a single repo', () => {
+    expect(
+      getExternalImportSpecifiers("import { ConfigService } from '@nestled-template/api/config'"),
+    ).toEqual(['@nestled-template/api/config'])
+  })
+
+  // An import specifier IS a string literal, so a scan that blanks strings to dodge comment
+  // false-positives blanks the thing being inspected. Reading the AST avoids both traps.
+  it('ignores a specifier-shaped string in a comment or a plain string', () => {
+    expect(
+      getExternalImportSpecifiers(`
+        // import { x } from '@mi-core/api/utils'
+        const note = '@cashcast/api/config'
+        import ts from 'typescript'
+      `),
+    ).toEqual(['typescript'])
+  })
+
+  it('catches dynamic import and require, not just static imports', () => {
+    expect(
+      getExternalImportSpecifiers(`
+        const a = await import('@mi-core/api/utils')
+        const b = require('@muzebook/api/config')
+      `),
+    ).toEqual(['@mi-core/api/utils', '@muzebook/api/config'])
+  })
+
+  // `import x = require('…')` reaches a module without an ImportDeclaration or a CallExpression, so
+  // a scan built from those two alone lets it through — a silent bypass of the portability rule.
+  it('catches import-equals-require, which is neither an import declaration nor a call', () => {
+    expect(getExternalImportSpecifiers("import cfg = require('@mi-core/api/config')")).toEqual([
+      '@mi-core/api/config',
+    ])
+  })
+
+  it('ignores a relative import-equals and a namespace alias', () => {
+    expect(
+      getExternalImportSpecifiers("import helper = require('./doctor-auth-analysis')"),
+    ).toEqual([])
+    // Not a module reference at all — aliasing an existing namespace imports nothing.
+    expect(getExternalImportSpecifiers('import factory = ts.factory')).toEqual([])
+  })
+
+  it('catches a re-export, which imports just as effectively', () => {
+    expect(getExternalImportSpecifiers("export * from '@mi-core/api/utils'")).toEqual([
+      '@mi-core/api/utils',
+    ])
+  })
+
+  it('deduplicates', () => {
+    expect(
+      getExternalImportSpecifiers(`
+        import ts from 'typescript'
+        import type { Node } from 'typescript'
+      `),
+    ).toEqual(['typescript'])
+  })
+})

--- a/doctor/src/doctor-source-analysis.ts
+++ b/doctor/src/doctor-source-analysis.ts
@@ -1,0 +1,295 @@
+import ts from 'typescript'
+
+/**
+ * Module specifiers a file imports from outside itself — relative siblings excluded.
+ *
+ * Read from the AST rather than by regex: an import specifier is a string literal, so any scan that
+ * blanks strings to avoid comment false-positives blanks the very thing being inspected.
+ */
+export const getExternalImportSpecifiers = (source: string, fileName = 'source.ts'): string[] => {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    fileName.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  )
+  const specifiers: string[] = []
+
+  const record = (node: ts.Expression | undefined): void => {
+    if (!node || !ts.isStringLiteralLike(node)) return
+    if (node.text.startsWith('.')) return
+    specifiers.push(node.text)
+  }
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      record(node.moduleSpecifier)
+    } else if (ts.isImportEqualsDeclaration(node)) {
+      // `import x = require('…')`. A static external import that looks nothing like one, and the
+      // only import form that reaches a module without an ImportDeclaration or a CallExpression —
+      // so a scan built from those two alone lets it through silently.
+      if (ts.isExternalModuleReference(node.moduleReference))
+        record(node.moduleReference.expression)
+    } else if (
+      ts.isCallExpression(node) &&
+      (node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(node.expression) && node.expression.text === 'require'))
+    ) {
+      record(node.arguments[0])
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return [...new Set(specifiers)].sort((left, right) => left.localeCompare(right))
+}
+
+export type GraphqlOperationMethod = {
+  /** The method's own decorators, verbatim. */
+  decorators: string
+  name: string
+  /** The method body, braces included. Empty for an overload or abstract signature. */
+  body: string
+  /** The ENTIRE method — decorators, signature, parameters and body. */
+  text: string
+  line: number
+}
+
+/**
+ * GraphQL operation methods, read from the AST.
+ *
+ * The previous line-scanning version located a method's body by taking the first `{` after the
+ * declaration line, which for any method with an object literal in its parameters —
+ * `@Args('id', { type: () => String })` — captured THAT literal as the body. Callers then tested
+ * the wrong text, and the resolver-scope check skipped almost every operation as a result.
+ *
+ * `text` exists because parameter decorators (`@CtxUser()`) live in the signature: they appear in
+ * neither `decorators` nor `body`, so any caller reasoning about the caller-scope of an operation
+ * has to look at the whole method.
+ */
+export const getGraphqlOperationMethods = (source: string): GraphqlOperationMethod[] => {
+  const sourceFile = ts.createSourceFile(
+    'operation.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  )
+  const methods: GraphqlOperationMethod[] = []
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isClassDeclaration(node)) {
+      for (const member of node.members) {
+        if (!ts.isMethodDeclaration(member) || !member.name) continue
+
+        const decorators = (ts.getDecorators(member) ?? [])
+          .map(decorator => decorator.getText(sourceFile))
+          .join('\n')
+        if (!/@(?:Query|Mutation|Subscription|ResolveField)\b/.test(decorators)) continue
+
+        methods.push({
+          decorators,
+          name: member.name.getText(sourceFile),
+          body: member.body ? member.body.getText(sourceFile) : '',
+          text: member.getText(sourceFile),
+          line: sourceFile.getLineAndCharacterOfPosition(member.name.getStart(sourceFile)).line + 1,
+        })
+      }
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return methods
+}
+
+const startsWithBlockComment = (source: string, index: number): boolean =>
+  source[index] === '/' && source[index + 1] === '*'
+
+const startsWithLineComment = (
+  source: string,
+  index: number,
+  onlyWhitespaceOnLine: boolean,
+): boolean => onlyWhitespaceOnLine && source[index] === '/' && source[index + 1] === '/'
+
+const skipBlockComment = (
+  source: string,
+  startIndex: number,
+): { index: number; preservedNewlines: string } => {
+  let index = startIndex + 2
+  let preservedNewlines = ''
+
+  while (index < source.length) {
+    if (source[index] === '\n') {
+      preservedNewlines += '\n'
+      index += 1
+    } else if (source[index] === '*' && source[index + 1] === '/') {
+      index += 2
+      break
+    } else {
+      index += 1
+    }
+  }
+
+  return { index, preservedNewlines }
+}
+
+const skipLineComment = (source: string, startIndex: number): number => {
+  let index = startIndex
+  while (index < source.length && source[index] !== '\n') {
+    index += 1
+  }
+  return index
+}
+
+const skipStringLiteral = (source: string, startIndex: number): number => {
+  const quote = source[startIndex]
+  let index = startIndex + 1
+
+  while (index < source.length) {
+    const current = source[index]
+    if (current === '\\') {
+      index += 2
+      continue
+    }
+    if (current === quote) return index + 1
+    index += 1
+  }
+
+  return index
+}
+
+const updateWhitespaceState = (current: string, onlyWhitespaceOnLine: boolean): boolean => {
+  if (current === '\n') return true
+  if (current === ' ' || current === '\t' || current === '\r') return onlyWhitespaceOnLine
+  return false
+}
+
+/**
+ * End index (exclusive) of a template literal, following `${…}` interpolations — including
+ * strings and NESTED template literals inside them. `skipStringLiteral` stops at the first
+ * unescaped backtick, which for `` `a ${flag ? `b` : ''} c` `` is the NESTED opener, leaving the
+ * tail parsed as code — so backticks need their own scanner.
+ */
+const skipTemplateLiteral = (source: string, startIndex: number): number => {
+  let index = startIndex + 1
+  while (index < source.length) {
+    const current = source[index]
+    if (current === '\\') {
+      index += 2
+      continue
+    }
+    if (current === '`') return index + 1
+    if (current === '$' && source[index + 1] === '{') {
+      index = skipInterpolation(source, index + 2)
+      continue
+    }
+    index += 1
+  }
+  return index
+}
+
+/** End index (exclusive) of a `${…}` interpolation body, starting just after the `${`. */
+const skipInterpolation = (source: string, startIndex: number): number => {
+  let depth = 1
+  let index = startIndex
+  while (index < source.length && depth > 0) {
+    const current = source[index]
+    if (current === '\\') {
+      index += 2
+      continue
+    }
+    if (current === '`') {
+      index = skipTemplateLiteral(source, index)
+      continue
+    }
+    if (current === "'" || current === '"') {
+      index = skipStringLiteral(source, index)
+      continue
+    }
+    if (current === '{') depth += 1
+    else if (current === '}') depth -= 1
+    index += 1
+  }
+  return index
+}
+
+/**
+ * Blank comments AND string-literal contents while preserving every byte offset, for scans that
+ * must match only CODE. `stripComments` deliberately keeps trailing `//` comments (a `//` later
+ * on a code line can live inside a regex literal) and keeps strings — right for structural scans,
+ * wrong for token scans like the `as any` gate, which flagged the prose "the same two locks as
+ * any other write" in a comment. Blanking instead of deleting keeps `getLineNumber` valid against
+ * the original source. The trade-offs are deliberate: an unescaped `//` inside a regex character
+ * class blanks the rest of that line, and code inside a template-literal `${…}` is blanked with
+ * the string — both vanishingly rare in product source, and both fail toward NOT flagging.
+ */
+export const blankCommentsAndStrings = (source: string): string => {
+  const out = source.split('')
+  const blank = (from: number, to: number): void => {
+    for (let position = from; position < to; position += 1) {
+      if (out[position] !== '\n') out[position] = ' '
+    }
+  }
+
+  let index = 0
+  while (index < source.length) {
+    if (startsWithBlockComment(source, index)) {
+      const end = skipBlockComment(source, index).index
+      blank(index, end)
+      index = end
+    } else if (source[index] === '/' && source[index + 1] === '/') {
+      const start = index
+      while (index < source.length && source[index] !== '\n') index += 1
+      blank(start, index)
+    } else if (source[index] === "'" || source[index] === '"') {
+      const end = skipStringLiteral(source, index)
+      blank(index, end)
+      index = end
+    } else if (source[index] === '`') {
+      const end = skipTemplateLiteral(source, index)
+      blank(index, end)
+      index = end
+    } else {
+      index += 1
+    }
+  }
+
+  return out.join('')
+}
+
+/**
+ * Remove comments before Doctor's lightweight source scans without mistaking comment-like text in
+ * string literals for comments. Newlines inside block comments are retained so diagnostics keep
+ * their original source line numbers.
+ */
+export const stripComments = (source: string): string => {
+  let output = ''
+  let index = 0
+  let onlyWhitespaceOnLine = true
+
+  while (index < source.length) {
+    if (startsWithBlockComment(source, index)) {
+      const skipped = skipBlockComment(source, index)
+      output += skipped.preservedNewlines
+      onlyWhitespaceOnLine = skipped.preservedNewlines.length > 0 || onlyWhitespaceOnLine
+      index = skipped.index
+    } else if (startsWithLineComment(source, index, onlyWhitespaceOnLine)) {
+      index = skipLineComment(source, index)
+    } else if (source[index] === "'" || source[index] === '"' || source[index] === '`') {
+      const end = skipStringLiteral(source, index)
+      output += source.slice(index, end)
+      onlyWhitespaceOnLine = false
+      index = end
+    } else {
+      output += source[index]
+      onlyWhitespaceOnLine = updateWhitespaceState(source[index], onlyWhitespaceOnLine)
+      index += 1
+    }
+  }
+
+  return output
+}

--- a/doctor/src/doctor-typescript-analysis.ts
+++ b/doctor/src/doctor-typescript-analysis.ts
@@ -1,0 +1,26 @@
+import ts from 'typescript'
+
+export const decoratorsOf = (node: ts.Node): readonly ts.Decorator[] =>
+  ts.canHaveDecorators(node) ? (ts.getDecorators(node) ?? []) : []
+
+export const decoratorName = (decorator: ts.Decorator): string => {
+  const expression = ts.isCallExpression(decorator.expression)
+    ? decorator.expression.expression
+    : decorator.expression
+
+  if (ts.isIdentifier(expression)) return expression.text
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text
+  return ''
+}
+
+export const unwrapExpression = (expression: ts.Expression): ts.Expression => {
+  let current = expression
+  while (
+    ts.isAsExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isParenthesizedExpression(current)
+  ) {
+    current = current.expression
+  }
+  return current
+}

--- a/doctor/src/doctor.ts
+++ b/doctor/src/doctor.ts
@@ -1,0 +1,2331 @@
+import { execSync } from 'node:child_process'
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { basename, dirname, join, relative } from 'node:path'
+import {
+  declaresAuthLevel,
+  getAuthOperations,
+  getGuardRank,
+  getOperationGuardNames,
+  hasAuthenticationGuard,
+} from './doctor-auth-analysis'
+import {
+  analyzeAccessPolicies,
+  getUndeclaredAccessOperations,
+  readStringObjectArray,
+  type AccessPolicyDeclaration,
+  type InlineAccessCheckViolation,
+} from './doctor-access-policy-analysis'
+import {
+  getCrudAuthAnnotationLines,
+  getCustomResolverNameViolations,
+  getGeneratedCrudImportViolations,
+  getGraphqlRootFieldNames,
+  getInlineClientGeneratedCrudViolations,
+  getNonAuthenticatedOperationViolations,
+  getLegacyCoreHelpersImportViolations,
+  getNonAdminOperationViolations,
+  getPublicSdkGeneratedCrudViolations,
+  isHandwrittenApiFile,
+  supportsAdminOnlyGeneratorBoundary,
+} from './doctor-crud-boundary-analysis'
+import {
+  getSdkContractReport,
+  normalizeContractPath,
+  type GraphqlSource,
+  type SdkContractReport,
+  type TypeScriptSource,
+} from './doctor-sdk-contract-analysis'
+import { getRegisteredModuleClasses } from './doctor-module-analysis'
+import {
+  GENERATED_CRUD_POSTURE_PATH,
+  readGeneratedCrudPosture,
+} from './doctor-generated-crud-posture'
+import {
+  blankCommentsAndStrings,
+  getExternalImportSpecifiers,
+  getGraphqlOperationMethods,
+  stripComments,
+} from './doctor-source-analysis'
+
+type Finding = {
+  check: string
+  message: string
+  file?: string
+  line?: number
+}
+
+const failures: Finding[] = []
+const warnings: Finding[] = []
+
+const routeRoot = 'apps/web/app/routes'
+const routeConfigPath = 'apps/web/app/routes.tsx'
+const schemaPath = 'libs/api/prisma/src/lib/schemas/schema.prisma'
+const generatorPackagePath = 'node_modules/@nestledjs/generators/package.json'
+const notesDir = '.nestled-updates/upgrade-notes'
+const guardBaselinePath = '.nestled-updates/security/guard-baseline.json'
+const publicOperationsPath = '.nestled-updates/security/public-operations.json'
+const permissionExemptionsPath = '.nestled-updates/security/permission-exemptions.json'
+const platformPermissionCatalogPath =
+  'libs/api/prisma/src/lib/seed/seed-data/seed-platform-access-control.ts'
+const organizationPermissionCatalogPath =
+  'libs/api/prisma/src/lib/seed/seed-data/seed-roles-permissions.ts'
+const sdkContractBaselinePath = '.nestled-updates/sdk-contract-baseline.json'
+const sdkContractExceptionsPath = '.nestled-updates/sdk-contract-exceptions.json'
+const resolverSourceRoots = ['libs/api', 'apps/api/src']
+const gitBaseRef = process.env.NX_BASE || process.env.GITHUB_BASE_REF || 'develop'
+const shouldUpdateGuardBaseline = process.argv.includes('--update-guard-baseline')
+const shouldUpdateSdkContractBaseline = process.argv.includes('--update-sdk-contract-baseline')
+const sourceTemplateRemotePattern = /github\.com[:/]nestledjs\/nestled-(?:dev-)?template(?:\.git)?$/
+
+type GuardBaseline = Record<string, Record<string, string[]>>
+
+// file -> operation name -> reason the operation is intentionally reachable without a guard.
+type PublicOperationAllowlist = Record<string, Record<string, string>>
+
+type SdkContractBaseline = {
+  apiWithoutSdk?: string[]
+  inlineClientOperations?: string[]
+}
+
+type SdkContractExceptions = {
+  apiWithoutSdk?: Record<string, string>
+  inlineClientOperations?: Record<string, string>
+  sdkWithoutConsumer?: Record<string, string>
+}
+
+const fail = (check: string, message: string, file?: string, line?: number) => {
+  failures.push({ check, message, file, line })
+}
+
+const warn = (check: string, message: string, file?: string, line?: number) => {
+  warnings.push({ check, message, file, line })
+}
+
+const getChangedLineMap = (): Map<string, Set<number>> => {
+  const changedLines = new Map<string, Set<number>>()
+
+  const recordDiffLines = (diff: string) => {
+    let currentFile = ''
+
+    for (const line of diff.split('\n')) {
+      const fileMatch = /^\+\+\+ b\/(.+)$/.exec(line)
+      if (fileMatch) {
+        currentFile = fileMatch[1]
+        if (!changedLines.has(currentFile)) changedLines.set(currentFile, new Set())
+        continue
+      }
+
+      const hunkMatch = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/.exec(line)
+      if (!hunkMatch || !currentFile) continue
+
+      const start = Number(hunkMatch[1])
+      const count = Number(hunkMatch[2] ?? '1')
+      const lines = changedLines.get(currentFile)
+      if (!lines) continue
+
+      for (let index = 0; index < count; index += 1) {
+        lines.add(start + index)
+      }
+    }
+  }
+
+  const diffCommands = [
+    `git diff --unified=0 ${gitBaseRef}...HEAD -- '*.ts' '*.tsx'`,
+    `git diff --cached --unified=0 -- '*.ts' '*.tsx'`,
+    `git diff --unified=0 -- '*.ts' '*.tsx'`,
+  ]
+
+  for (const command of diffCommands) {
+    try {
+      recordDiffLines(
+        execSync(command, {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }),
+      )
+    } catch {
+      continue
+    }
+  }
+
+  return changedLines
+}
+
+const changedLineMap = getChangedLineMap()
+
+const isChangedLine = (file: string | undefined, line: number | undefined): boolean => {
+  if (!file || !line) return false
+  return changedLineMap.get(file)?.has(line) ?? false
+}
+
+const review = (check: string, message: string, file?: string, line?: number) => {
+  if (isChangedLine(file, line)) {
+    fail(check, `New changed-line finding: ${message}`, file, line)
+  } else {
+    warn(check, message, file, line)
+  }
+}
+
+const getCommandOutput = (command: string): string => {
+  try {
+    return execSync(command, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {
+    return ''
+  }
+}
+
+const isSourceTemplateRepository = (): boolean => {
+  if (process.env.NESTLED_TEMPLATE_SOURCE === 'true') return true
+  if (process.env.NESTLED_TEMPLATE_SOURCE === 'false') return false
+
+  const originUrl = getCommandOutput('git remote get-url origin')
+  return sourceTemplateRemotePattern.test(originUrl)
+}
+
+const getChangedFiles = (): string[] => {
+  const files = new Set<string>()
+  const commands = [
+    `git diff --name-only ${gitBaseRef}...HEAD`,
+    'git diff --cached --name-only',
+    'git diff --name-only',
+    'git ls-files --others --exclude-standard',
+  ]
+
+  for (const command of commands) {
+    const output = getCommandOutput(command)
+    if (!output) continue
+
+    for (const file of output.split('\n')) {
+      if (file.trim()) files.add(file)
+    }
+  }
+
+  return Array.from(files).sort((left, right) => left.localeCompare(right))
+}
+
+const safeReadDir = (dir: string): string[] => {
+  try {
+    return readdirSync(dir)
+  } catch {
+    return []
+  }
+}
+
+const safeStat = (path: string) => {
+  try {
+    return statSync(path)
+  } catch {
+    return undefined
+  }
+}
+
+const walkFiles = (dir: string, predicate: (path: string) => boolean): string[] => {
+  if (!existsSync(dir)) return []
+
+  const files: string[] = []
+  for (const entry of safeReadDir(dir)) {
+    const path = join(dir, entry)
+    const stat = safeStat(path)
+    if (!stat) continue
+
+    if (stat.isDirectory()) {
+      if (
+        entry === 'node_modules' ||
+        entry === 'dist' ||
+        entry === 'build' ||
+        entry === '.nx' ||
+        entry === '.git' ||
+        entry === '.claude'
+      ) {
+        continue
+      }
+      files.push(...walkFiles(path, predicate))
+    } else if (stat.isFile() && predicate(path)) {
+      files.push(path)
+    }
+  }
+  return files
+}
+
+const directFiles = (dir: string, predicate: (path: string) => boolean): string[] => {
+  if (!existsSync(dir)) return []
+
+  return safeReadDir(dir)
+    .map(entry => join(dir, entry))
+    .filter(path => safeStat(path)?.isFile() === true && predicate(path))
+}
+
+const getRegexMatches = (pattern: RegExp, source: string): RegExpExecArray[] => {
+  pattern.lastIndex = 0
+  const matches: RegExpExecArray[] = []
+  let match: RegExpExecArray | null
+
+  while ((match = pattern.exec(source)) !== null) {
+    matches.push(match)
+    if (match[0] === '') {
+      pattern.lastIndex += 1
+    }
+  }
+
+  return matches
+}
+
+// Resolve a relative import spec to a file on disk (adding .ts/.tsx or an index file).
+const resolveLocalImport = (fromDir: string, spec: string): string | undefined => {
+  const base = join(fromDir, spec)
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    join(base, 'index.ts'),
+    join(base, 'index.tsx'),
+  ]
+  return candidates.find(candidate => safeStat(candidate)?.isFile() === true)
+}
+
+const getRegisteredRouteFiles = (): Set<string> => {
+  if (!existsSync(routeConfigPath)) {
+    fail('routes', 'Route configuration file is missing', routeConfigPath)
+    return new Set()
+  }
+
+  // Route file paths (`route('x', './routes/x.tsx')`) resolve from the app root, so a helper that
+  // composes routes (createAdminRoutes() etc.) uses the same `./routes/...` strings from a different
+  // file. Scan routes.tsx AND every file it imports transitively (relative imports only), or
+  // helper-composed routes report as unregistered (fleet-upstream #121).
+  const registered = new Set<string>()
+  const routeFilePattern = /['"]\.\/routes\/([^'"]+\.(?:tsx|ts))['"]/g
+  const importPattern = /from\s+['"](\.[^'"]+)['"]/g
+  const visited = new Set<string>()
+
+  // Template-literal route paths: helpers build a family of routes from a shared prefix —
+  // route('overview', `./routes/${basePath}/overview.tsx`) — which the quoted-string pattern
+  // cannot see, so helper-composed routes read as unregistered even after the transitive scan
+  // (fleet-upstream #135). Substituting simple string constants declared in the SAME file
+  // resolves them to concrete paths. Concrete matters: `registered` is also used to check each
+  // entry EXISTS, so a wildcard would satisfy the is-it-registered check while silently
+  // disabling the does-it-exist one. Anything still carrying an unresolved `${…}` is skipped,
+  // not guessed at.
+  const templatePattern = /`\.\/routes\/([^`]+\.(?:tsx|ts))`/g
+  // The literal must be the WHOLE initializer (allowing a trailing `as const`): matching the
+  // prefix of `const basePath = 'foo' + suffix` would substitute 'foo' as if it were the full
+  // value and register a wrong concrete path. Only horizontal whitespace before the terminator,
+  // so the lookahead can see the newline that ends the declaration.
+  const constantPattern =
+    /\b(?:const|let|var)\s+(\w+)\s*=\s*['"]([^'"]+)['"][^\S\n]*(?=as\b|;|\n|$)/g
+
+  const scan = (filePath: string): void => {
+    if (visited.has(filePath) || !existsSync(filePath)) return
+    visited.add(filePath)
+    const source = stripComments(readFileSync(filePath, 'utf8'))
+    for (const match of getRegexMatches(routeFilePattern, source)) {
+      registered.add(join(routeRoot, match[1]))
+    }
+
+    const constants = new Map<string, string>()
+    for (const match of getRegexMatches(constantPattern, source)) {
+      constants.set(match[1], match[2])
+    }
+    for (const match of getRegexMatches(templatePattern, source)) {
+      const resolved = match[1].replace(
+        /\$\{(\w+)\}/g,
+        (whole, name: string) => constants.get(name) ?? whole,
+      )
+      if (!resolved.includes('${')) registered.add(join(routeRoot, resolved))
+    }
+
+    for (const match of getRegexMatches(importPattern, source)) {
+      const resolved = resolveLocalImport(dirname(filePath), match[1])
+      if (resolved) scan(resolved)
+    }
+  }
+  scan(routeConfigPath)
+
+  return registered
+}
+
+const isRouteHelperFile = (path: string): boolean => {
+  const file = basename(path)
+  if (file.endsWith('.spec.ts') || file.endsWith('.spec.tsx')) return true
+  if (file === 'route.ts' || file === 'routes.tsx') return true
+  if (file === '_layout.tsx' || file === '_index.tsx') return false
+  return file.startsWith('_')
+}
+
+const checkRoutes = () => {
+  const registered = getRegisteredRouteFiles()
+  const routeFiles = walkFiles(
+    routeRoot,
+    path => (path.endsWith('.tsx') || path.endsWith('.ts')) && !isRouteHelperFile(path),
+  )
+
+  for (const file of routeFiles) {
+    if (!registered.has(file)) {
+      fail('routes', `Route file is not registered in ${routeConfigPath}`, file)
+    }
+  }
+
+  for (const file of registered) {
+    if (!existsSync(file)) {
+      fail('routes', 'Registered route file does not exist', file)
+    }
+  }
+}
+
+const checkForbiddenPrismaImports = () => {
+  const files = walkFiles(
+    '.',
+    path =>
+      /\.(ts|tsx|js|jsx|mjs|cjs)$/.test(path) &&
+      !path.includes('/node_modules/') &&
+      !path.includes('/build/') &&
+      !path.includes('/dist/') &&
+      !path.includes('/libs/shared/sdk/src/generated/') &&
+      !path.includes('/libs/api/generated-crud/'),
+  )
+
+  const directImportPattern =
+    /(?:from\s+['"]@prisma\/client['"]|require\(['"]@prisma\/client['"]\))/g
+
+  for (const file of files) {
+    const source = readFileSync(file, 'utf8')
+    if (directImportPattern.test(source)) {
+      fail(
+        'prisma-imports',
+        "Import Prisma types from the workspace's API Prisma wrapper instead of @prisma/client",
+        file,
+      )
+    }
+  }
+}
+
+const checkStaleConfigNames = () => {
+  const files = walkFiles(
+    '.',
+    path =>
+      /\.(ts|tsx|js|jsx|mjs|cjs|md|yml|yaml|json)$/.test(path) &&
+      path !== 'scripts/doctor.ts' &&
+      // Skip dev-authoring docs (plans/, agents/, ai-docs/): not the product surface, and they
+      // routinely quote the stale/buggy config key by name while documenting the very fix.
+      !path.startsWith('plans/') &&
+      !path.startsWith('agents/') &&
+      !path.startsWith('ai-docs/') &&
+      !path.includes('/node_modules/') &&
+      !path.includes('/build/') &&
+      !path.includes('/dist/'),
+  )
+
+  for (const file of files) {
+    const source = readFileSync(file, 'utf8')
+    if (source.includes('frontendUrl') || source.includes('frontend.url')) {
+      fail('config-names', 'Use siteUrl/SITE_URL instead of frontendUrl/frontend.url', file)
+    }
+  }
+}
+
+const checkMcpWiring = () => {
+  const mcpModulePath = 'libs/api/custom/src/lib/plugins/mcp/mcp.module.ts'
+  if (!existsSync(mcpModulePath)) return
+
+  const appModulePath = 'apps/api/src/app.module.ts'
+  const mainPath = 'apps/api/src/main.ts'
+  const appModule = existsSync(appModulePath) ? readFileSync(appModulePath, 'utf8') : ''
+  const main = existsSync(mainPath) ? readFileSync(mainPath, 'utf8') : ''
+
+  if (!appModule.includes('McpModule')) {
+    fail('mcp', 'McpModule exists but is not registered in the API app module', appModulePath)
+  }
+
+  if (!main.includes('/api/mcp')) {
+    fail('mcp', 'MCP endpoints are not allowed by the early API request filter', mainPath)
+  }
+}
+
+const normalizePath = (path: string): string =>
+  `/${path}`.replace(/\/+/g, '/').replace(/\/$/, '') || '/'
+
+const getDecoratorPath = (decoratorArgs: string | undefined): string => {
+  if (!decoratorArgs) return ''
+
+  const trimmed = decoratorArgs.trim()
+  if (!trimmed) return ''
+
+  const literalMatch = /^['"`]([^'"`]*)['"`]/.exec(trimmed)
+  return literalMatch?.[1] ?? ''
+}
+
+const toApiRoute = (controllerPath: string, methodPath: string): string => {
+  const combined = normalizePath(`${controllerPath}/${methodPath}`)
+  if (combined === '/api' || combined.startsWith('/api/')) {
+    return combined
+  }
+  return normalizePath(`/api${combined}`)
+}
+
+const getAllowedApiPrefixes = (): string[] => {
+  const mainPath = 'apps/api/src/main.ts'
+  if (!existsSync(mainPath)) {
+    fail('api-routes', 'API bootstrap file is missing', mainPath)
+    return []
+  }
+
+  const source = stripComments(readFileSync(mainPath, 'utf8'))
+  const match = /const\s+VALID_API_PREFIXES\s*=\s*\[([\s\S]*?)\]/.exec(source)
+  if (!match) {
+    fail('api-routes', 'VALID_API_PREFIXES could not be found', mainPath)
+    return []
+  }
+
+  return getRegexMatches(/['"`]([^'"`]+)['"`]/g, match[1]).map(item => normalizePath(item[1]))
+}
+
+const isControllerCandidateFile = (path: string): boolean =>
+  path.endsWith('.ts') &&
+  !path.includes('/node_modules/') &&
+  !path.includes('/build/') &&
+  !path.includes('/dist/') &&
+  !path.includes('/libs/api/generated-crud/') &&
+  !path.endsWith('.spec.ts')
+
+const getControllerClassSources = (source: string): { path: string; source: string }[] => {
+  const controllers = getRegexMatches(/@Controller\s*\(([^)]*)\)/g, source)
+  return controllers.map((controllerMatch, index) => {
+    const classStart = controllerMatch.index
+    const nextControllerIndex = controllers[index + 1]?.index ?? source.length
+    return {
+      path: getDecoratorPath(controllerMatch[1]),
+      source: source.slice(classStart, nextControllerIndex),
+    }
+  })
+}
+
+const getHttpMethodPaths = (source: string): string[] =>
+  getRegexMatches(/@(Get|Post|Put|Patch|Delete|All)\s*(?:\(([^)]*)\))?/g, source).map(match =>
+    getDecoratorPath(match[2]),
+  )
+
+const checkControllerMethodPaths = (
+  file: string,
+  controllerPath: string,
+  methodPaths: string[],
+  allowedPrefixes: string[],
+) => {
+  if (methodPaths.length === 0) {
+    warn('api-routes', 'Controller has no HTTP method decorators to check', file)
+    return
+  }
+
+  for (const methodPath of methodPaths) {
+    const routePath = toApiRoute(controllerPath, methodPath)
+    const isAllowed = allowedPrefixes.some(prefix => routePath.startsWith(prefix))
+    if (!isAllowed) {
+      fail(
+        'api-routes',
+        `Registered API route ${routePath} is not covered by VALID_API_PREFIXES`,
+        file,
+      )
+    }
+  }
+}
+
+const checkApiControllerRoutesAllowed = () => {
+  const allowedPrefixes = getAllowedApiPrefixes()
+  if (allowedPrefixes.length === 0) return
+
+  const controllerFiles = walkFiles('.', isControllerCandidateFile)
+
+  for (const file of controllerFiles) {
+    const source = stripComments(readFileSync(file, 'utf8'))
+    if (!source.includes('@Controller')) continue
+
+    for (const controller of getControllerClassSources(source)) {
+      checkControllerMethodPaths(
+        file,
+        controller.path,
+        getHttpMethodPaths(controller.source),
+        allowedPrefixes,
+      )
+    }
+  }
+}
+
+const controllerSourceRoots = ['apps/api', 'libs/api']
+
+const getControllerSourceFiles = (): string[] => {
+  const files = controllerSourceRoots.flatMap(root =>
+    walkFiles(root, path => isControllerCandidateFile(path) && path.endsWith('.controller.ts')),
+  )
+  return [...new Set(files)].sort((left, right) => left.localeCompare(right))
+}
+
+const getAuthSourceFiles = (): string[] => {
+  const files = resolverSourceRoots.flatMap(root =>
+    walkFiles(root, path => path.endsWith('.resolver.ts') && !path.endsWith('.spec.ts')),
+  )
+  return [...new Set([...files, ...getControllerSourceFiles()])].sort((left, right) =>
+    left.localeCompare(right),
+  )
+}
+
+const getGuardBaselineSourceFiles = (): string[] => {
+  const customResolverFiles = walkFiles('libs/api/custom/src/lib', path =>
+    path.endsWith('.resolver.ts'),
+  )
+  return [...new Set([...customResolverFiles, ...getControllerSourceFiles()])].sort((left, right) =>
+    left.localeCompare(right),
+  )
+}
+
+const getGraphqlResolverMethods = (source: string): string[] =>
+  getRegexMatches(/^\s{2}(?:override\s+)?(?:async\s+)?(\w+)\s*\(/gm, source)
+    .map(match => match[1])
+    .filter(methodName => methodName !== 'constructor')
+
+const getLineNumber = (source: string, index: number): number =>
+  source.slice(0, index).split('\n').length
+
+const getGeneratedCrudMethodNames = (): Set<string> => {
+  const generatedResolverFiles = walkFiles('libs/api/generated-crud/feature/src/lib', path =>
+    path.endsWith('.resolver.ts'),
+  )
+  const methodNames = new Set<string>()
+
+  for (const file of generatedResolverFiles) {
+    const source = stripComments(readFileSync(file, 'utf8'))
+    for (const methodName of getGraphqlResolverMethods(source)) {
+      methodNames.add(methodName)
+    }
+  }
+
+  return methodNames
+}
+
+const checkDefaultResolverComposition = (file: string, source: string) => {
+  if (!/\bextends\s+Generated\w+Resolver\b/.test(source)) return
+
+  fail(
+    'api-names',
+    'Custom model resolvers must be additive and must not extend generated CRUD resolvers',
+    file,
+  )
+}
+
+const checkDefaultResolverFile = (file: string, generatedMethodNames: Set<string>) => {
+  const source = readFileSync(file, 'utf8')
+  checkDefaultResolverComposition(file, stripComments(source))
+
+  for (const violation of getCustomResolverNameViolations(source, generatedMethodNames, file)) {
+    fail('api-names', violation.message, file, violation.line)
+  }
+}
+
+const getGeneratedResolverClassNames = (): string[] => {
+  const resolverFiles = walkFiles('libs/api/generated-crud/feature/src/lib', path =>
+    path.endsWith('.resolver.ts'),
+  )
+  const classNames: string[] = []
+
+  for (const file of resolverFiles) {
+    const source = stripComments(readFileSync(file, 'utf8'))
+    const classMatch = /export\s+class\s+(Generated\w+Resolver)\b/.exec(source)
+    if (classMatch) classNames.push(classMatch[1])
+  }
+
+  return classNames.sort((left, right) => left.localeCompare(right))
+}
+
+const checkGeneratedCrudModuleRegistration = () => {
+  const featureRoot = 'libs/api/generated-crud/feature/src'
+  const canonicalModulePath = join(featureRoot, 'lib/api-generated-crud-feature.module.ts')
+  const featureIndexPath = join(featureRoot, 'index.ts')
+  const appModulePath = 'apps/api/src/app.module.ts'
+  const moduleFiles = walkFiles(join(featureRoot, 'lib'), path => path.endsWith('.module.ts'))
+  const moduleDeclarations = moduleFiles.filter(file =>
+    readFileSync(file, 'utf8').includes('export class ApiGeneratedCrudFeatureModule'),
+  )
+
+  if (moduleDeclarations.length !== 1 || moduleDeclarations[0] !== canonicalModulePath) {
+    fail(
+      'crud-registration',
+      'Generated CRUD must declare exactly one ApiGeneratedCrudFeatureModule at the canonical path',
+      canonicalModulePath,
+    )
+    return
+  }
+
+  const moduleSource = stripComments(readFileSync(canonicalModulePath, 'utf8'))
+  const providerBlock = /providers\s*:\s*\[([\s\S]*?)\]/.exec(moduleSource)?.[1] ?? ''
+  const registeredProviders = new Set(
+    getRegexMatches(/\bGenerated\w+Resolver\b/g, providerBlock).map(match => match[0]),
+  )
+  const resolverClasses = getGeneratedResolverClassNames()
+
+  for (const resolverClass of resolverClasses) {
+    if (!registeredProviders.has(resolverClass)) {
+      fail(
+        'crud-registration',
+        `Generated resolver provider "${resolverClass}" is missing from ApiGeneratedCrudFeatureModule`,
+        canonicalModulePath,
+      )
+    }
+  }
+  if (registeredProviders.size !== resolverClasses.length) {
+    fail(
+      'crud-registration',
+      'Generated CRUD provider count does not match the generated resolver files',
+      canonicalModulePath,
+    )
+  }
+
+  if (!existsSync(featureIndexPath)) {
+    fail('crud-registration', 'Generated CRUD feature barrel is missing', featureIndexPath)
+  } else {
+    const indexSource = stripComments(readFileSync(featureIndexPath, 'utf8'))
+    if (!indexSource.includes("'./lib/api-generated-crud-feature.module'")) {
+      fail(
+        'crud-registration',
+        'Generated CRUD feature barrel must export the canonical feature module',
+        featureIndexPath,
+      )
+    }
+  }
+
+  if (!existsSync(appModulePath)) {
+    fail('crud-registration', 'API app module is missing', appModulePath)
+    return
+  }
+  const appModuleSource = stripComments(readFileSync(appModulePath, 'utf8'))
+  const hasFeatureImport =
+    /import\s*\{\s*ApiGeneratedCrudFeatureModule\s*\}\s*from\s*['"]@[^'"]+\/api\/generated-crud\/feature['"]/.test(
+      appModuleSource,
+    )
+  // Scanned rather than matched with a regex: two lazy [\s\S]*? either side of the module name
+  // backtracks super-linearly on any file that declares coreModules without registering it, which
+  // is exactly the failing case this check exists to report.
+  const hasFeatureRegistration = (() => {
+    const declaration = appModuleSource.indexOf('coreModules')
+    if (declaration === -1) return false
+    const open = appModuleSource.indexOf('[', declaration)
+    if (open === -1) return false
+    const close = appModuleSource.indexOf(']', open)
+    if (close === -1) return false
+    return /\bApiGeneratedCrudFeatureModule\b/.test(appModuleSource.slice(open + 1, close))
+  })()
+  if (!hasFeatureImport || !hasFeatureRegistration) {
+    fail(
+      'crud-registration',
+      'ApiGeneratedCrudFeatureModule must be imported and registered in coreModules',
+      appModulePath,
+    )
+  }
+}
+
+const checkGeneratedCrudPosture = () => {
+  const reading = readGeneratedCrudPosture()
+
+  // A posture file the generator would reject is worse than no file: the repo believes it declared
+  // something. Both read it fail-closed, so nothing is unguarded — but say so loudly.
+  if (reading.invalid) {
+    fail(
+      'admin-crud-boundary',
+      `${GENERATED_CRUD_POSTURE_PATH} declares ${reading.invalid}; both the generator and this check fall back to admin, so fix the file or delete it`,
+      GENERATED_CRUD_POSTURE_PATH,
+    )
+  }
+
+  const resolverFiles = walkFiles('libs/api/generated-crud/feature/src/lib', path =>
+    path.endsWith('.resolver.ts'),
+  )
+
+  // At `authenticated` the repo has deliberately suspended the admin rule, so asserting it would
+  // report every generated operation as a violation and bury the findings that matter. Assert the
+  // tier the repo actually declared instead — drift is still drift.
+  const relaxed = reading.posture === 'authenticated'
+
+  if (relaxed) {
+    const declaredReason = reading.reason ? ` — ${reading.reason}` : ''
+    review(
+      'admin-crud-boundary',
+      `Generated CRUD is running at posture "authenticated", not admin-only${declaredReason}`,
+      GENERATED_CRUD_POSTURE_PATH,
+    )
+  }
+
+  for (const file of resolverFiles) {
+    const source = readFileSync(file, 'utf8')
+    const violations = relaxed
+      ? getNonAuthenticatedOperationViolations(source, file)
+      : getNonAdminOperationViolations(source, file)
+
+    for (const violation of violations) {
+      fail(
+        'admin-crud-boundary',
+        relaxed
+          ? `Generated CRUD does not match its declared posture: ${violation.message}`
+          : `Generated CRUD is fixed admin-only: ${violation.message}`,
+        file,
+        violation.line,
+      )
+    }
+  }
+}
+
+const checkCrudAuthAnnotations = () => {
+  if (!existsSync(schemaPath)) return
+
+  const schema = readFileSync(schemaPath, 'utf8')
+  for (const line of getCrudAuthAnnotationLines(schema)) {
+    fail(
+      'admin-crud-boundary',
+      '@crudAuth is no longer supported: generated CRUD is always admin-only; create an explicit custom resolver and input for user-facing access',
+      schemaPath,
+      line,
+    )
+  }
+}
+
+const checkGeneratorAdminBoundaryVersion = () => {
+  if (!existsSync(generatorPackagePath)) {
+    fail(
+      'admin-crud-boundary',
+      '@nestledjs/generators is not installed; run pnpm install with version 3.0.3 or newer',
+      generatorPackagePath,
+    )
+    return
+  }
+
+  const packageJson = JSON.parse(readFileSync(generatorPackagePath, 'utf8')) as {
+    version?: unknown
+  }
+  const version = typeof packageJson.version === 'string' ? packageJson.version : ''
+  if (!supportsAdminOnlyGeneratorBoundary(version)) {
+    fail(
+      'admin-crud-boundary',
+      `@nestledjs/generators ${version || '(unknown version)'} cannot enforce the permanent admin-only CRUD and application-owned SDK boundary; upgrade to 3.0.3 or newer before running db-update`,
+      generatorPackagePath,
+    )
+  }
+}
+
+const checkHandwrittenCrudImports = () => {
+  const handwrittenApiFiles = [
+    ...walkFiles('libs/api', isHandwrittenApiFile),
+    ...walkFiles('apps/api/src', isHandwrittenApiFile),
+  ]
+
+  for (const file of handwrittenApiFiles) {
+    const source = readFileSync(file, 'utf8')
+    const violations = [
+      ...getGeneratedCrudImportViolations(source, file),
+      ...getLegacyCoreHelpersImportViolations(source, file),
+    ]
+
+    for (const violation of violations) {
+      fail('admin-crud-boundary', violation.message, file, violation.line)
+    }
+  }
+}
+
+const checkDefaultResolverGeneratedNameCollisions = () => {
+  const generatedMethodNames = getGeneratedCrudMethodNames()
+  if (generatedMethodNames.size === 0) {
+    fail('api-names', 'Generated CRUD method names could not be discovered')
+    return
+  }
+
+  const defaultResolverFiles = walkFiles('libs/api/custom/src/lib/default', path =>
+    path.endsWith('.resolver.ts'),
+  )
+
+  for (const file of defaultResolverFiles) {
+    checkDefaultResolverFile(file, generatedMethodNames)
+  }
+}
+
+const checkHandwrittenAdminSdkOperations = () => {
+  const graphqlFiles = walkFiles('libs/shared/sdk/src/graphql', path => path.endsWith('.graphql'))
+
+  for (const file of graphqlFiles) {
+    const source = stripComments(readFileSync(file, 'utf8'))
+    const adminOperation = /\b(?:query|mutation|subscription)\s+__Admin\w+/.exec(source)
+    if (adminOperation) {
+      fail(
+        'api-names',
+        'Hand-written __Admin* SDK operations belong under libs/shared/sdk/src/__admin',
+        file,
+      )
+    }
+  }
+}
+
+const checkApplicationSdkCrudBoundary = () => {
+  const generatedRootFields = new Set<string>()
+  const adminFiles = walkFiles('libs/shared/sdk/src/__admin', path => path.endsWith('.graphql'))
+
+  for (const file of adminFiles) {
+    const source = readFileSync(file, 'utf8')
+    for (const fieldName of getGraphqlRootFieldNames(source)) generatedRootFields.add(fieldName)
+  }
+
+  const applicationFiles = walkFiles('libs/shared/sdk/src/graphql', path =>
+    path.endsWith('.graphql'),
+  )
+  const applicationDocuments = applicationFiles.map(file => ({
+    file,
+    source: readFileSync(file, 'utf8'),
+  }))
+  const applicationSources = applicationDocuments.map(document => document.source)
+
+  for (const document of applicationDocuments) {
+    for (const violation of getPublicSdkGeneratedCrudViolations(
+      document.source,
+      generatedRootFields,
+      applicationSources,
+    )) {
+      fail('admin-crud-boundary', violation.message, document.file, violation.line)
+    }
+  }
+
+  // The SDK is not the only way a client reaches a root field: a component can write the document
+  // inline as gql`...`. Scanning only the SDK left that path unguarded.
+  for (const clientSource of clientContractSources()) {
+    for (const violation of getInlineClientGeneratedCrudViolations(
+      clientSource.source,
+      generatedRootFields,
+      clientSource.file,
+      applicationSources,
+    )) {
+      fail('admin-crud-boundary', violation.message, clientSource.file, violation.line)
+    }
+  }
+}
+
+const readSdkContractBaseline = (): SdkContractBaseline => {
+  if (!existsSync(sdkContractBaselinePath)) return {}
+  return JSON.parse(readFileSync(sdkContractBaselinePath, 'utf8')) as SdkContractBaseline
+}
+
+const readSdkContractExceptions = (): SdkContractExceptions => {
+  if (!existsSync(sdkContractExceptionsPath)) return {}
+  return JSON.parse(readFileSync(sdkContractExceptionsPath, 'utf8')) as SdkContractExceptions
+}
+
+const writeSdkContractBaseline = (
+  report: ReturnType<typeof getSdkContractReport>,
+  exceptions: SdkContractExceptions,
+): SdkContractBaseline => {
+  const baseline: SdkContractBaseline = {
+    apiWithoutSdk: report.apiWithoutSdk.filter(field => !exceptions.apiWithoutSdk?.[field]),
+    inlineClientOperations: report.inlineClientOperations
+      .map(operation => `${operation.file}#${operation.name}`)
+      .filter(operation => !exceptions.inlineClientOperations?.[operation]),
+  }
+  mkdirSync(dirname(sdkContractBaselinePath), { recursive: true })
+  writeFileSync(sdkContractBaselinePath, `${JSON.stringify(baseline, null, 2)}\n`)
+  return baseline
+}
+
+const graphqlSourcesUnder = (root: string): GraphqlSource[] =>
+  walkFiles(root, path => path.endsWith('.graphql')).map(file => ({
+    file: normalizeContractPath(file),
+    source: readFileSync(file, 'utf8'),
+  }))
+
+const isClientContractSource = (path: string): boolean => {
+  const contractPath = normalizeContractPath(path)
+  return (
+    (contractPath.endsWith('.ts') || contractPath.endsWith('.tsx')) &&
+    !contractPath.startsWith('apps/api/') &&
+    !contractPath.startsWith('libs/api/') &&
+    !contractPath.startsWith('libs/shared/sdk/') &&
+    !contractPath.endsWith('.spec.ts') &&
+    !contractPath.endsWith('.spec.tsx') &&
+    !contractPath.endsWith('.test.ts') &&
+    !contractPath.endsWith('.test.tsx')
+  )
+}
+
+const clientContractSources = (): TypeScriptSource[] =>
+  ['apps', 'libs'].flatMap(root =>
+    walkFiles(root, isClientContractSource).map(file => ({
+      file: normalizeContractPath(file),
+      source: readFileSync(file, 'utf8'),
+    })),
+  )
+
+const reportSdkWithoutApi = (report: SdkContractReport): void => {
+  for (const mismatch of report.sdkWithoutApi) {
+    fail(
+      'sdk-contract',
+      `SDK operation ${mismatch.operation} references missing GraphQL root field(s): ` +
+        mismatch.rootFields.join(', '),
+      mismatch.file,
+    )
+  }
+}
+
+const reportApiWithoutSdk = (
+  report: SdkContractReport,
+  exceptions: SdkContractExceptions,
+  baselineApiFields: ReadonlySet<string>,
+): void => {
+  for (const field of report.apiWithoutSdk) {
+    if (exceptions.apiWithoutSdk?.[field]) continue
+    const message =
+      `GraphQL root field ${field} has no SDK operation document; add one under ` +
+      'libs/shared/sdk/src/graphql or document an external/internal/deprecated exception'
+    if (baselineApiFields.has(field)) warn('sdk-contract', `Existing drift: ${message}`)
+    else fail('sdk-contract', message, 'api-schema.graphql')
+  }
+}
+
+const reportInlineClientOperations = (
+  report: SdkContractReport,
+  exceptions: SdkContractExceptions,
+  baselineInlineOperations: ReadonlySet<string>,
+): void => {
+  for (const operation of report.inlineClientOperations) {
+    const key = `${operation.file}#${operation.name}`
+    if (exceptions.inlineClientOperations?.[key]) continue
+    const message =
+      `Client operation ${operation.name} bypasses the application SDK; move it to ` +
+      'libs/shared/sdk/src/graphql and regenerate the SDK'
+    if (baselineInlineOperations.has(key)) {
+      warn('sdk-contract', `Existing drift: ${message}`, operation.file, operation.line)
+    } else {
+      fail('sdk-contract', message, operation.file, operation.line)
+    }
+  }
+}
+
+const reportResolvedSdkBaselineEntries = (
+  report: SdkContractReport,
+  baselineApiFields: ReadonlySet<string>,
+  baselineInlineOperations: ReadonlySet<string>,
+): void => {
+  const currentApiFields = new Set(report.apiWithoutSdk)
+  for (const field of baselineApiFields) {
+    if (!currentApiFields.has(field)) {
+      warn('sdk-contract', `Remove resolved API-without-SDK baseline entry: ${field}`)
+    }
+  }
+
+  const currentInlineOperations = new Set(
+    report.inlineClientOperations.map(operation => `${operation.file}#${operation.name}`),
+  )
+  for (const operation of baselineInlineOperations) {
+    if (!currentInlineOperations.has(operation)) {
+      warn('sdk-contract', `Remove resolved inline-operation baseline entry: ${operation}`)
+    }
+  }
+}
+
+const unusedSdkOperationsByFile = (
+  report: SdkContractReport,
+  exceptions: SdkContractExceptions,
+): Map<string, string[]> => {
+  const unusedByFile = new Map<string, string[]>()
+  for (const operation of report.sdkWithoutConsumer) {
+    const key = `${operation.file}#${operation.name}`
+    if (exceptions.sdkWithoutConsumer?.[key]) continue
+    const names = unusedByFile.get(operation.file) ?? []
+    names.push(operation.name)
+    unusedByFile.set(operation.file, names)
+  }
+  return unusedByFile
+}
+
+const operationNameCompare = (left: string, right: string): number => left.localeCompare(right)
+
+const reportUnusedSdkOperations = (
+  report: SdkContractReport,
+  exceptions: SdkContractExceptions,
+): void => {
+  for (const [file, operationNames] of unusedSdkOperationsByFile(report, exceptions)) {
+    operationNames.sort(operationNameCompare)
+    warn(
+      'sdk-contract',
+      `SDK operations have no in-repo value consumer: ${operationNames.join(', ')}; ` +
+        'remove them, document an external consumer, or begin API deprecation',
+      file,
+    )
+  }
+}
+
+const checkSdkContract = () => {
+  if (!existsSync('api-schema.graphql')) return
+
+  const report = getSdkContractReport({
+    adminSources: graphqlSourcesUnder('libs/shared/sdk/src/__admin'),
+    applicationSources: graphqlSourcesUnder('libs/shared/sdk/src/graphql'),
+    clientSources: clientContractSources(),
+    schemaSource: readFileSync('api-schema.graphql', 'utf8'),
+  })
+  const exceptions = readSdkContractExceptions()
+  const baseline = shouldUpdateSdkContractBaseline
+    ? writeSdkContractBaseline(report, exceptions)
+    : readSdkContractBaseline()
+  const baselineApiFields = new Set(baseline.apiWithoutSdk ?? [])
+  const baselineInlineOperations = new Set(baseline.inlineClientOperations ?? [])
+
+  reportSdkWithoutApi(report)
+  reportApiWithoutSdk(report, exceptions, baselineApiFields)
+  reportInlineClientOperations(report, exceptions, baselineInlineOperations)
+  reportResolvedSdkBaselineEntries(report, baselineApiFields, baselineInlineOperations)
+  reportUnusedSdkOperations(report, exceptions)
+}
+
+const getModuleClasses = (source: string): string[] =>
+  getRegexMatches(/export\s+class\s+(\w+Module)\b/g, source).map(match => match[1])
+
+const isExportedFromIndex = (source: string, path: string): boolean =>
+  source.includes(`'./${path}'`) || source.includes(`"./${path}"`)
+
+const validatePluginModuleFile = (
+  moduleFile: string,
+  pluginIndex: string,
+  registeredModules: Set<string>,
+) => {
+  const moduleSource = readFileSync(moduleFile, 'utf8')
+  const moduleBasename = basename(moduleFile, '.ts')
+
+  if (!isExportedFromIndex(pluginIndex, moduleBasename)) {
+    fail('plugin-structure', 'Plugin module is not exported from its index.ts', moduleFile)
+  }
+
+  for (const moduleClass of getModuleClasses(moduleSource)) {
+    if (!registeredModules.has(moduleClass)) {
+      fail(
+        'plugin-structure',
+        'Plugin module is not reachable from the API app module; import it there or from another registered module',
+        moduleFile,
+      )
+    }
+  }
+}
+
+const validatePluginDirectory = (
+  entry: string,
+  pluginsRoot: string,
+  rootIndex: string,
+  registeredModules: Set<string>,
+) => {
+  const pluginDir = join(pluginsRoot, entry)
+  if (!statSync(pluginDir).isDirectory()) return
+
+  const indexPath = join(pluginDir, 'index.ts')
+  const moduleFiles = walkFiles(pluginDir, path => path.endsWith('.module.ts'))
+  if (moduleFiles.length === 0) return
+
+  if (!existsSync(indexPath)) {
+    fail('plugin-structure', 'Plugin with module is missing index.ts barrel', indexPath)
+    return
+  }
+
+  if (!isExportedFromIndex(rootIndex, entry)) {
+    fail('plugin-structure', 'Plugin is not exported from plugins/index.ts', pluginDir)
+  }
+
+  const pluginIndex = readFileSync(indexPath, 'utf8')
+  for (const moduleFile of moduleFiles) {
+    validatePluginModuleFile(moduleFile, pluginIndex, registeredModules)
+  }
+}
+
+const checkPluginExportsAndRegistration = () => {
+  const pluginsRoot = 'libs/api/custom/src/lib/plugins'
+  if (!existsSync(pluginsRoot)) return
+
+  const rootIndexPath = join(pluginsRoot, 'index.ts')
+  const appModulePath = 'apps/api/src/app.module.ts'
+  const rootIndex = existsSync(rootIndexPath) ? readFileSync(rootIndexPath, 'utf8') : ''
+  const moduleSources = [
+    ...walkFiles('libs/api', path => path.endsWith('.module.ts')),
+    ...walkFiles('apps/api', path => path.endsWith('.module.ts')),
+  ].map(file => ({ file, source: readFileSync(file, 'utf8') }))
+  const registeredModules = getRegisteredModuleClasses(moduleSources, appModulePath)
+
+  for (const entry of readdirSync(pluginsRoot)) {
+    validatePluginDirectory(entry, pluginsRoot, rootIndex, registeredModules)
+  }
+}
+
+const getIntegrationFiles = (integrationDir: string): string[] => [
+  ...directFiles(integrationDir, path => path.endsWith('.module.ts')),
+  ...directFiles(integrationDir, path => path.endsWith('.service.ts')),
+]
+
+const validateIntegrationDirectory = (
+  entry: string,
+  integrationsRoot: string,
+  rootIndex: string,
+) => {
+  const integrationDir = join(integrationsRoot, entry)
+  if (!statSync(integrationDir).isDirectory()) return
+
+  const indexPath = join(integrationDir, 'index.ts')
+  const integrationFiles = getIntegrationFiles(integrationDir)
+  if (integrationFiles.length === 0) return
+
+  if (!existsSync(indexPath)) {
+    fail(
+      'integration-structure',
+      'Integration with service/module is missing index.ts barrel',
+      indexPath,
+    )
+    return
+  }
+
+  if (!rootIndex.includes(`'./lib/${entry}'`) && !rootIndex.includes(`"./lib/${entry}"`)) {
+    fail(
+      'integration-structure',
+      'Integration is not exported from integrations/src/index.ts',
+      integrationDir,
+    )
+  }
+
+  const integrationIndex = readFileSync(indexPath, 'utf8')
+  for (const integrationFile of integrationFiles) {
+    const expectedBasename = basename(integrationFile, '.ts')
+    if (!isExportedFromIndex(integrationIndex, expectedBasename)) {
+      fail(
+        'integration-structure',
+        'Integration module/service is not exported from its index.ts',
+        integrationFile,
+      )
+    }
+  }
+}
+
+const checkIntegrationExports = () => {
+  const integrationsRoot = 'libs/api/integrations/src/lib'
+  const rootIndexPath = 'libs/api/integrations/src/index.ts'
+  if (!existsSync(integrationsRoot)) return
+
+  const rootIndex = existsSync(rootIndexPath) ? readFileSync(rootIndexPath, 'utf8') : ''
+
+  for (const entry of readdirSync(integrationsRoot)) {
+    validateIntegrationDirectory(entry, integrationsRoot, rootIndex)
+  }
+}
+
+const checkSkipCrudDocumentation = () => {
+  if (!existsSync(schemaPath)) return
+
+  const lines = readFileSync(schemaPath, 'utf8').split('\n')
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!lines[index].includes('@skipCrud')) continue
+
+    const context = lines
+      .slice(index, index + 5)
+      .join(' ')
+      .toLowerCase()
+    const hasSecurityExplanation =
+      context.includes('security') ||
+      context.includes('credential') ||
+      context.includes('password') ||
+      context.includes('secret') ||
+      context.includes('token') ||
+      context.includes('internal')
+
+    if (!hasSecurityExplanation) {
+      fail(
+        'skip-crud',
+        '@skipCrud must include an adjacent security-sensitive internal model explanation',
+        `${schemaPath}:${index + 1}`,
+      )
+    }
+  }
+}
+
+const checkPublishablePackageReadmes = () => {
+  const packageFiles = walkFiles('libs', path => basename(path) === 'package.json')
+
+  for (const file of packageFiles) {
+    const pkg = JSON.parse(readFileSync(file, 'utf8')) as {
+      name?: string
+      publishConfig?: unknown
+      private?: boolean
+    }
+    const isPublishable = !pkg.private && (pkg.publishConfig || pkg.name?.startsWith('@nestledjs/'))
+    if (!isPublishable) continue
+
+    const readmePath = join(dirname(file), 'README.md')
+    if (!existsSync(readmePath)) {
+      fail('package-readmes', 'Publishable package is missing README.md', readmePath)
+    }
+  }
+}
+
+const checkPublishedPackageVersions = () => {
+  // Only this repository publishes @nestledjs/data-browser and @nestledjs/shared-components;
+  // downstream projects consume them from npm and must not run this check.
+  if (!isSourceTemplateRepository()) return
+
+  // A version bump lands in a PR but the npm publish happens after merge, so an
+  // unpublished version is expected on pull_request runs and only a failure once
+  // the bump has been pushed to develop.
+  const enforce = process.env.GITHUB_EVENT_NAME === 'push'
+  const packageFiles = walkFiles('libs', path => basename(path) === 'package.json')
+
+  for (const file of packageFiles) {
+    const pkg = JSON.parse(readFileSync(file, 'utf8')) as {
+      name?: string
+      version?: string
+      publishConfig?: unknown
+      private?: boolean
+    }
+    const isPublishable = !pkg.private && (pkg.publishConfig || pkg.name?.startsWith('@nestledjs/'))
+    if (!isPublishable || !pkg.name || !pkg.version) continue
+
+    const publishedVersion = getCommandOutput(`npm view "${pkg.name}@${pkg.version}" version`)
+    if (publishedVersion === pkg.version) continue
+
+    const packageOnRegistry = getCommandOutput(`npm view "${pkg.name}" name`)
+    if (!packageOnRegistry) {
+      review(
+        'published-versions',
+        `Could not verify ${pkg.name}@${pkg.version} on npm (registry unreachable or package never published)`,
+        file,
+      )
+      continue
+    }
+
+    const message = `${pkg.name}@${pkg.version} is not published to npm; publish it (pnpm nx release publish -p <project>) or revert the version bump`
+    if (enforce) {
+      fail('published-versions', message, file)
+    } else {
+      review('published-versions', message, file)
+    }
+  }
+}
+
+const readGuardBaseline = (): GuardBaseline | null => {
+  if (!existsSync(guardBaselinePath)) {
+    fail(
+      'guard-regression',
+      'Guard baseline is missing; regenerate it from the current trusted API surface',
+      guardBaselinePath,
+    )
+    return null
+  }
+
+  return JSON.parse(readFileSync(guardBaselinePath, 'utf8')) as GuardBaseline
+}
+
+const getApiGuardMap = (): GuardBaseline => {
+  const guardMap: GuardBaseline = {}
+
+  for (const file of getGuardBaselineSourceFiles()) {
+    const source = stripComments(readFileSync(file, 'utf8'))
+    const operations = getAuthOperations(source, file)
+    if (operations.length === 0) continue
+
+    guardMap[file] = {}
+    for (const operation of operations) {
+      guardMap[file][operation.name] = getOperationGuardNames(operation)
+    }
+  }
+
+  return guardMap
+}
+
+const formatGuardList = (guards: string[]): string =>
+  guards.length > 0 ? guards.join(', ') : 'none'
+
+const checkGuardRegressions = () => {
+  const baseline = readGuardBaseline()
+  if (!baseline) return
+
+  const current = getApiGuardMap()
+  for (const [file, methods] of Object.entries(baseline)) {
+    if (!existsSync(file)) continue
+
+    for (const [method, expectedGuards] of Object.entries(methods)) {
+      const actualGuards = current[file]?.[method]
+      if (!actualGuards) continue
+
+      if (getGuardRank(actualGuards) < getGuardRank(expectedGuards)) {
+        fail(
+          'guard-regression',
+          `API operation guard for ${method} was downgraded from ${formatGuardList(
+            expectedGuards,
+          )} to ${formatGuardList(actualGuards)}`,
+          file,
+        )
+      }
+    }
+  }
+}
+
+const readPublicOperationAllowlist = (): PublicOperationAllowlist => {
+  if (!existsSync(publicOperationsPath)) {
+    fail(
+      'unguarded-operation',
+      'Public operation allowlist is missing; every intentionally public root operation must be declared there',
+      publicOperationsPath,
+    )
+    return {}
+  }
+
+  return JSON.parse(readFileSync(publicOperationsPath, 'utf8')) as PublicOperationAllowlist
+}
+
+const reportStalePublicOperations = (
+  allowlist: PublicOperationAllowlist,
+  unguarded: Set<string>,
+) => {
+  for (const [file, operations] of Object.entries(allowlist)) {
+    for (const name of Object.keys(operations)) {
+      if (unguarded.has(`${file}::${name}`)) continue
+      warn(
+        'unguarded-operation',
+        `Allowlisted public operation ${name} is now guarded or no longer exists; remove the stale entry`,
+        publicOperationsPath,
+      )
+    }
+  }
+}
+
+// `checkGuardRegressions` only walks the baseline, so it can catch a guard being *downgraded* but
+// never a brand-new operation that shipped with no guard at all. Check GraphQL resolvers and REST
+// controllers together: every API operation must carry an auth guard or be allowlisted as public.
+const checkUnguardedRootOperations = () => {
+  const allowlist = readPublicOperationAllowlist()
+  const unguarded = new Set<string>()
+
+  for (const file of getAuthSourceFiles()) {
+    const source = stripComments(readFileSync(file, 'utf8'))
+
+    for (const operation of getAuthOperations(source, file)) {
+      // Keep @ResolveField handlers in this check. Nest executes guards on field handlers, and the
+      // parent root may be public or otherwise less restrictive than the field it exposes.
+      if (hasAuthenticationGuard(operation)) continue
+
+      unguarded.add(`${file}::${operation.name}`)
+      if (allowlist[file]?.[operation.name]) continue
+
+      fail(
+        'unguarded-operation',
+        `API operation ${operation.className}.${operation.name} has no auth guard and is reachable unauthenticated; add @UseGuards(...) or declare it in ${publicOperationsPath} with a reason`,
+        file,
+        operation.line,
+      )
+    }
+  }
+
+  reportStalePublicOperations(allowlist, unguarded)
+}
+
+const updateGuardBaseline = () => {
+  mkdirSync(dirname(guardBaselinePath), { recursive: true })
+  writeFileSync(guardBaselinePath, `${JSON.stringify(getApiGuardMap(), null, 2)}\n`)
+  try {
+    execSync(`pnpm exec prettier --write ${guardBaselinePath}`, { stdio: 'ignore' })
+  } catch {
+    // Formatting is best effort; format:check will catch any remaining drift.
+  }
+}
+
+const isGeneratedOrExternalCode = (path: string): boolean =>
+  path.includes('/node_modules/') ||
+  path.includes('/build/') ||
+  path.includes('/dist/') ||
+  path.includes('/coverage/') ||
+  path.includes('libs/api/generated-crud/') ||
+  path.includes('libs/api/prisma/src/lib/prisma-generated/') ||
+  path.includes('libs/shared/sdk/src/generated/')
+
+const checkUnsafeTypeScriptCasts = () => {
+  const files = walkFiles(
+    '.',
+    path =>
+      /\.(ts|tsx)$/.test(path) &&
+      // scripts/ is one-off ops/maintenance tooling (also excluded from Sonar), not shipped product
+      // code; the cast gate targets the product surface. Specs and skipped future specs likewise.
+      !path.startsWith('scripts/') &&
+      !path.endsWith('.spec.ts') &&
+      !path.endsWith('.spec.tsx') &&
+      !path.endsWith('.spec.future.ts') &&
+      !isGeneratedOrExternalCode(path),
+  )
+
+  // The cast patterns scan code only: raw source flagged the English "…the same two locks as any
+  // other write" in a comment, and would equally flag an error-message string. `@ts-ignore` is the
+  // opposite case — the directive IS a comment — so it scans raw text, tightened to a `//` comment
+  // that OPENS with the directive (the form TypeScript honors, leading or trailing). Prose
+  // mentioning @ts-ignore mid-sentence suppresses nothing and no longer flags.
+  const unsafePatterns = [
+    { pattern: /\bas\s+any\b/g, message: 'Avoid as any in non-generated source', codeOnly: true },
+    {
+      pattern: /\bas\s+unknown\s+as\b/g,
+      message: 'Avoid double-casting through unknown',
+      codeOnly: true,
+    },
+    {
+      pattern: /\/\/\s*@ts-ignore\b/g,
+      message: 'Use typed code instead of @ts-ignore',
+      codeOnly: false,
+    },
+  ]
+
+  for (const file of files) {
+    const source = readFileSync(file, 'utf8')
+    // Offset-preserving, so match indexes remain valid against the raw source for line numbers.
+    const code = blankCommentsAndStrings(source)
+    for (const { pattern, message, codeOnly } of unsafePatterns) {
+      for (const match of getRegexMatches(pattern, codeOnly ? code : source)) {
+        review('typescript-safety', message, file, getLineNumber(source, match.index))
+      }
+    }
+  }
+}
+
+// Generator output, not authored code. `db-update` runs the doctor, regenerates, then runs the
+// doctor again — so the second run always sees these rewritten and would demand a note for a file
+// nobody wrote. Nothing is lost by skipping them: the change that produced them is `schema.prisma`,
+// which is gated on its own line below, so gating the generated mirror too makes one change demand
+// two notes. Generated CRUD output (`libs/api/generated-crud/**`) already sits outside this gate
+// for the same reason.
+//
+// Exact file paths, NOT a directory prefix: `models/` also holds hand-written files
+// (`core-paging.model.ts`), and `api-core-models.module.ts` sits beside it — a prefix would
+// silently ungate them. These three are what `nx g @nestledjs/generators:models` writes; if that
+// generator's output ever changes, this list changes with it.
+const generatedOutputPaths = new Set([
+  'libs/api/core/models/src/lib/models/models.ts',
+  'libs/api/core/models/src/lib/models/enums.ts',
+  'libs/api/core/models/src/lib/models/index.ts',
+])
+
+const isGeneratedOutput = (path: string): boolean => generatedOutputPaths.has(path)
+
+const isSensitiveUpgradePath = (path: string): boolean =>
+  !isGeneratedOutput(path) &&
+  (/^libs\/api\/(core|custom|utils|integrations)\//.test(path) ||
+    path.startsWith('apps/api/') ||
+    path.startsWith('apps/web/app/routes/') ||
+    path === 'apps/web/app/routes.tsx' ||
+    path === schemaPath ||
+    path.includes('/guards/') ||
+    path.includes('/billing/') ||
+    path.includes('/auth/') ||
+    path.includes('/rbac/') ||
+    path.includes('/admin/'))
+
+const checkUpgradeNoteImpactGate = () => {
+  if (!isSourceTemplateRepository()) return
+
+  const changedFiles = getChangedFiles()
+  const changedSensitiveFiles = changedFiles.filter(isSensitiveUpgradePath)
+  if (changedSensitiveFiles.length === 0) return
+
+  const changedNotes = changedFiles.filter(
+    path => path.startsWith(`${notesDir}/`) && path.endsWith('.yaml'),
+  )
+  if (changedNotes.length === 0) {
+    fail(
+      'upgrade-notes',
+      'Sensitive template behavior changed without a new upgrade note or priority: ignore note',
+      changedSensitiveFiles[0],
+    )
+  }
+}
+
+const hasContextScopeAnchor = (source: string): boolean =>
+  /@CtxUser\s*\(\)|\buser\.(?:id|organizationId|currentOrganizationId)\b|currentUser|organizationScoped/i.test(
+    source,
+  )
+
+const usesInputIdInPrismaWhere = (source: string): boolean =>
+  /\b(?:userId|organizationId|teamId|roleId|memberId|inviteId|subscriptionId|tokenId)\b/.test(
+    source,
+  ) &&
+  /\b(?:findFirst|findUnique|findMany|update|updateMany|delete|deleteMany|create)\s*\(/.test(source)
+
+const checkResolverScopeAnchoring = () => {
+  const resolverFiles = walkFiles('libs/api/custom/src/lib', path => path.endsWith('.resolver.ts'))
+
+  for (const file of resolverFiles) {
+    const source = stripComments(readFileSync(file, 'utf8'))
+    for (const operation of getGraphqlOperationMethods(source)) {
+      // The whole method, not decorators+body: @CtxUser() lives in the parameter list.
+      const operationSource = operation.text
+      if (!/@Args\s*\(/.test(operationSource) || !usesInputIdInPrismaWhere(operationSource))
+        continue
+      if (hasContextScopeAnchor(operationSource)) continue
+
+      review(
+        'resolver-scope',
+        `Review ${operation.name}: resolver uses caller-supplied IDs in data access without an obvious @CtxUser scope anchor`,
+        file,
+        operation.line,
+      )
+    }
+  }
+}
+
+const isSensitiveMutationDomain = (file: string): boolean =>
+  /\/(auth|admin|billing|organization|subscription|user|role|permission|invite)\//.test(file)
+
+const hasAuditMarker = (source: string): boolean =>
+  /\baudit(?:Log)?\b|recordAuditLog|SecurityEvent|securityEvent/i.test(source)
+
+const hasSiblingServiceAuditMarker = (file: string): boolean => {
+  const serviceFiles = directFiles(dirname(file), path => path.endsWith('.service.ts'))
+  return serviceFiles.some(serviceFile =>
+    hasAuditMarker(stripComments(readFileSync(serviceFile, 'utf8'))),
+  )
+}
+
+const checkAuditCoverageHeuristic = () => {
+  const resolverFiles = walkFiles('libs/api/custom/src/lib', path => path.endsWith('.resolver.ts'))
+
+  for (const file of resolverFiles) {
+    if (!isSensitiveMutationDomain(file)) continue
+
+    const source = stripComments(readFileSync(file, 'utf8'))
+    const siblingServiceHasAuditMarker = hasSiblingServiceAuditMarker(file)
+    for (const operation of getGraphqlOperationMethods(source)) {
+      if (!/@Mutation\b/.test(operation.decorators)) continue
+      if (
+        hasAuditMarker(operation.body) ||
+        hasAuditMarker(source) ||
+        siblingServiceHasAuditMarker
+      ) {
+        continue
+      }
+
+      review(
+        'audit-coverage',
+        `Review ${operation.name}: sensitive mutation has no obvious audit log call in its resolver file`,
+        file,
+        operation.line,
+      )
+    }
+  }
+}
+
+const hasPrivilegeCeiling = (source: string): boolean =>
+  /role|permission|privilege|superAdmin|isSuperAdmin|higher|equal|ceiling/i.test(source)
+
+type GraphqlOperation = ReturnType<typeof getGraphqlOperationMethods>[number]
+
+const isEmulationMutation = (operation: GraphqlOperation): boolean =>
+  /@Mutation\b/.test(operation.decorators) &&
+  (/\b(emulat|impersonat)/i.test(operation.name) ||
+    /\b\w+\.emulate\w*\s*\(/i.test(operation.body) ||
+    /\b\w+\.impersonate\w*\s*\(/i.test(operation.body))
+
+const hasEmulationAuthorization = (operation: GraphqlOperation): boolean =>
+  operation.decorators.includes('GqlAuthAdminGuard') ||
+  (operation.decorators.includes('RequirePlatformPermission') &&
+    operation.decorators.includes('platform.users.emulate'))
+
+const checkEmulationResolverFile = (file: string) => {
+  const source = stripComments(readFileSync(file, 'utf8'))
+  for (const operation of getGraphqlOperationMethods(source)) {
+    if (!isEmulationMutation(operation) || hasEmulationAuthorization(operation)) continue
+    fail(
+      'emulation-security',
+      `Emulation/impersonation resolver ${operation.name} must require GqlAuthAdminGuard or platform.users.emulate`,
+      file,
+    )
+  }
+}
+
+const checkEmulationServiceFile = (file: string) => {
+  const source = stripComments(readFileSync(file, 'utf8'))
+  if (!/\b(emulat|impersonat)/i.test(source) || hasPrivilegeCeiling(source)) return
+  fail(
+    'emulation-security',
+    'Emulation/impersonation service code must enforce an explicit privilege ceiling',
+    file,
+  )
+}
+
+const checkEmulationPrivilegeCeiling = () => {
+  walkFiles('libs/api/custom/src/lib', path => path.endsWith('.resolver.ts')).forEach(
+    checkEmulationResolverFile,
+  )
+  walkFiles(
+    'libs/api/custom/src/lib',
+    path => path.endsWith('.service.ts') && !path.endsWith('.spec.ts'),
+  ).forEach(checkEmulationServiceFile)
+}
+
+// Read one key out of an already-loaded `.env` body. Shared by every check that inspects local
+// env pairings, so the quoting/comment rules stay in one place.
+const readEnvValue = (env: string, key: string): string => {
+  const line = env.split('\n').find(l => l.startsWith(`${key}=`))
+  const raw = line ? line.slice(key.length + 1).trim() : ''
+  // Quoted value: strip the surrounding quotes and keep it verbatim. Unquoted
+  // value: drop a dotenv-style inline ` # comment` so the parsed value matches
+  // what dotenv actually loads. (String ops, not regex — avoids backtracking.)
+  const quote = raw[0]
+  if ((quote === '"' || quote === "'") && raw.length >= 2 && raw.endsWith(quote)) {
+    return raw.slice(1, -1)
+  }
+  const commentAt = raw.indexOf(' #')
+  return (commentAt === -1 ? raw : raw.slice(0, commentAt)).trim()
+}
+
+const checkCookieDomainConfig = () => {
+  if (!existsSync('.env')) return
+  const env = readFileSync('.env', 'utf8')
+  const read = (key: string) => readEnvValue(env, key)
+  const apiDomain = read('API_COOKIE_DOMAIN')
+  const webDomain = read('VITE_COOKIE_DOMAIN')
+  const isLocal = (v: string) => !v || v === 'localhost' || v.startsWith('127.')
+  // Cookie scope ignores a single leading dot and case, so `.example.com` and
+  // `example.com` are equivalent — normalize before comparing to avoid false warnings.
+  const sameDomain = (a: string, b: string) =>
+    a.replace(/^\./, '').toLowerCase() === b.replace(/^\./, '').toLowerCase()
+  if (!isLocal(apiDomain) && isLocal(webDomain)) {
+    warn(
+      'cookie-domain',
+      `API_COOKIE_DOMAIN=${apiDomain} is domain-scoped but VITE_COOKIE_DOMAIN is unset/localhost; ` +
+        `the web app cannot clear the session cookie (PIR-173 redirect-loop risk). ` +
+        `Set VITE_COOKIE_DOMAIN to match.`,
+      '.env',
+    )
+  } else if (!isLocal(apiDomain) && !isLocal(webDomain) && !sameDomain(apiDomain, webDomain)) {
+    warn(
+      'cookie-domain',
+      `VITE_COOKIE_DOMAIN (${webDomain}) does not match API_COOKIE_DOMAIN (${apiDomain}).`,
+      '.env',
+    )
+  }
+}
+
+// Local dev ports move in must-move-together pairs: a port var, and the URL that points at it.
+// Moving only one half fails SILENTLY — the process starts clean and is broken only in the
+// browser, or, worse, connects to another repo's database. Documentation alone does not catch a
+// half-edited .env; this does. See the port block in .env.example.
+//
+// WARN ONLY, never fail: .env is developer-local, CI has none, and a deliberate local setup must
+// never be able to break a build.
+type EnvReader = (key: string) => string
+
+const DEV_PORT_DEFAULTS: Record<string, string> = {
+  PORT: '3000',
+  WEB_PORT: '4200',
+  POSTGRES_PORT: '5432',
+  POSTGRES_TEST_PORT: '5433',
+  REDIS_PORT: '6379',
+  MAILHOG_SMTP_PORT: '1025',
+}
+
+// A URL with no explicit port still connects to a concrete one, and that is exactly where the
+// nastiest case hides: `postgresql://prisma:prisma@localhost/prisma` alongside POSTGRES_PORT=5442
+// silently reaches 5432 — a DIFFERENT repo's database. Treating "no port written down" as
+// "unknown, skip it" left that unwarned, so resolve the scheme's implicit port instead.
+const DEFAULT_SCHEME_PORTS: Record<string, string> = {
+  'postgres:': '5432',
+  'postgresql:': '5432',
+  'redis:': '6379',
+  'rediss:': '6380',
+  'http:': '80',
+  'https:': '443',
+}
+
+/**
+ * A URL's effective host port: the explicit one, else the scheme's default. '' only when the value
+ * is unparseable or its scheme has no known default — genuinely unknown, and not this check's
+ * problem. (`new URL` also drops a port that equals the scheme default, so `http://host:80` and
+ * `http://host` both resolve to 80 here.)
+ */
+const urlPort = (value: string): string => {
+  try {
+    const url = new URL(value)
+    return url.port || DEFAULT_SCHEME_PORTS[url.protocol] || ''
+  } catch {
+    return ''
+  }
+}
+
+/** The value of a port var only when it has actually moved off its default; '' otherwise. */
+const movedDevPort = (read: EnvReader, key: string): string => {
+  const value = read(key)
+  return value.length > 0 && value !== DEV_PORT_DEFAULTS[key] ? value : ''
+}
+
+const warnPortMismatch = (options: {
+  portKey: string
+  port: string
+  urlKey: string
+  urlValue: string
+  requireSet: boolean
+  consequence: string
+  fix: string
+}) => {
+  const { portKey, port, urlKey, urlValue, requireSet, consequence, fix } = options
+  if (urlValue.length === 0) {
+    if (requireSet) {
+      warn(
+        'dev-ports',
+        `${portKey}=${port} but ${urlKey} is not set — ${consequence} ${fix}`,
+        '.env',
+      )
+    }
+    return
+  }
+
+  const actual = urlPort(urlValue)
+  if (actual === '' || actual === port) return
+
+  warn(
+    'dev-ports',
+    `${portKey}=${port} but ${urlKey} uses port ${actual} — ${consequence} ${fix}`,
+    '.env',
+  )
+}
+
+const checkApiPortPairing = (read: EnvReader) => {
+  const port = movedDevPort(read, 'PORT')
+  if (!port) return
+
+  for (const urlKey of ['VITE_API_URL', 'API_URL']) {
+    warnPortMismatch({
+      portKey: 'PORT',
+      port,
+      urlKey,
+      urlValue: read(urlKey),
+      requireSet: true,
+      consequence: 'the browser will call the old API port and every request 404s or hangs.',
+      fix: `Set ${urlKey} to http://localhost:${port}.`,
+    })
+  }
+}
+
+const checkWebPortPairing = (read: EnvReader) => {
+  const port = movedDevPort(read, 'WEB_PORT')
+  if (!port) return
+
+  const origins = read('ALLOWED_ORIGINS')
+    .split(',')
+    .map(origin => origin.trim())
+    .filter(origin => origin.length > 0)
+
+  if (origins.length > 0 && !origins.some(origin => urlPort(origin) === port)) {
+    warn(
+      'dev-ports',
+      `WEB_PORT=${port} but ALLOWED_ORIGINS does not include http://localhost:${port} — ` +
+        `the API will reject every browser request with a CORS error. Add it to ALLOWED_ORIGINS.`,
+      '.env',
+    )
+  }
+
+  // An unset ALLOWED_ORIGINS is fine: the API derives the origin from WEB_URL, and failing that
+  // from WEB_PORT. Only an explicit WEB_URL on the wrong port defeats that derivation.
+  if (origins.length === 0) {
+    warnPortMismatch({
+      portKey: 'WEB_PORT',
+      port,
+      urlKey: 'WEB_URL',
+      urlValue: read('WEB_URL'),
+      requireSet: false,
+      consequence:
+        'ALLOWED_ORIGINS is empty, so CORS falls back to WEB_URL and the API will reject every ' +
+        'browser request.',
+      fix: `Set WEB_URL to http://localhost:${port}, or list the origin in ALLOWED_ORIGINS.`,
+    })
+  }
+
+  warnPortMismatch({
+    portKey: 'WEB_PORT',
+    port,
+    urlKey: 'SITE_URL',
+    urlValue: read('SITE_URL'),
+    requireSet: false,
+    consequence:
+      'links in verification, password-reset, and invite emails point at the old web port.',
+    fix: `Set SITE_URL to http://localhost:${port}.`,
+  })
+}
+
+const checkDatabasePortPairings = (read: EnvReader) => {
+  const pgPort = movedDevPort(read, 'POSTGRES_PORT')
+  if (pgPort) {
+    for (const urlKey of ['DATABASE_URL', 'DIRECT_URL']) {
+      warnPortMismatch({
+        portKey: 'POSTGRES_PORT',
+        port: pgPort,
+        urlKey,
+        urlValue: read(urlKey),
+        // DIRECT_URL is optional locally; DATABASE_URL is not.
+        requireSet: urlKey === 'DATABASE_URL',
+        consequence:
+          'this connects to whatever Postgres is on the old port, very likely a DIFFERENT ' +
+          'repo database, with no error anywhere.',
+        fix: `Point ${urlKey} at port ${pgPort}.`,
+      })
+    }
+  }
+
+  const testPort = movedDevPort(read, 'POSTGRES_TEST_PORT')
+  if (!testPort) return
+  warnPortMismatch({
+    portKey: 'POSTGRES_TEST_PORT',
+    port: testPort,
+    urlKey: 'TEST_DATABASE_URL',
+    urlValue: read('TEST_DATABASE_URL'),
+    requireSet: true,
+    consequence: 'pnpm test:e2e will run against the wrong database, or none at all.',
+    fix: `Point TEST_DATABASE_URL at port ${testPort}.`,
+  })
+}
+
+const checkServicePortPairings = (read: EnvReader) => {
+  const redisPort = movedDevPort(read, 'REDIS_PORT')
+  if (redisPort) {
+    warnPortMismatch({
+      portKey: 'REDIS_PORT',
+      port: redisPort,
+      urlKey: 'REDIS_URL',
+      urlValue: read('REDIS_URL'),
+      requireSet: false,
+      consequence: 'the API will talk to whatever Redis is on the old port.',
+      fix: `Point REDIS_URL at port ${redisPort}.`,
+    })
+  }
+
+  const mailhogPort = movedDevPort(read, 'MAILHOG_SMTP_PORT')
+  if (!mailhogPort) return
+
+  const smtpHost = read('SMTP_HOST')
+  const isLocalSmtp = !smtpHost || smtpHost === 'localhost' || smtpHost.startsWith('127.')
+  const smtpPort = read('SMTP_PORT')
+  if (!isLocalSmtp || !smtpPort || smtpPort === mailhogPort) return
+
+  warn(
+    'dev-ports',
+    `MAILHOG_SMTP_PORT=${mailhogPort} but SMTP_PORT=${smtpPort} with a local SMTP_HOST — ` +
+      `outbound dev mail will fail to connect. Set SMTP_PORT to ${mailhogPort}.`,
+    '.env',
+  )
+}
+
+const checkDevPortPairings = () => {
+  if (!existsSync('.env')) return
+  const env = readFileSync('.env', 'utf8')
+  const read = (key: string) => readEnvValue(env, key)
+
+  checkApiPortPairing(read)
+  checkWebPortPairing(read)
+  checkDatabasePortPairings(read)
+  checkServicePortPairings(read)
+}
+
+// `GlobalAuthGuard` applies equally to GraphQL resolvers and REST controllers. Declaration is the
+// only way through, so Doctor must inspect both surfaces or a controller can pass review and start
+// returning 403 for every request at runtime. Generated CRUD is covered here too rather than
+// exempted: a regeneration that drops a decorator should fail before deployment.
+const checkAuthLevelDeclarations = () => {
+  for (const file of getAuthSourceFiles()) {
+    const source = stripComments(readFileSync(file, 'utf8'))
+
+    for (const operation of getAuthOperations(source, file)) {
+      // GlobalAuthGuard also evaluates @ResolveField handlers, so they need explicit intent even
+      // though they are reached through a parent root operation.
+      if (declaresAuthLevel(operation)) continue
+
+      fail(
+        'auth-level',
+        `API operation ${operation.className}.${operation.name} does not declare an access level; add @Public(), @Authenticated(), @AdminOnly(), or a scoped permission decorator at the method or class level so intent is explicit`,
+        file,
+        operation.line,
+      )
+    }
+  }
+}
+
+const readPermissionCatalogs = () => {
+  const platform = new Set<string>()
+  if (existsSync(platformPermissionCatalogPath)) {
+    const source = readFileSync(platformPermissionCatalogPath, 'utf8')
+    for (const entry of readStringObjectArray(source, 'platformPermissions', ['key'])) {
+      platform.add(entry.key)
+    }
+  }
+  const organization = new Set<string>()
+  if (existsSync(organizationPermissionCatalogPath)) {
+    const source = readFileSync(organizationPermissionCatalogPath, 'utf8')
+    for (const entry of readStringObjectArray(source, 'defaultPermissions', [
+      'subject',
+      'action',
+    ])) {
+      organization.add(`${entry.subject}:${entry.action}`)
+    }
+  }
+  return { organization, platform }
+}
+
+const reportAccessPolicyDeclaration = (
+  declaration: AccessPolicyDeclaration,
+  file: string,
+  catalogs: ReturnType<typeof readPermissionCatalogs>,
+  emptyScopesInUse: Set<string>,
+): void => {
+  if (declaration.permissions.length === 0) {
+    fail(
+      'access-policy',
+      `${declaration.className}.${declaration.name} declares ${declaration.decorator} without a permission`,
+      file,
+      declaration.line,
+    )
+    return
+  }
+
+  const catalog = catalogs[declaration.scope]
+  // An empty catalog would report EVERY declared permission as "unknown" — a broken read, not N real
+  // findings (fleet-upstream #120). Note the scope once; the caller reports it after the sweep.
+  if (catalog.size === 0) {
+    emptyScopesInUse.add(declaration.scope)
+    return
+  }
+  for (const permission of declaration.permissions) {
+    if (catalog.has(permission)) continue
+    fail(
+      'access-policy',
+      `${declaration.className}.${declaration.name} declares unknown ${declaration.scope} permission ${permission}; add it to the code-owned catalog or fix the typo`,
+      file,
+      declaration.line,
+    )
+  }
+}
+
+type PermissionExemptions = Record<string, Record<string, string>>
+
+const readPermissionExemptions = (): PermissionExemptions => {
+  if (!existsSync(permissionExemptionsPath)) return {}
+  return JSON.parse(readFileSync(permissionExemptionsPath, 'utf8')) as PermissionExemptions
+}
+
+/**
+ * Authentication says *someone* is calling. It never says *this* caller may do *this*.
+ *
+ * Two mechanisms answer that question, and both are legitimate:
+ *
+ *   1. a declared permission — for anything touching shared or other people's data;
+ *   2. caller scoping — `me`, `changePassword`, own tokens and preferences, where the question is
+ *      not "do you hold permission X" but "is this row yours", enforced by taking @CtxUser() and
+ *      passing the caller's id into the query.
+ *
+ * An operation with NEITHER is the interesting case: authenticated, but nothing anywhere decides
+ * whether this caller may do this to this row. That is not a hypothetical — `getSignedUrl` and
+ * `organizationFiles` were exactly this shape, took a caller-supplied id, and let any authenticated
+ * user read any private file and list any organization's files.
+ *
+ * Requiring a permission from every operation would instead demand ~59 written exemptions in this
+ * template alone, which is a list nobody reads rather than a rule, and would bury the few that
+ * matter among the many that are already correct.
+ */
+const reportUnauthorizedOperations = (
+  file: string,
+  exemptions: PermissionExemptions,
+  unauthorized: Set<string>,
+): void => {
+  const raw = readFileSync(file, 'utf8')
+  const source = stripComments(raw)
+
+  const guardedNames = new Set(
+    getAuthOperations(source, file)
+      .filter(operation => hasAuthenticationGuard(operation))
+      .map(operation => operation.name),
+  )
+
+  for (const operation of getUndeclaredAccessOperations(raw, file, name =>
+    guardedNames.has(name),
+  )) {
+    if (operation.callerScoped) continue
+
+    unauthorized.add(`${file}::${operation.name}`)
+    if (exemptions[file]?.[operation.name]) continue
+
+    fail(
+      'access-policy',
+      `${operation.className}.${operation.name} is authenticated but neither declares a permission nor scopes to the caller; add a Require*Permission decorator, take @CtxUser() and scope the query, or record it in ${permissionExemptionsPath} with a reason`,
+      file,
+      operation.line,
+    )
+  }
+}
+
+// An exemption that no longer applies is a claim nobody is checking.
+const reportStaleExemptions = (
+  exemptions: PermissionExemptions,
+  unauthorized: Set<string>,
+): void => {
+  for (const [file, operations] of Object.entries(exemptions)) {
+    for (const name of Object.keys(operations)) {
+      if (unauthorized.has(`${file}::${name}`)) continue
+      warn(
+        'access-policy',
+        `Exempted operation ${name} is now authorized or no longer exists; remove the stale entry`,
+        permissionExemptionsPath,
+      )
+    }
+  }
+}
+
+// The enforcement surface: the checks every repo is judged by. The promotion mirror copies these
+// verbatim into eleven repos, so they have to be portable — free of anything true of one repo only.
+// Both prefixes in both directories, and .mjs as well as .ts. The first cut matched only
+// scripts/doctor*.ts and tools/verify-*.ts, which silently excluded five enforcement files that
+// CI actually runs: scripts/verify-prisma-client.ts, tools/verify-selects.mjs,
+// tools/verify-select-coverage.mjs and the two .mjs specs. A guard with an arbitrary blind spot is
+// worse than none, because the gap is invisible from its passing output.
+const enforcementSourceGlobs = ['scripts', 'tools'].map(dir => ({
+  dir,
+  match: (name: string) => /^(?:doctor|verify-).*\.(?:ts|mjs)$/.test(name),
+}))
+
+// The test is not "is it on a short list" but "does it resolve identically in every clone".
+// A published package the template declares does; a workspace scope (@nestled-template/...,
+// @mi-core/...) does not, because the scope is rewritten per clone.
+//
+// Still an allowlist rather than a scope-shaped denylist: adding a dependency that all eleven repos
+// must then carry should be a decision taken once, not a drive-by import.
+const portableEnforcementModules = new Set([
+  'typescript',
+  'graphql',
+  'vitest',
+  // Dynamically imported by verify-selects, with a fallback when it is unavailable. A direct
+  // devDependency of the template, so present wherever the template's package.json is.
+  '@prisma/internals',
+])
+
+const enforcementSourceFiles = (): string[] =>
+  enforcementSourceGlobs.flatMap(({ dir, match }) =>
+    existsSync(dir)
+      ? readdirSync(dir)
+          .filter(match)
+          .map(name => `${dir}/${name}`)
+      : [],
+  )
+
+/**
+ * Enforcement code must not import anything repo-specific — including this repo's own scope.
+ *
+ * These files are copied verbatim into every clone, where the workspace scope is different
+ * (`@mi-core/...`, `@cashcast/...`, …). An import of `@nestled-template/api/utils` would resolve
+ * here and nowhere else, so the check would silently stop working in exactly the repos it is meant
+ * to police — while continuing to pass in the one place anybody looks.
+ *
+ * Scoped to the source template on purpose: this exists to stop repo-specific content being
+ * promoted INTO the shared tool. A downstream repo's local edits are a different question, and are
+ * surfaced by the upgrader's convergence-status enforcement drift report.
+ *
+ * Limit worth stating: this reads imports, which are precise. A hardcoded repo-specific PATH STRING
+ * inside a check would not be caught — a real near-miss, since mi-core's local doctor edit
+ * referenced a path that exists only there.
+ */
+const checkEnforcementPortability = () => {
+  if (!isSourceTemplateRepository()) return
+
+  for (const file of enforcementSourceFiles()) {
+    for (const specifier of getExternalImportSpecifiers(readFileSync(file, 'utf8'), file)) {
+      if (specifier.startsWith('node:')) continue
+      if (portableEnforcementModules.has(specifier)) continue
+
+      fail(
+        'enforcement-portability',
+        `Enforcement code must be portable across every clone, but ${file} imports "${specifier}"; use only node builtins, ${[...portableEnforcementModules].join('/')}, or a relative sibling — a workspace-scoped import resolves in this repo alone`,
+        file,
+      )
+    }
+  }
+}
+
+const checkAccessPolicyCoverage = () => {
+  const exemptions = readPermissionExemptions()
+  const unauthorized = new Set<string>()
+
+  for (const file of getAuthSourceFiles()) {
+    // Generated CRUD is governed by generated-crud posture, not per-operation permissions: the
+    // whole surface is one declared tier, asserted by checkGeneratedCrudPosture.
+    if (file.includes('libs/api/generated-crud/')) continue
+    reportUnauthorizedOperations(file, exemptions, unauthorized)
+  }
+
+  reportStaleExemptions(exemptions, unauthorized)
+}
+
+const reportInlineAccessViolation = (violation: InlineAccessCheckViolation, file: string): void => {
+  fail(
+    'access-policy',
+    `${violation.className}.${violation.name} calls ${violation.calls.join(', ')} inside the operation body without a scoped permission decorator; move the role gate into declarative metadata and leave only row/object checks in the service`,
+    file,
+    violation.line,
+  )
+}
+
+const checkAccessPolicyDeclarations = () => {
+  const catalogs = readPermissionCatalogs()
+  const emptyScopesInUse = new Set<string>()
+
+  for (const file of getAuthSourceFiles()) {
+    const report = analyzeAccessPolicies(readFileSync(file, 'utf8'), file)
+    for (const declaration of report.declarations) {
+      reportAccessPolicyDeclaration(declaration, file, catalogs, emptyScopesInUse)
+    }
+    for (const violation of report.inlineViolations) {
+      reportInlineAccessViolation(violation, file)
+    }
+  }
+
+  const scopeCatalogPath: Record<string, string> = {
+    platform: platformPermissionCatalogPath,
+    organization: organizationPermissionCatalogPath,
+  }
+  for (const scope of emptyScopesInUse) {
+    fail(
+      'access-policy',
+      `The ${scope} permission catalog is empty or unreadable, so access-policy declarations using it cannot be validated (every permission would otherwise report "unknown"). Check the catalog seed file and the exported array the doctor reads.`,
+      scopeCatalogPath[scope],
+    )
+  }
+}
+
+// A concurrent `prisma generate` — typically `db-update` running while a dev server triggers its
+// own generate — can truncate the client to an empty file while still reporting success. Nx cannot
+// see it: `api-prisma:generate` declares this directory as an output, but Nx hashes inputs, so an
+// unchanged schema yields an unchanged cache key no matter what the generator actually wrote. The
+// directory is also gitignored, so nothing else notices either.
+//
+// The resulting failure is three hops from its cause. `client.ts` re-exports this file, so every
+// enum becomes undefined at runtime, `registerEnumType(undefined, ...)` stores an undefined ref, and
+// the API dies during GraphQL schema build with "Cannot convert undefined or null to object" —
+// naming neither Prisma nor this file.
+const checkPrismaGeneratedEnums = () => {
+  const generatedDir = 'libs/api/prisma/src/lib/prisma-generated'
+  // Nothing generated yet is a legitimate state, e.g. a fresh clone before the first generate.
+  if (!existsSync(generatedDir) || !existsSync(schemaPath)) return
+
+  const declaredEnums = getRegexMatches(/^enum\s+(\w+)/gm, readFileSync(schemaPath, 'utf8')).map(
+    match => match[1],
+  )
+  if (declaredEnums.length === 0) return
+
+  const enumsPath = join(generatedDir, 'enums.ts')
+  if (!existsSync(enumsPath)) {
+    fail(
+      'prisma-generated',
+      `${schemaPath} declares ${declaredEnums.length} enum(s) but the generated enums file is missing; re-run pnpm prisma:generate`,
+      enumsPath,
+    )
+    return
+  }
+
+  const source = readFileSync(enumsPath, 'utf8')
+  const missing = declaredEnums.filter(name => !source.includes(`export const ${name} =`))
+  if (missing.length === 0) return
+
+  fail(
+    'prisma-generated',
+    `Generated Prisma enums are incomplete (missing ${missing.join(', ')}). The client was written truncated, so these are undefined at runtime and the API will fail during GraphQL schema build. Re-run pnpm prisma:generate, then rebuild with --skip-nx-cache because Nx will otherwise reuse the stale bundle`,
+    enumsPath,
+  )
+}
+
+const printFindings = (label: string, items: Finding[]) => {
+  if (items.length === 0) return
+
+  console.log(`\n${label}`)
+  for (const item of items) {
+    let location = ''
+    if (item.file) {
+      location = relative(process.cwd(), item.file)
+      if (item.line) {
+        location = `${location}:${item.line}`
+      }
+    }
+    const suffix = location ? ` (${location})` : ''
+    console.log(`- [${item.check}] ${item.message}${suffix}`)
+  }
+}
+
+const cleanDownstreamAgentsMd = () => {
+  if (isSourceTemplateRepository()) return
+
+  const agentsPath = 'AGENTS.md'
+  if (!existsSync(agentsPath)) return
+
+  const content = readFileSync(agentsPath, 'utf8')
+
+  // Locate the section by string scanning rather than a regex — avoids backtracking on large files
+  // and, unlike the previous `(?=\n\n## )` lookahead, correctly handles the case where "Downstream
+  // Upgrade Notes" is the LAST section (no following `## ` header) by falling back to end-of-file.
+  const marker = '\n\n## Downstream Upgrade Notes\n'
+  const start = content.indexOf(marker)
+  if (start === -1) return
+
+  const nextHeader = content.indexOf('\n\n## ', start + marker.length)
+  const end = nextHeader === -1 ? content.length : nextHeader
+  // `marker` starts with the section's leading `\n\n`, so when the section is LAST the remainder
+  // ends mid-text with no trailing newline. Re-add it — .editorconfig sets insert_final_newline.
+  const removed = content.slice(0, start) + content.slice(end)
+  const cleaned = removed.endsWith('\n') ? removed : `${removed}\n`
+  writeFileSync(agentsPath, cleaned, 'utf8')
+
+  // Leave the edit UNSTAGED and let the caller commit it. Auto-running `git add`/`git commit` here
+  // is unsafe in CI, on a dirty tree, with no configured git identity, or with pre-commit hooks.
+  console.log(
+    'Removed template-only upgrade note section from AGENTS.md — review and commit the change.',
+  )
+}
+
+if (shouldUpdateGuardBaseline) {
+  updateGuardBaseline()
+  console.log(`Updated ${guardBaselinePath}`)
+  process.exit(0)
+}
+
+cleanDownstreamAgentsMd()
+checkRoutes()
+checkForbiddenPrismaImports()
+checkStaleConfigNames()
+checkMcpWiring()
+checkApiControllerRoutesAllowed()
+checkGeneratedCrudModuleRegistration()
+checkGeneratedCrudPosture()
+checkCrudAuthAnnotations()
+checkGeneratorAdminBoundaryVersion()
+checkHandwrittenCrudImports()
+checkDefaultResolverGeneratedNameCollisions()
+checkHandwrittenAdminSdkOperations()
+checkApplicationSdkCrudBoundary()
+checkSdkContract()
+checkPluginExportsAndRegistration()
+checkIntegrationExports()
+checkSkipCrudDocumentation()
+checkPublishablePackageReadmes()
+checkPublishedPackageVersions()
+checkUpgradeNoteImpactGate()
+checkCookieDomainConfig()
+checkDevPortPairings()
+checkGuardRegressions()
+checkUnguardedRootOperations()
+checkAuthLevelDeclarations()
+checkAccessPolicyDeclarations()
+checkAccessPolicyCoverage()
+checkEnforcementPortability()
+checkPrismaGeneratedEnums()
+checkUnsafeTypeScriptCasts()
+checkResolverScopeAnchoring()
+checkAuditCoverageHeuristic()
+checkEmulationPrivilegeCeiling()
+
+printFindings('Warnings', warnings)
+printFindings('Failures', failures)
+
+if (failures.length > 0) {
+  console.error(`\nNestled doctor failed with ${failures.length} issue(s).`)
+  process.exit(1)
+}
+
+console.log('Nestled doctor passed.')

--- a/doctor/src/index.ts
+++ b/doctor/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * The analysis primitives, exported so they can be unit-tested and so a future check can build on
+ * them. The CHECKS themselves are not exported: they are run through the bins, so every repo runs
+ * the same rules rather than assembling its own subset.
+ */
+export * from './doctor-access-policy-analysis'
+export * from './doctor-auth-analysis'
+export * from './doctor-crud-boundary-analysis'
+export * from './doctor-generated-crud-posture'
+export * from './doctor-module-analysis'
+export * from './doctor-sdk-contract-analysis'
+export * from './doctor-source-analysis'

--- a/doctor/src/verify-fragment-coverage.spec.ts
+++ b/doctor/src/verify-fragment-coverage.spec.ts
@@ -474,13 +474,13 @@ describe('sanitize', () => {
 
     const sanitized = sanitize(source)
     expect(sanitized).toHaveLength(source.length)
-    expect((sanitized.match(/\n/g) ?? []).length).toBe((source.match(/\n/g) ?? []).length)
+    expect(sanitized.match(/\n/g) ?? []).toHaveLength((source.match(/\n/g) ?? []).length)
   })
 
   it('keeps the newline of a CRLF line continuation', () => {
     const source = 'const X = { a: "line\\\r\n", b: true }'
 
-    expect((sanitize(source).match(/\n/g) ?? []).length).toBe(1)
+    expect(sanitize(source).match(/\n/g) ?? []).toHaveLength(1)
   })
 })
 

--- a/doctor/src/verify-fragment-coverage.spec.ts
+++ b/doctor/src/verify-fragment-coverage.spec.ts
@@ -1,0 +1,568 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { buildSchema } from 'graphql'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  annotationListBefore,
+  matchingBrace,
+  nonNullableAt,
+  parentProduced,
+  readSelectConstants,
+  resolveSpreads,
+  sanitize,
+  scanObject,
+  toSelect,
+} from './verify-fragment-coverage'
+
+/**
+ * The parser is the whole tool. Its first version reported 584 missing fields against a codebase
+ * whose real count was 9, because it looked for a `select` key INSIDE a relation's column list
+ * instead of one level up — so every relation silently vanished and every field under it was
+ * reported as unproduced. A checker that cries wolf 584 times gets ignored, which is worse than
+ * having no checker, so these cases exist to keep that specific mistake from coming back.
+ */
+
+const openBraceOf = (source: string): number => source.indexOf('{')
+
+const workspaces: string[] = []
+
+const createSelectWorkspace = (source: string): string => {
+  const workspace = mkdtempSync(join(tmpdir(), 'verify-fragment-coverage-'))
+  const directory = join(workspace, 'libs/api/custom/src/lib/example')
+  mkdirSync(directory, { recursive: true })
+  writeFileSync(join(directory, 'example.select.ts'), source)
+  workspaces.push(workspace)
+  return workspace
+}
+
+afterEach(() => {
+  for (const workspace of workspaces.splice(0)) {
+    rmSync(workspace, { recursive: true, force: true })
+  }
+})
+
+describe('toSelect', () => {
+  it('captures a relation whose select holds only plain columns', () => {
+    // The regression: `{ id: true }` has no `select` of its own, and treating that as
+    // "not a relation" dropped `images` entirely.
+    const source = `{
+      id: true,
+      images: {
+        select: {
+          id: true,
+          url: true,
+        },
+      },
+    }`
+
+    expect(toSelect(source, openBraceOf(source))).toEqual({
+      id: true,
+      images: { select: { id: true, url: true } },
+    })
+  })
+
+  it('reads columns through several levels of relation', () => {
+    const source = `{
+      tracks: {
+        select: {
+          title: true,
+          audioFiles: {
+            select: { filename: true },
+          },
+        },
+      },
+    }`
+
+    expect(toSelect(source, openBraceOf(source))).toEqual({
+      tracks: {
+        select: {
+          audioFiles: { select: { filename: true } },
+          title: true,
+        },
+      },
+    })
+  })
+
+  it('ignores query arguments sitting beside a relation select', () => {
+    // take/orderBy/where are arguments, not columns. Counting them would invent fields that no
+    // fragment can ask for and no schema check would ever catch.
+    const source = `{
+      tracks: {
+        orderBy: { order: 'asc' },
+        take: 50,
+        where: { published: true },
+        select: { id: true },
+      },
+    }`
+
+    expect(toSelect(source, openBraceOf(source))).toEqual({
+      tracks: { select: { id: true } },
+    })
+  })
+
+  it('yields an empty select for a relation that names no columns', () => {
+    const source = `{ tracks: { take: 10 } }`
+
+    expect(toSelect(source, openBraceOf(source))).toEqual({ tracks: { select: {} } })
+  })
+
+  it('does not treat a false or computed value as a selected column', () => {
+    const source = `
+      { id: true, secret: false, computed: someHelper() }
+      const someHelper = { leaked: true }
+    `
+
+    expect(toSelect(source, openBraceOf(source))).toEqual({ id: true })
+  })
+
+  it('resolves a relation whose select is a named constant', () => {
+    const source = `
+      const AUTHOR_SELECT = {
+        id: true,
+        name: true,
+      }
+
+      const POST_SELECT = {
+        id: true,
+        author: { select: AUTHOR_SELECT },
+      }
+    `
+
+    expect(toSelect(source, source.indexOf('{', source.indexOf('POST_SELECT')))).toEqual({
+      id: true,
+      author: { select: { id: true, name: true } },
+    })
+  })
+
+  it('resolves a relation whose whole value is a named select', () => {
+    const source = `
+      const AUTHOR_SELECT = { id: true }
+      const POST_SELECT = { author: AUTHOR_SELECT }
+    `
+
+    expect(toSelect(source, source.indexOf('{', source.indexOf('POST_SELECT')))).toEqual({
+      author: { select: { id: true } },
+    })
+  })
+
+  it('resolves a parameterized select factory and stops identifier cycles', () => {
+    const source = `
+      const USER_SELECT = (viewerId: string) => ({
+        id: true,
+        manager: { select: USER_SELECT },
+      })
+      const POST_SELECT = { author: { select: USER_SELECT } }
+    `
+
+    expect(toSelect(source, source.indexOf('{', source.indexOf('POST_SELECT')))).toEqual({
+      author: {
+        select: {
+          id: true,
+          manager: { select: {} },
+        },
+      },
+    })
+  })
+})
+
+describe('readSelectConstants', () => {
+  const models = [{ modelName: 'Download', fields: [] }]
+
+  it('attributes an annotated constant whose name does not imply its Prisma model', () => {
+    const workspace = createSelectWorkspace(`
+      /**
+       * @prisma-model Download
+       */
+      export const USER_DOWNLOADS_SELECT = {
+        id: true,
+      } as const
+    `)
+
+    expect(readSelectConstants(workspace, models)).toMatchObject([
+      {
+        model: 'Download',
+        name: 'USER_DOWNLOADS_SELECT',
+        select: { id: true },
+      },
+    ])
+  })
+
+  it('keeps a fragment-partial helper available to spreads without checking it independently', () => {
+    const workspace = createSelectWorkspace(`
+      /**
+       * @prisma-model Download
+       * @fragment-partial
+       */
+      export const USER_DOWNLOADS_SELECT = {
+        id: true,
+      } as const
+
+      export const DOWNLOAD_SELECT = {
+        ...USER_DOWNLOADS_SELECT,
+        url: true,
+      } as const
+    `)
+
+    expect(readSelectConstants(workspace, models)).toMatchObject([
+      {
+        model: 'Download',
+        name: 'DOWNLOAD_SELECT',
+        select: { id: true, url: true },
+      },
+    ])
+  })
+
+  it('captures @graphql-operations even when no model resolves, so main can report the gap', () => {
+    // A model-less operation-scoped select must not be dropped silently — it still reaches
+    // operationScoped so main can flag the missing @prisma-model instead of reading green.
+    const workspace = createSelectWorkspace(`
+      /**
+       * @graphql-operations me
+       */
+      export const UNMAPPED_SELECT = {
+        id: true,
+      } as const
+    `)
+
+    expect(readSelectConstants(workspace, models)).toMatchObject([
+      { name: 'UNMAPPED_SELECT', model: undefined, operations: ['me'] },
+    ])
+  })
+
+  // Sharing a subtree between two selects (one document's select doubling as another's relation
+  // subtree) is the natural reason a select constant is imported. Before #142 a cross-file
+  // reference silently read as `{}`, and every field of the referenced shape reported as absent
+  // (mi-core: 10 false `Course.chapters.*` findings).
+  describe('cross-file select constants (#142)', () => {
+    const courseModels = [
+      { modelName: 'Course', fields: [] },
+      { modelName: 'CourseChapter', fields: [] },
+    ]
+
+    const writeSelectFile = (workspace: string, name: string, source: string): void => {
+      writeFileSync(join(workspace, 'libs/api/custom/src/lib/example', name), source)
+    }
+
+    it('resolves a select constant imported from a sibling file', () => {
+      const workspace = createSelectWorkspace(`
+        import { COURSE_CHAPTER_SELECT } from './course-chapter.select'
+
+        export const COURSE_SELECT = {
+          id: true,
+          chapters: { select: COURSE_CHAPTER_SELECT },
+        } as const
+      `)
+      writeSelectFile(
+        workspace,
+        'course-chapter.select.ts',
+        `export const COURSE_CHAPTER_SELECT = {
+          id: true,
+          title: true,
+        } as const
+      `,
+      )
+
+      const constants = readSelectConstants(workspace, courseModels)
+      expect(constants.find(constant => constant.name === 'COURSE_SELECT')?.select).toEqual({
+        id: true,
+        chapters: { select: { id: true, title: true } },
+      })
+    })
+
+    it('resolves an aliased import by its original exported name', () => {
+      const workspace = createSelectWorkspace(`
+        import { COURSE_CHAPTER_SELECT as CHAPTERS } from './course-chapter.select'
+
+        export const COURSE_SELECT = {
+          chapters: { select: CHAPTERS },
+        } as const
+      `)
+      writeSelectFile(
+        workspace,
+        'course-chapter.select.ts',
+        `export const COURSE_CHAPTER_SELECT = { title: true } as const`,
+      )
+
+      const constants = readSelectConstants(workspace, courseModels)
+      expect(constants.find(constant => constant.name === 'COURSE_SELECT')?.select).toEqual({
+        chapters: { select: { title: true } },
+      })
+    })
+
+    it('follows one hop only: an import chain two files deep reads as absent, not wrong', () => {
+      const workspace = createSelectWorkspace(`
+        import { MIDDLE_SELECT } from './middle.select'
+
+        export const COURSE_SELECT = {
+          chapters: { select: MIDDLE_SELECT },
+        } as const
+      `)
+      writeSelectFile(
+        workspace,
+        'middle.select.ts',
+        `import { LEAF_SELECT } from './leaf.select'
+        export const MIDDLE_SELECT = {
+          title: true,
+          sections: { select: LEAF_SELECT },
+        } as const
+      `,
+      )
+      writeSelectFile(
+        workspace,
+        'leaf.select.ts',
+        `export const LEAF_SELECT = { id: true } as const`,
+      )
+
+      // MIDDLE_SELECT's own fields resolve; the second hop to LEAF_SELECT deliberately does not.
+      const course = readSelectConstants(workspace, courseModels).find(
+        constant => constant.name === 'COURSE_SELECT',
+      )
+      expect(course?.select).toEqual({
+        chapters: { select: { title: true, sections: { select: {} } } },
+      })
+    })
+
+    it('does not bind an identifier through a commented-out import', () => {
+      const warnings: string[] = []
+      const original = console.warn
+      console.warn = (message: string) => warnings.push(message)
+      try {
+        const workspace = createSelectWorkspace(`
+          // import { COURSE_CHAPTER_SELECT } from './stale-location.select'
+          import { COURSE_CHAPTER_SELECT } from './course-chapter.select'
+
+          export const COURSE_SELECT = {
+            chapters: { select: COURSE_CHAPTER_SELECT },
+          } as const
+        `)
+        writeSelectFile(
+          workspace,
+          'course-chapter.select.ts',
+          `export const COURSE_CHAPTER_SELECT = { title: true } as const`,
+        )
+
+        // The live import resolves; the commented one neither binds nor warns about its
+        // nonexistent module.
+        const constants = readSelectConstants(workspace, courseModels)
+        expect(constants.find(constant => constant.name === 'COURSE_SELECT')?.select).toEqual({
+          chapters: { select: { title: true } },
+        })
+        expect(warnings).toEqual([])
+      } finally {
+        console.warn = original
+      }
+    })
+
+    it('warns instead of silently reading absent when the import cannot be resolved', () => {
+      const warnings: string[] = []
+      const original = console.warn
+      console.warn = (message: string) => warnings.push(message)
+      try {
+        const workspace = createSelectWorkspace(`
+          import { GHOST_SELECT } from './does-not-exist.select'
+
+          export const COURSE_SELECT = {
+            chapters: { select: GHOST_SELECT },
+          } as const
+        `)
+
+        const constants = readSelectConstants(workspace, courseModels)
+        expect(constants.find(constant => constant.name === 'COURSE_SELECT')?.select).toEqual({
+          chapters: { select: {} },
+        })
+        expect(warnings.some(message => message.includes('could not resolve import'))).toBe(true)
+      } finally {
+        console.warn = original
+      }
+    })
+  })
+})
+
+describe('scanObject', () => {
+  it('collects spreads so a select composed from another constant can be resolved', () => {
+    const source = `{ ...BASE_FIELDS, ownedByOrganizationId: true }`
+    const scanned = scanObject(source, openBraceOf(source))
+
+    expect(scanned.spreads).toEqual(['BASE_FIELDS'])
+    expect(scanned.entries.map(entry => entry.name)).toEqual(['ownedByOrganizationId'])
+  })
+
+  it('reports only the outermost level', () => {
+    const source = `{ a: true, rel: { select: { b: true } } }`
+    const scanned = scanObject(source, openBraceOf(source))
+
+    expect(scanned.entries.map(entry => entry.name)).toEqual(['a', 'rel'])
+  })
+})
+
+describe('resolveSpreads', () => {
+  /** A spreads B, B spreads C — with A declared FIRST, which is the order-dependent case. */
+  const chain = new Map([
+    ['A_FIELDS', { select: { a: true as const }, spreads: ['B_FIELDS'] }],
+    ['B_FIELDS', { select: { b: true as const }, spreads: ['C_FIELDS'] }],
+    ['C_FIELDS', { select: { c: true as const }, spreads: [] }],
+  ])
+
+  it('follows a spread chain to its end regardless of declaration order', () => {
+    // A single resolution pass gives A only {a, b}: C's fields arrive through B, which has not
+    // been resolved yet. Every field reaching A through C would then be reported MISSING.
+    expect(resolveSpreads('A_FIELDS', chain)).toEqual({ a: true, b: true, c: true })
+  })
+
+  it('resolves a mid-chain constant to its own reachable set', () => {
+    expect(resolveSpreads('B_FIELDS', chain)).toEqual({ b: true, c: true })
+  })
+
+  it('terminates on a cycle instead of recursing forever', () => {
+    // Not valid TypeScript, but this tool parses text rather than evaluating it, so it must not
+    // hang on input a compiler would have rejected.
+    const cyclic = new Map([
+      ['X_FIELDS', { select: { x: true as const }, spreads: ['Y_FIELDS'] }],
+      ['Y_FIELDS', { select: { y: true as const }, spreads: ['X_FIELDS'] }],
+    ])
+
+    expect(resolveSpreads('X_FIELDS', cyclic)).toEqual({ x: true, y: true })
+  })
+
+  it('merges relations from a spread rather than replacing them', () => {
+    const withRelation = new Map([
+      ['BASE', { select: { rel: { select: { id: true as const } } }, spreads: [] }],
+      ['WIDE', { select: { own: true as const }, spreads: ['BASE'] }],
+    ])
+
+    expect(resolveSpreads('WIDE', withRelation)).toEqual({
+      own: true,
+      rel: { select: { id: true } },
+    })
+  })
+
+  it('returns nothing for a spread of a constant declared in another file', () => {
+    const partial = new Map([['A', { select: { a: true as const }, spreads: ['ELSEWHERE'] }]])
+
+    expect(resolveSpreads('A', partial)).toEqual({ a: true })
+  })
+})
+
+describe('sanitize', () => {
+  it('blanks comments without moving any later offset', () => {
+    const source = `{ /* id: true */ name: true }`
+    const sanitized = sanitize(source)
+
+    expect(sanitized).toHaveLength(source.length)
+    expect(toSelect(sanitized, openBraceOf(sanitized))).toEqual({ name: true })
+  })
+
+  it('blanks string bodies so a brace inside a string cannot close an object early', () => {
+    const source = `{ label: "}", id: true }`
+    const sanitized = sanitize(source)
+
+    expect(sanitized).toHaveLength(source.length)
+    expect(matchingBrace(sanitized, 0)).toBe(source.length - 1)
+  })
+
+  it('keeps newlines so line-based reporting stays accurate', () => {
+    const source = `// leading comment\n{ id: true }`
+
+    expect(sanitize(source).split('\n')).toHaveLength(2)
+  })
+
+  it('keeps the newline a line-continuation escapes', () => {
+    // The escape branch consumes two characters. Blanking the second unconditionally deletes a
+    // real line break, so every line number reported after this string is off by one.
+    const source = 'const X = { a: "line\\\n", b: true }'
+
+    const sanitized = sanitize(source)
+    expect(sanitized).toHaveLength(source.length)
+    expect((sanitized.match(/\n/g) ?? []).length).toBe((source.match(/\n/g) ?? []).length)
+  })
+
+  it('keeps the newline of a CRLF line continuation', () => {
+    const source = 'const X = { a: "line\\\r\n", b: true }'
+
+    expect((sanitize(source).match(/\n/g) ?? []).length).toBe(1)
+  })
+})
+
+describe('annotationListBefore', () => {
+  const constant = 'const ME_SELECT = {'
+
+  it('splits a comma-separated list', () => {
+    const raw = `/** @select-omits redFlagged, tokenVersion */\n${constant}`
+    expect(annotationListBefore(raw, raw.indexOf(constant), 0, 'select-omits')).toEqual([
+      'redFlagged',
+      'tokenVersion',
+    ])
+  })
+
+  it('accumulates repeated tags across lines', () => {
+    const raw = `/**\n * @graphql-operations me\n * @graphql-operations UserToken.user\n */\n${constant}`
+    expect(annotationListBefore(raw, raw.indexOf(constant), 0, 'graphql-operations')).toEqual([
+      'me',
+      'UserToken.user',
+    ])
+  })
+
+  it('does not inherit an annotation that belongs to the previous constant', () => {
+    // The window starts where the previous constant's body ended; an annotation
+    // before that point documented THAT constant, not this one.
+    const raw = `/** @select-omits redFlagged */\nconst A = { a: true }\n${constant}`
+    const previousEnd = raw.indexOf('}') + 1
+    expect(annotationListBefore(raw, raw.indexOf(constant), previousEnd, 'select-omits')).toEqual(
+      [],
+    )
+  })
+})
+
+describe('parentProduced', () => {
+  const have = new Set(['id', 'lineItems', 'lineItems.order'])
+
+  it('is trivially true at top level', () => {
+    expect(parentProduced(have, 'redFlagged')).toBe(true)
+  })
+
+  it('is true when the immediate parent is selected', () => {
+    expect(parentProduced(have, 'lineItems.order.id')).toBe(true)
+  })
+
+  it('is false when the parent is absent — the parent finding covers the subtree', () => {
+    expect(parentProduced(have, 'addresses.id')).toBe(false)
+  })
+})
+
+describe('nonNullableAt', () => {
+  // GraphQL nullability, not Prisma optionality, decides null-versus-error:
+  // currentStreak is non-optional in Prisma (it has a default) yet nullable here.
+  const schema = buildSchema(`
+    type Query { me: User }
+    type User {
+      id: ID!
+      redFlagged: Boolean!
+      currentStreak: Int
+      trainerType: [String!]!
+      favorites: [Experience!]
+    }
+    type Experience { id: ID!, title: String }
+  `)
+
+  it('flags a non-nullable scalar', () => {
+    expect(nonNullableAt(schema, 'User', 'redFlagged')).toBe(true)
+  })
+
+  it('flags a non-nullable list — omitting it errors exactly like a scalar', () => {
+    expect(nonNullableAt(schema, 'User', 'trainerType')).toBe(true)
+  })
+
+  it('passes a nullable field', () => {
+    expect(nonNullableAt(schema, 'User', 'currentStreak')).toBe(false)
+  })
+
+  it('reads nested nullability through a list relation', () => {
+    expect(nonNullableAt(schema, 'User', 'favorites.id')).toBe(true)
+    expect(nonNullableAt(schema, 'User', 'favorites.title')).toBe(false)
+  })
+
+  it('treats an unknown field as nullable rather than guessing', () => {
+    expect(nonNullableAt(schema, 'User', 'notAField')).toBe(false)
+  })
+})

--- a/doctor/src/verify-fragment-coverage.ts
+++ b/doctor/src/verify-fragment-coverage.ts
@@ -102,7 +102,14 @@ Reports SDK fragment fields that no resolver select produces. Exits non-zero on 
 
 const SEARCH_ROOTS = ['libs/api/custom/src', 'libs/api/core', 'apps/api/src']
 const SELECT_FILE_SUFFIXES = ['.select.ts', '.resolver.ts', '.service.ts']
-const SELECT_CONSTANT = /^[ \t]*(?:export\s+)?const\s+([A-Z][A-Z0-9_]*)\s*=\s*\{/gm
+// Discovery has to match what findConstantBody can READ, or a constant it would happily parse is
+// never offered to it — a silent skip that reports as a clean run. So: the optional type annotation
+// (`const USER_SELECT: Prisma.UserSelect = {`) and let/var, both of which findConstantBody accepts.
+//
+// The annotation excludes newlines deliberately. `[^=]+` would span lines and reintroduce the
+// backtracking that S8786 flagged here; a one-line annotation is the realistic case.
+const SELECT_CONSTANT =
+  /^[ \t]*(?:export\s+)?(?:const|let|var)\s+([A-Z][A-Z0-9_]*)\s*(?::[^=\n]+)?=\s*\{/gm
 
 const alphabetical = (left: string, right: string): number => left.localeCompare(right)
 

--- a/doctor/src/verify-fragment-coverage.ts
+++ b/doctor/src/verify-fragment-coverage.ts
@@ -102,7 +102,7 @@ Reports SDK fragment fields that no resolver select produces. Exits non-zero on 
 
 const SEARCH_ROOTS = ['libs/api/custom/src', 'libs/api/core', 'apps/api/src']
 const SELECT_FILE_SUFFIXES = ['.select.ts', '.resolver.ts', '.service.ts']
-const SELECT_CONSTANT = /(?:^|\n)\s*(?:export\s+)?const\s+([A-Z][A-Z0-9_]*)\s*=\s*\{/g
+const SELECT_CONSTANT = /^[ \t]*(?:export\s+)?const\s+([A-Z][A-Z0-9_]*)\s*=\s*\{/gm
 
 const alphabetical = (left: string, right: string): number => left.localeCompare(right)
 
@@ -324,7 +324,7 @@ const importedConstantSelect = (
       .split(',')
       .map(name => name.trim())
       .map(name => {
-        const [original, alias] = name.split(/\s+as\s+/).map(part => part.trim())
+        const [original, alias] = name.split(/\bas\b/).map(part => part.trim())
         return { original, local: alias ?? original }
       })
       .find(candidate => candidate.local === ident)
@@ -604,7 +604,7 @@ export const resolveFieldsByModel = (repo: string): Map<string, Set<string>> => 
 
         const fields = served.get(modelName) ?? new Set<string>()
         for (const match of body.matchAll(
-          /@ResolveField\(([\s\S]*?)\)\s*\n\s*(?:async\s+)?(\w+)\s*\(/g,
+          /@ResolveField\(([\s\S]*?)\)[^\S\n]*\n\s*(?:async\s+)?(\w+)\s*\(/g,
         )) {
           // `@ResolveField(() => X, { name: 'graphqlName' })` overrides the method name.
           const renamed = /name:\s*['"`]?(\w+)/.exec(match[1])

--- a/doctor/src/verify-fragment-coverage.ts
+++ b/doctor/src/verify-fragment-coverage.ts
@@ -59,7 +59,6 @@
  */
 import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
-import { pathToFileURL } from 'node:url'
 import { buildSchema, getNamedType, isNonNullType, isObjectType, type GraphQLSchema } from 'graphql'
 import {
   buildPrismaSelectFromFragments,
@@ -90,7 +89,7 @@ const loadDatabaseModels = async (metadataPath: string): Promise<DatabaseModelMe
 
   const loaded = require(metadataPath) as { DATABASE_MODELS?: DatabaseModelMetadata[] }
   if (!Array.isArray(loaded.DATABASE_MODELS)) {
-    throw new Error(`${metadataPath} does not export DATABASE_MODELS`)
+    throw new TypeError(`${metadataPath} does not export DATABASE_MODELS`)
   }
 
   return loaded.DATABASE_MODELS
@@ -196,7 +195,7 @@ interface RawEntry {
 
 /** `const NAME = {` / `const NAME = (args) => ({` — where a named select's body starts. */
 export const findConstantBody = (source: string, name: string): number => {
-  const declaration = new RegExp(`\\b(?:const|let|var)\\s+${name}\\s*(?::[^=]+)?=\\s*`).exec(source)
+  const declaration = new RegExp(String.raw`\b(?:const|let|var)\s+${name}\s*(?::[^=]+)?=\s*`).exec(source)
   if (!declaration) return -1
   let cursor = declaration.index + declaration[0].length
   const arrow = /^\([^)]*\)\s*(?::[^=]+)?=>\s*\(?\s*/.exec(source.slice(cursor))
@@ -508,7 +507,7 @@ export const annotationListBefore = (
   tag: string,
 ): string[] => {
   const window = raw.slice(Math.max(previousEnd, 0), offset)
-  return [...window.matchAll(new RegExp(`@${tag}[ \\t]+([^\\n]+)`, 'g'))]
+  return [...window.matchAll(new RegExp(String.raw`@${tag}[ \t]+([^\n]+)`, 'g'))]
     .flatMap(match => match[1].replace(/\*\/.*$/, '').split(','))
     .map(entry => entry.trim())
     .filter(Boolean)
@@ -627,7 +626,7 @@ export const relationTarget = (
   const field = models
     .find(model => model.modelName === modelName)
     ?.fields?.find(entry => entry.name === fieldName)
-  return field && field.kind === 'object' ? field.type : undefined
+  return field?.kind === 'object' ? field.type : undefined
 }
 
 /**
@@ -684,8 +683,7 @@ export const flatten = (select: PrismaSelect, prefix = ''): string[] => {
     const path = prefix ? `${prefix}.${field}` : field
     if (value === true) paths.push(path)
     else {
-      paths.push(path)
-      paths.push(...flatten(value.select, path))
+      paths.push(path, ...flatten(value.select, path))
     }
   }
   return paths
@@ -867,28 +865,28 @@ const main = async (): Promise<void> => {
     console.log(
       `\nMISSING (${missing.length}) — a fragment asks for these and nothing produces them:`,
     )
-    for (const entry of missing.sort(alphabetical)) console.log(`  ${entry}`)
+    for (const entry of [...missing].sort(alphabetical)) console.log(`  ${entry}`)
   }
 
   if (nonNullPartial.length > 0) {
     console.log(
       `\nNON-NULLABLE PARTIAL (${nonNullPartial.length}) — these error the whole query, not a field:`,
     )
-    for (const entry of nonNullPartial.sort(alphabetical)) console.log(`  ${entry}`)
+    for (const entry of [...nonNullPartial].sort(alphabetical)) console.log(`  ${entry}`)
   }
 
   if (operationFindings.length > 0) {
     console.log(
       `\nOPERATION-SCOPED (${operationFindings.length}) — a served document requests what its select does not produce:`,
     )
-    for (const entry of operationFindings.sort(alphabetical)) console.log(`  ${entry}`)
+    for (const entry of [...operationFindings].sort(alphabetical)) console.log(`  ${entry}`)
   }
 
   if (verbose && partial.length > 0) {
     console.log(
       `\nPARTIAL (${partial.length}) — advisory; thinner list selects are usually correct:`,
     )
-    for (const entry of partial.sort(alphabetical)) console.log(`  ${entry}`)
+    for (const entry of [...partial].sort(alphabetical)) console.log(`  ${entry}`)
   } else if (partial.length > 0) {
     console.log(
       `\nPARTIAL: ${partial.length} field(s) present in some selects but not others (--verbose to list).`,
@@ -898,7 +896,7 @@ const main = async (): Promise<void> => {
   if (skipped.length > 0) {
     console.log(
       `\nNOT CHECKED (${skipped.length}): no named select constant maps to these models — ` +
-        `generated CRUD or inline selects. ${verbose ? skipped.sort(alphabetical).join(', ') : '--verbose to list'}`,
+        `generated CRUD or inline selects. ${verbose ? [...skipped].sort(alphabetical).join(', ') : '--verbose to list'}`,
     )
   }
 

--- a/doctor/src/verify-fragment-coverage.ts
+++ b/doctor/src/verify-fragment-coverage.ts
@@ -1,0 +1,935 @@
+#!/usr/bin/env tsx
+/**
+ * Every field an SDK fragment requests must be produced by the resolver's Prisma select.
+ *
+ * `tools/verify-selects.mjs` checks the OTHER direction: that a select names only columns the
+ * Prisma schema actually has. A select can pass that check completely and still be wrong, because
+ * a select is also allowed to be too NARROW. When a fragment asks for a column the select omits,
+ * Prisma simply does not load it, GraphQL resolves it to `null`, and the client renders a blank
+ * field. Nothing throws. Nothing logs. The only symptom is missing data on a screen, which is
+ * exactly the failure the boundary migration was most likely to introduce: 41 resolvers were
+ * rewritten from generic `info`-driven selection to hand-written explicit selects, and an explicit
+ * select is only as complete as the person who typed it.
+ *
+ * The required side reuses `buildPrismaSelectFromFragments`, so it sees precisely what
+ * `tools/fragment-to-select.ts` would generate: comments ignored, fragment spreads followed across
+ * the whole SDK, and GraphQL-only fields (`@ResolveField` values with no column behind them)
+ * filtered out through generated DATABASE_MODELS metadata.
+ *
+ * Granularity: by default this compares the UNION of fragments on a model against the selects
+ * for that model. It is not per-operation. That yields two levels:
+ *
+ *   MISSING  a fragment field no select for the model produces. Some operation returns null for
+ *            it. This is a real defect.
+ *   PARTIAL  a field some selects have and others lack. Usually correct and intentional — a list
+ *            select is meant to be thinner than a detail select — so it is advisory, not a
+ *            failure. Read it when a specific screen looks empty. EXCEPT when the field is
+ *            non-nullable in api-schema.graphql: then the thinner select does not return null
+ *            for it, it fails the whole query ("Cannot return null for non-nullable field") the
+ *            moment any document served by that select requests it. That was the login-breaking
+ *            redFlagged incident, and it was sitting in this advisory bucket — so a non-nullable
+ *            PARTIAL is a FAILURE unless every select lacking the field acknowledges it with
+ *            `@select-omits <field>` (the deliberate deny-list case, e.g. a self-read).
+ *
+ * A select annotated with `@graphql-operations <paths>` opts out of the model union into a
+ * sharper PER-OPERATION check: the required set is what SDK documents actually request at those
+ * positions (`me`, or `UserToken.user` for a field resolver shared across operations), and ANY
+ * requested field the select lacks is a failure — nullable ones are silent blanks, non-nullable
+ * ones kill the query. A required field that is also in `@select-omits` is the sharpest failure
+ * of all: a served document is requesting a field the select deliberately never produces, so the
+ * DOCUMENT is wrong and must be repointed at a select-safe fragment (that is exactly how login
+ * broke: the token user fragment pointed at the staff kitchen-sink). A path entry that matches
+ * no document is itself a failure — a renamed operation must not silently dissolve the net.
+ *
+ * A helper annotated with `@fragment-partial` still contributes to a same-file `...SPREAD`, but is
+ * not treated as an operation select for model-wide fragment coverage. Use that marker for a
+ * nested helper that needs `@prisma-model` so verify-selects can validate its columns.
+ *
+ * MISSING, non-nullable PARTIAL, and every OPERATION-SCOPED finding set a non-zero exit code.
+ *
+ * Known blind spots, so nobody reads a clean run as more than it is:
+ *   - inline selects written at a call site rather than as a named constant are not attributed
+ *   - `...SPREAD` is resolved only within the same file; a named select identifier also resolves
+ *     through ONE relative-import hop (#142) — a chain of imports past that reads as absent
+ *   - attribution is by a constant's top-level model, so a relation block nested in another
+ *     model's select does not count as a separate select for the related model
+ *   - models served entirely by generated CRUD have no select constant and are skipped (they are
+ *     covered by generated-crud-guards.spec.ts instead)
+ * Each of these is counted and printed, so the report says what it did not check.
+ */
+import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { buildSchema, getNamedType, isNonNullType, isObjectType, type GraphQLSchema } from 'graphql'
+import {
+  buildPrismaSelectFromFragments,
+  buildPrismaSelectFromOperationPaths,
+  type DatabaseModelMetadata,
+  type GraphqlSource,
+  type PrismaSelect,
+} from './doctor-sdk-contract-analysis'
+
+/**
+ * Load DATABASE_MODELS from the consuming repo's TypeScript source.
+ *
+ * Under tsx this was a bare dynamic import. As a package it runs under plain node, which cannot
+ * load .ts — so register tsx's loader first. tsx is a real dependency of this package for exactly
+ * this reason; the alternative is asking every repo to emit a JSON copy of metadata it already has.
+ */
+const loadDatabaseModels = async (metadataPath: string): Promise<DatabaseModelMetadata[]> => {
+  if (!existsSync(metadataPath)) {
+    throw new Error(`Database metadata not found at ${metadataPath}`)
+  }
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    require('tsx/cjs')
+  } catch {
+    // Already registered, or running under a loader that handles TypeScript itself.
+  }
+
+  const loaded = require(metadataPath) as { DATABASE_MODELS?: DatabaseModelMetadata[] }
+  if (!Array.isArray(loaded.DATABASE_MODELS)) {
+    throw new Error(`${metadataPath} does not export DATABASE_MODELS`)
+  }
+
+  return loaded.DATABASE_MODELS
+}
+
+const usage = `Usage:
+  pnpm exec tsx tools/verify-fragment-coverage.ts [repo] [--verbose]
+
+Reports SDK fragment fields that no resolver select produces. Exits non-zero on MISSING.`
+
+const SEARCH_ROOTS = ['libs/api/custom/src', 'libs/api/core', 'apps/api/src']
+const SELECT_FILE_SUFFIXES = ['.select.ts', '.resolver.ts', '.service.ts']
+const SELECT_CONSTANT = /(?:^|\n)\s*(?:export\s+)?const\s+([A-Z][A-Z0-9_]*)\s*=\s*\{/g
+
+const alphabetical = (left: string, right: string): number => left.localeCompare(right)
+
+const walk = (directory: string, keep: (path: string) => boolean): string[] => {
+  let entries: string[]
+  try {
+    entries = readdirSync(directory)
+  } catch {
+    return []
+  }
+  const files: string[] = []
+  for (const entry of entries) {
+    const path = join(directory, entry)
+    const stat = statSync(path)
+    if (stat.isDirectory()) files.push(...walk(path, keep))
+    else if (stat.isFile() && keep(path)) files.push(path)
+  }
+  return files.sort(alphabetical)
+}
+
+/**
+ * Blank out comments and string bodies while preserving every byte offset.
+ *
+ * Offsets must survive because the `@prisma-model` annotation is located by scanning backwards
+ * from a constant's offset in the raw source. Deleting rather than blanking would shift every
+ * offset after the first comment and silently misattribute annotations.
+ */
+export const sanitize = (source: string): string => {
+  const out = source.split('')
+  let index = 0
+  while (index < source.length) {
+    const two = source.slice(index, index + 2)
+    if (two === '//') {
+      while (index < source.length && source[index] !== '\n') out[index++] = ' '
+      continue
+    }
+    if (two === '/*') {
+      const end = source.indexOf('*/', index + 2)
+      const stop = end === -1 ? source.length : end + 2
+      while (index < stop) {
+        if (source[index] !== '\n') out[index] = ' '
+        index++
+      }
+      continue
+    }
+    const quote = source[index]
+    if (quote === '"' || quote === "'" || quote === '`') {
+      out[index] = ' '
+      index++
+      while (index < source.length) {
+        if (source[index] === '\\') {
+          out[index] = ' '
+          // A line-continuation escapes the newline itself. Blanking it unconditionally would
+          // delete a real line break and shift every line number reported after this string.
+          if (source[index + 1] !== '\n') out[index + 1] = ' '
+          index += 2
+          continue
+        }
+        const done = source[index] === quote
+        if (source[index] !== '\n') out[index] = ' '
+        index++
+        if (done) break
+      }
+      continue
+    }
+    index++
+  }
+  return out.join('')
+}
+
+export const matchingBrace = (source: string, open: number): number => {
+  let depth = 0
+  for (let index = open; index < source.length; index++) {
+    if (source[index] === '{') depth++
+    else if (source[index] === '}') {
+      depth--
+      if (depth === 0) return index
+    }
+  }
+  return -1
+}
+
+interface RawEntry {
+  kind: 'object' | 'true' | 'other'
+  name: string
+  open: number
+  /** For kind===other: the bare identifier, when the value is one. */
+  ident?: string
+}
+
+/** `const NAME = {` / `const NAME = (args) => ({` — where a named select's body starts. */
+export const findConstantBody = (source: string, name: string): number => {
+  const declaration = new RegExp(`\\b(?:const|let|var)\\s+${name}\\s*(?::[^=]+)?=\\s*`).exec(source)
+  if (!declaration) return -1
+  let cursor = declaration.index + declaration[0].length
+  const arrow = /^\([^)]*\)\s*(?::[^=]+)?=>\s*\(?\s*/.exec(source.slice(cursor))
+  if (arrow) cursor += arrow[0].length
+  return source[cursor] === '{' ? cursor : -1
+}
+
+interface ScannedObject {
+  entries: RawEntry[]
+  spreads: string[]
+}
+
+/** One level of an object literal: its keys, their value kinds, and any `...SPREAD`. No recursion. */
+export const scanObject = (source: string, open: number): ScannedObject => {
+  const entries: RawEntry[] = []
+  const spreads: string[] = []
+  const close = matchingBrace(source, open)
+  if (close === -1) return { entries, spreads }
+
+  let index = open + 1
+  while (index < close) {
+    const character = source[index]
+    if (character === undefined || /\s|,/.test(character)) {
+      index++
+      continue
+    }
+    if (source.startsWith('...', index)) {
+      const spread = /^\.\.\.\s*([A-Za-z_$][\w$]*)/.exec(source.slice(index, close))
+      if (spread) spreads.push(spread[1])
+      index += spread ? spread[0].length : 3
+      continue
+    }
+    const key = /^([A-Za-z_$][\w$]*)\s*:/.exec(source.slice(index, close + 1))
+    if (!key) {
+      index++
+      continue
+    }
+    let cursor = index + key[0].length
+    while (cursor < close && /\s/.test(source[cursor])) cursor++
+
+    if (source.startsWith('true', cursor)) {
+      entries.push({ kind: 'true', name: key[1], open: cursor })
+      index = cursor + 4
+      continue
+    }
+    if (source[cursor] === '{') {
+      entries.push({ kind: 'object', name: key[1], open: cursor })
+      const nestedClose = matchingBrace(source, cursor)
+      index = nestedClose === -1 ? cursor + 1 : nestedClose + 1
+      continue
+    }
+    // `false`, a variable, a call — not a column selection we can attribute directly. Retain a
+    // BARE identifier so `select: SOME_SELECT` can resolve against a same-file constant. Requiring
+    // the comma/end boundary keeps `someHelper()` and property access from masquerading as one.
+    const identifier = /^([A-Za-z_$][\w$]*)\s*(?=,|$)/.exec(source.slice(cursor, close))
+    entries.push({ kind: 'other', name: key[1], open: cursor, ident: identifier?.[1] })
+    index = cursor + 1
+  }
+
+  return { entries, spreads }
+}
+
+/**
+ * Where `source` came from, when known — enables one level of relative-import following for
+ * select-constant identifiers. `imported` marks source that was itself reached through an import,
+ * so resolution never chains further than one hop (fleet-upstream #142).
+ */
+export interface SourceContext {
+  file: string
+  imported?: boolean
+}
+
+const NAMED_IMPORT_PATTERN = /import\s+(?:type\s+)?\{([^}]*)\}\s*from\s*['"](\.[^'"]+)['"]/g
+
+const resolveImportFile = (fromDir: string, spec: string): string | undefined => {
+  const base = resolve(fromDir, spec)
+  const candidates = [base, `${base}.ts`, `${base}.tsx`, join(base, 'index.ts')]
+  return candidates.find(candidate => {
+    try {
+      return statSync(candidate).isFile()
+    } catch {
+      return false
+    }
+  })
+}
+
+/**
+ * Resolve a select-constant identifier through a relative import: parse the imported file's
+ * exported constant exactly the way the current file's are parsed. Sharing a subtree between two
+ * selects (one document's select doubling as another's relation subtree) is the natural reason a
+ * constant is imported, and without this every field of the referenced shape reported as absent.
+ * One hop only; an import that cannot be resolved warns rather than silently reading as `{}` —
+ * silent absence is what buries real findings under false ones.
+ */
+// Reading and sanitizing a file is pure for the duration of a run, and importedConstantSelect is
+// called once per identifier it has to resolve — so a select constant with several imported
+// sub-selects re-read and re-sanitized the same sources repeatedly. Memoize by path.
+const fileTextCache = new Map<string, { raw: string; sanitized: string }>()
+
+const readFileText = (file: string): { raw: string; sanitized: string } => {
+  const cached = fileTextCache.get(file)
+  if (cached) return cached
+
+  const raw = readFileSync(file, 'utf8')
+  const text = { raw, sanitized: sanitize(raw) }
+  fileTextCache.set(file, text)
+  return text
+}
+
+const importedConstantSelect = (
+  ident: string,
+  context: SourceContext,
+): PrismaSelect | undefined => {
+  if (context.imported) return undefined
+  // Import specifiers live inside string literals, which sanitize() blanks — so imports are read
+  // from the raw file, not from the sanitized source the select parser works on. But raw text
+  // also still contains comments, so each match is checked against the offset-preserving
+  // sanitized source: a commented-out import has its `import` keyword blanked there, and must
+  // not bind the identifier to a file nobody imports anymore.
+  const { raw, sanitized } = readFileText(context.file)
+  NAMED_IMPORT_PATTERN.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = NAMED_IMPORT_PATTERN.exec(raw)) !== null) {
+    if (!sanitized.startsWith('import', match.index)) continue
+    const binding = match[1]
+      .split(',')
+      .map(name => name.trim())
+      .map(name => {
+        const [original, alias] = name.split(/\s+as\s+/).map(part => part.trim())
+        return { original, local: alias ?? original }
+      })
+      .find(candidate => candidate.local === ident)
+    if (!binding?.original) continue
+
+    const importedFile = resolveImportFile(dirname(context.file), match[2])
+    if (!importedFile) {
+      console.warn(
+        `⚠️  ${context.file}: could not resolve import '${match[2]}' for select constant ${ident}; its fields will read as absent`,
+      )
+      return undefined
+    }
+    const importedSource = readFileText(importedFile).sanitized
+    const body = findConstantBody(importedSource, binding.original)
+    if (body === -1) {
+      console.warn(
+        `⚠️  ${context.file}: ${binding.original} not found in '${match[2]}'; its fields will read as absent`,
+      )
+      return undefined
+    }
+    return toSelect(importedSource, body, new Set([binding.original]), {
+      file: importedFile,
+      imported: true,
+    })
+  }
+  return undefined
+}
+
+/**
+ * Interpret a select object literal as nested `{field: true | {select}}`.
+ *
+ * A relation is written `relation: { select: {...} }`, often alongside `take`, `orderBy` or
+ * `where`. Only the `select` sub-object names columns; the rest are query arguments. The
+ * distinction has to be made HERE, one level above, rather than by looking for a `select` key
+ * inside the columns themselves — the innermost `{ id: true }` has no `select` of its own, and
+ * treating that as "not a relation" silently drops every relation in the file.
+ */
+export const toSelect = (
+  source: string,
+  open: number,
+  seen: ReadonlySet<string> = new Set(),
+  context?: SourceContext,
+): PrismaSelect => {
+  const select: PrismaSelect = {}
+  for (const entry of scanObject(source, open).entries) {
+    if (entry.kind === 'true') {
+      select[entry.name] = true
+      continue
+    }
+    if (entry.kind === 'other' && entry.ident && !seen.has(entry.ident)) {
+      const body = findConstantBody(source, entry.ident)
+      if (body !== -1) {
+        select[entry.name] = {
+          select: toSelect(source, body, new Set([...seen, entry.ident]), context),
+        }
+        continue
+      }
+      const imported = context && importedConstantSelect(entry.ident, context)
+      if (imported) select[entry.name] = { select: imported }
+      continue
+    }
+    if (entry.kind !== 'object') continue
+    const inner = scanObject(source, entry.open).entries.find(
+      candidate => candidate.name === 'select',
+    )
+    if (inner?.kind === 'object') {
+      select[entry.name] = { select: toSelect(source, inner.open, seen, context) }
+      continue
+    }
+    if (inner?.kind === 'other' && inner.ident && !seen.has(inner.ident)) {
+      const body = findConstantBody(source, inner.ident)
+      if (body !== -1) {
+        select[entry.name] = {
+          select: toSelect(source, body, new Set([...seen, inner.ident]), context),
+        }
+        continue
+      }
+      const imported = context && importedConstantSelect(inner.ident, context)
+      select[entry.name] = { select: imported ?? {} }
+      continue
+    }
+    select[entry.name] = { select: {} }
+  }
+  return select
+}
+
+export const mergeInto = (target: PrismaSelect, source: PrismaSelect): void => {
+  for (const [field, value] of Object.entries(source)) {
+    const existing = target[field]
+    if (value === true) {
+      if (!existing) target[field] = true
+      continue
+    }
+    if (existing && existing !== true) mergeInto(existing.select, value.select)
+    else target[field] = { select: { ...value.select } }
+  }
+}
+
+interface SelectConstant {
+  file: string
+  model: string | undefined
+  name: string
+  /** Fields the constant deliberately never selects (`@select-omits a, b`). */
+  omits: string[]
+  /** Document positions the constant serves (`@graphql-operations me, UserToken.user`). */
+  operations: string[]
+  select: PrismaSelect
+}
+
+/**
+ * Whether requesting `path` on `modelName` errors the whole query when the select omits it.
+ * Read from the committed api-schema.graphql, NOT from Prisma metadata: the two disagree —
+ * `currentStreak` is non-optional in Prisma (it has a default) but nullable in GraphQL, and it
+ * is the GraphQL wrapper that decides null-versus-error at runtime.
+ */
+export const nonNullableAt = (schema: GraphQLSchema, modelName: string, path: string): boolean => {
+  let type = schema.getType(modelName)
+  const segments = path.split('.')
+  for (const [index, segment] of segments.entries()) {
+    if (!isObjectType(type)) return false
+    const field = type.getFields()[segment]
+    if (!field) return false
+    if (index === segments.length - 1) return isNonNullType(field.type)
+    type = getNamedType(field.type)
+  }
+  return false
+}
+
+/**
+ * A constant's fields plus everything reachable through its `...SPREAD` chain.
+ *
+ * `seen` guards against a cycle: a constant that spreads itself, directly or through a chain, would
+ * otherwise recurse forever. A cycle is not valid TypeScript, but this tool parses text rather than
+ * evaluating it, so it must not hang on input a compiler would have rejected.
+ */
+export const resolveSpreads = (
+  name: string,
+  inFile: ReadonlyMap<string, { select: PrismaSelect; spreads: string[] }>,
+  seen: Set<string> = new Set(),
+): PrismaSelect => {
+  const resolved: PrismaSelect = {}
+  if (seen.has(name)) return resolved
+  seen.add(name)
+
+  const entry = inFile.get(name)
+  if (!entry) return resolved
+
+  for (const spread of entry.spreads) mergeInto(resolved, resolveSpreads(spread, inFile, seen))
+  mergeInto(resolved, entry.select)
+  return resolved
+}
+
+const modelForConstant = (
+  name: string,
+  annotated: string | undefined,
+  models: readonly DatabaseModelMetadata[],
+): string | undefined => {
+  if (annotated) return models.find(model => model.modelName === annotated)?.modelName
+  const stem = name.replace(/_(FIELDS|SELECT)$/, '').replaceAll('_', '')
+  return models.find(model => model.modelName.toUpperCase() === stem)?.modelName
+}
+
+/** The `@prisma-model X` annotation attached to a constant, if the comment directly precedes it. */
+const annotationBefore = (raw: string, offset: number, previousEnd: number): string | undefined => {
+  const window = raw.slice(Math.max(previousEnd, 0), offset)
+  const matches = [...window.matchAll(/@prisma-model\s+([A-Za-z_$][\w$]*)/g)]
+  return matches.length > 0 ? matches[matches.length - 1][1] : undefined
+}
+
+/**
+ * A comma-separated list annotation (`@select-omits a, b` / `@graphql-operations me, X.y`) in
+ * the comment directly preceding a constant. Several lines with the same tag accumulate. The
+ * value runs to end of line; a closing comment marker on the same line is stripped so the
+ * annotation can sit last in a one-line or block comment.
+ */
+export const annotationListBefore = (
+  raw: string,
+  offset: number,
+  previousEnd: number,
+  tag: string,
+): string[] => {
+  const window = raw.slice(Math.max(previousEnd, 0), offset)
+  return [...window.matchAll(new RegExp(`@${tag}[ \\t]+([^\\n]+)`, 'g'))]
+    .flatMap(match => match[1].replace(/\*\/.*$/, '').split(','))
+    .map(entry => entry.trim())
+    .filter(Boolean)
+}
+
+export const readSelectConstants = (
+  repo: string,
+  models: readonly DatabaseModelMetadata[],
+): SelectConstant[] => {
+  const constants: SelectConstant[] = []
+
+  for (const root of SEARCH_ROOTS) {
+    const files = walk(join(repo, root), path => SELECT_FILE_SUFFIXES.some(s => path.endsWith(s)))
+    for (const absolute of files) {
+      if (absolute.includes('.spec.')) continue
+      const raw = readFileSync(absolute, 'utf8')
+      const source = sanitize(raw)
+      const file = relative(repo, absolute)
+
+      const inFile = new Map<string, { select: PrismaSelect; spreads: string[] }>()
+      let previousEnd = 0
+      SELECT_CONSTANT.lastIndex = 0
+      let match: RegExpExecArray | null
+      while ((match = SELECT_CONSTANT.exec(source)) !== null) {
+        const open = source.indexOf('{', match.index + match[0].length - 1)
+        if (open === -1) continue
+        const select = toSelect(source, open, new Set(), { file: absolute })
+        const { spreads } = scanObject(source, open)
+        if (Object.keys(select).length === 0 && spreads.length === 0) continue
+        // The regex runs against sanitized source. A preceding JSDoc is whitespace there, so its
+        // leading `\s*` can move match.index to the top of the comment and put the annotation
+        // behind its own lookup window. The `const` keyword has the same offset in raw and
+        // sanitized source and is the stable anchor.
+        const declaration = match.index + match[0].indexOf('const')
+        const annotated = annotationBefore(raw, declaration, previousEnd)
+        const fragmentPartial = /@fragment-partial\b/.test(
+          raw.slice(Math.max(previousEnd, 0), declaration),
+        )
+        const omits = annotationListBefore(raw, declaration, previousEnd, 'select-omits')
+        const operations = annotationListBefore(raw, declaration, previousEnd, 'graphql-operations')
+        previousEnd = matchingBrace(source, open)
+        inFile.set(match[1], { select, spreads })
+        if (fragmentPartial) continue
+        constants.push({
+          file,
+          model: modelForConstant(match[1], annotated, models),
+          name: match[1],
+          omits,
+          operations,
+          select,
+        })
+      }
+
+      // Resolve `...SPREAD` against constants declared in the same file, following chains.
+      //
+      // A single pass would be order-dependent: if A spreads B and B spreads C, then resolving A
+      // before B has resolved its own spreads gives A only B's literal fields, and every field
+      // reaching A through C would be reported MISSING even though it is selected. Recursing per
+      // constant makes the result independent of declaration order.
+      for (const constant of constants.filter(entry => entry.file === file)) {
+        constant.select = resolveSpreads(constant.name, inFile)
+      }
+    }
+  }
+
+  return constants
+}
+
+/**
+ * GraphQL fields each model serves with `@ResolveField` rather than from the parent's select.
+ *
+ * These are the reason a narrow select is often correct. `Album.totalMinutes` and `Album.trackCount`
+ * are real columns, but the resolver computes them in `@ResolveField` and deliberately leaves them
+ * out of ALBUM_FIELDS; the same is true of most relations. Counting those as missing would bury the
+ * handful of genuine omissions under hundreds of false positives — which is exactly what the first
+ * run of this tool did.
+ */
+export const resolveFieldsByModel = (repo: string): Map<string, Set<string>> => {
+  const served = new Map<string, Set<string>>()
+
+  for (const root of SEARCH_ROOTS) {
+    for (const absolute of walk(join(repo, root), path => path.endsWith('.resolver.ts'))) {
+      if (absolute.includes('.spec.')) continue
+      const source = sanitize(readFileSync(absolute, 'utf8'))
+
+      // Split on the class decorator so each @ResolveField is attributed to the right model.
+      const classes = [...source.matchAll(/@Resolver\(\s*\(\)\s*=>\s*(\w+)/g)]
+      for (let index = 0; index < classes.length; index++) {
+        const modelName = classes[index][1]
+        const start = classes[index].index ?? 0
+        const end =
+          index + 1 < classes.length ? (classes[index + 1].index ?? source.length) : source.length
+        const body = source.slice(start, end)
+
+        const fields = served.get(modelName) ?? new Set<string>()
+        for (const match of body.matchAll(
+          /@ResolveField\(([\s\S]*?)\)\s*\n\s*(?:async\s+)?(\w+)\s*\(/g,
+        )) {
+          // `@ResolveField(() => X, { name: 'graphqlName' })` overrides the method name.
+          const renamed = /name:\s*['"`]?(\w+)/.exec(match[1])
+          fields.add(renamed ? renamed[1] : match[2])
+        }
+        served.set(modelName, fields)
+      }
+    }
+  }
+
+  return served
+}
+
+export const relationTarget = (
+  models: readonly DatabaseModelMetadata[],
+  modelName: string,
+  fieldName: string,
+): string | undefined => {
+  const field = models
+    .find(model => model.modelName === modelName)
+    ?.fields?.find(entry => entry.name === fieldName)
+  return field && field.kind === 'object' ? field.type : undefined
+}
+
+/**
+ * Fragment-required paths, minus anything a `@ResolveField` supplies at that level.
+ *
+ * Skipping a served field skips its whole subtree: once `Album.tracks` is resolved separately, the
+ * parent select owes nothing about a track.
+ */
+export const requiredPaths = (
+  select: PrismaSelect,
+  modelName: string,
+  served: ReadonlyMap<string, Set<string>>,
+  models: readonly DatabaseModelMetadata[],
+  prefix = '',
+): { skipped: string[]; wanted: string[] } => {
+  const wanted: string[] = []
+  const skipped: string[] = []
+
+  for (const [field, value] of Object.entries(select)) {
+    const path = prefix ? `${prefix}.${field}` : field
+    if (served.get(modelName)?.has(field)) {
+      skipped.push(path)
+      continue
+    }
+    wanted.push(path)
+    if (value === true) continue
+    const child = relationTarget(models, modelName, field)
+    if (!child) continue
+    const nested = requiredPaths(value.select, child, served, models, path)
+    wanted.push(...nested.wanted)
+    skipped.push(...nested.skipped)
+  }
+
+  return { skipped, wanted }
+}
+
+/**
+ * Whether a select produces the PARENT of a dotted path (trivially true at top level).
+ *
+ * The consequence of an absent field belongs to the shallowest absent segment: when a select
+ * lacks `addresses` entirely, `addresses.id` never resolves at all, so reporting it — let alone
+ * as query-fatal — is noise on top of the `addresses` finding. Only a gap whose parent IS
+ * produced is a finding of its own, and only then does the field's own nullability decide
+ * silent-null versus query-fatal.
+ */
+export const parentProduced = (have: ReadonlySet<string>, path: string): boolean => {
+  const dot = path.lastIndexOf('.')
+  return dot === -1 || have.has(path.slice(0, dot))
+}
+
+export const flatten = (select: PrismaSelect, prefix = ''): string[] => {
+  const paths: string[] = []
+  for (const [field, value] of Object.entries(select)) {
+    const path = prefix ? `${prefix}.${field}` : field
+    if (value === true) paths.push(path)
+    else {
+      paths.push(path)
+      paths.push(...flatten(value.select, path))
+    }
+  }
+  return paths
+}
+
+const graphqlSources = (root: string): GraphqlSource[] =>
+  walk(root, path => path.endsWith('.graphql')).map(file => ({
+    file,
+    source: readFileSync(file, 'utf8'),
+  }))
+
+const main = async (): Promise<void> => {
+  const args = process.argv.slice(2)
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(usage)
+    return
+  }
+  const verbose = args.includes('--verbose')
+  const repo = resolve(args.find(argument => !argument.startsWith('--')) ?? process.cwd())
+
+  // database-models.ts is TypeScript SOURCE in the consuming repo, so it cannot be imported by a
+  // plain node process — which is what this becomes once these checks ship as a package rather than
+  // running under tsx. loadDatabaseModels registers a TypeScript loader before reaching for it.
+  const metadataPath = join(repo, 'libs/shared/sdk/src/lib/database-models.ts')
+  const DATABASE_MODELS = await loadDatabaseModels(metadataPath)
+  const allSources = graphqlSources(join(repo, 'libs/shared/sdk/src/graphql'))
+  if (allSources.length === 0) throw new Error('No SDK .graphql files found')
+  // The nullability oracle. Committed and CI-verified, so a missing file is a broken
+  // checkout, not a condition to soldier through — without it the non-nullable net is off.
+  const schema = buildSchema(readFileSync(join(repo, 'api-schema.graphql'), 'utf8'))
+
+  const constants = readSelectConstants(repo, DATABASE_MODELS)
+  const operationScoped = constants.filter(constant => constant.operations.length > 0)
+  const byModel = new Map<string, SelectConstant[]>()
+  for (const constant of constants) {
+    // An operation-scoped select answers for ITS documents, not for the model's whole
+    // fragment union — holding a self-read to the staff kitchen-sink would only bury
+    // real findings under hundreds of false ones.
+    if (!constant.model || constant.operations.length > 0) continue
+    const list = byModel.get(constant.model) ?? []
+    list.push(constant)
+    byModel.set(constant.model, list)
+  }
+
+  const fragmentModels = new Set(
+    allSources.flatMap(source =>
+      [...source.source.matchAll(/^fragment\s+\w+\s+on\s+(\w+)/gm)].map(match => match[1]),
+    ),
+  )
+
+  const served = resolveFieldsByModel(repo)
+  const missing: string[] = []
+  const nonNullPartial: string[] = []
+  const operationFindings: string[] = []
+  const partial: string[] = []
+  const skipped: string[] = []
+  let checkedModels = 0
+  let checkedPaths = 0
+  let resolvedElsewhere = 0
+
+  for (const modelName of [...fragmentModels].sort(alphabetical)) {
+    if (!DATABASE_MODELS.some(model => model.modelName === modelName)) continue
+    const selects = byModel.get(modelName)
+    if (!selects || selects.length === 0) {
+      if (!operationScoped.some(constant => constant.model === modelName)) skipped.push(modelName)
+      continue
+    }
+
+    let required: PrismaSelect
+    try {
+      required = buildPrismaSelectFromFragments({
+        allSources,
+        models: DATABASE_MODELS,
+        rootSources: allSources,
+        targetModelName: modelName,
+      }).select
+    } catch {
+      skipped.push(modelName)
+      continue
+    }
+
+    checkedModels++
+    const { skipped: viaResolveField, wanted } = requiredPaths(
+      required,
+      modelName,
+      served,
+      DATABASE_MODELS,
+    )
+    resolvedElsewhere += viaResolveField.length
+    const provided = selects.map(select => new Set(flatten(select.select)))
+
+    for (const path of wanted) {
+      const holders = provided.filter(set => set.has(path)).length
+      if (holders === 0) {
+        missing.push(
+          `${modelName}.${path} — produced by none of ${selects.map(s => s.name).join(', ')}`,
+        )
+      } else if (holders < selects.length) {
+        const without = selects.filter((_, index) => !provided[index].has(path))
+        const escalated = selects.filter(
+          (select, index) =>
+            !provided[index].has(path) &&
+            !select.omits.includes(path) &&
+            parentProduced(provided[index], path),
+        )
+        if (nonNullableAt(schema, modelName, path) && escalated.length > 0) {
+          nonNullPartial.push(
+            `${modelName}.${path} — non-nullable, absent from ${escalated.map(s => s.name).join(', ')}: ` +
+              `any document those selects serve that requests it fails the WHOLE query. ` +
+              `Add the field, or acknowledge a deliberate deny with @select-omits ${path}.`,
+          )
+        } else {
+          partial.push(`${modelName}.${path} — absent from ${without.map(s => s.name).join(', ')}`)
+        }
+      }
+    }
+  }
+
+  // Operation-scoped selects: the required set is what documents request at the annotated
+  // positions, so ANY gap is a defect of this select or of a document it serves — there is no
+  // "another select covers that operation" excuse left to hide behind.
+  for (const constant of operationScoped) {
+    // A `@graphql-operations` select with no resolvable model can't be checked — but dropping it
+    // silently would make the net read green while skipping it. Report it so the gap is visible.
+    if (constant.model === undefined) {
+      operationFindings.push(
+        `${constant.name}: @graphql-operations is set but no @prisma-model resolves — the ` +
+          `operation-scoped net cannot check it. Add @prisma-model so the annotation is not silently skipped.`,
+      )
+      continue
+    }
+    const model = constant.model
+    const { matched, select: required } = buildPrismaSelectFromOperationPaths({
+      allSources,
+      models: DATABASE_MODELS,
+      paths: constant.operations,
+      targetModelName: model,
+    })
+    checkedPaths += constant.operations.length
+
+    for (const [entry, sites] of matched) {
+      if (sites === 0) {
+        operationFindings.push(
+          `${constant.name}: @graphql-operations "${entry}" matches no SDK document — ` +
+            `a renamed or deleted operation must not silently dissolve the net; fix or drop the entry.`,
+        )
+      }
+    }
+
+    const { wanted } = requiredPaths(required, model, served, DATABASE_MODELS)
+    const have = new Set(flatten(constant.select))
+    for (const path of wanted) {
+      if (have.has(path)) continue
+      if (!parentProduced(have, path)) continue
+      if (constant.omits.includes(path)) {
+        operationFindings.push(
+          `${model}.${path} — DELIBERATELY omitted by ${constant.name} (@select-omits), yet a document ` +
+            `on ${constant.operations.join('/')} requests it. The document is wrong, not the select: ` +
+            `repoint it at a fragment the select actually produces. Do not add the field.`,
+        )
+        continue
+      }
+      const fatal = nonNullableAt(schema, model, path)
+      operationFindings.push(
+        `${model}.${path} — requested via ${constant.operations.join('/')} but absent from ${constant.name}` +
+          (fatal ? ' — non-nullable: the whole query FAILS.' : ' — comes back null silently.'),
+      )
+    }
+  }
+
+  console.log(
+    `Checked ${checkedModels} model(s) with both fragments and selects; ` +
+      `${operationScoped.length} select(s) checked per-operation against ${checkedPaths} path(s); ` +
+      `${constants.length} select constant(s) parsed; ` +
+      `${resolvedElsewhere} field(s) skipped as @ResolveField.`,
+  )
+
+  if (missing.length > 0) {
+    console.log(
+      `\nMISSING (${missing.length}) — a fragment asks for these and nothing produces them:`,
+    )
+    for (const entry of missing.sort(alphabetical)) console.log(`  ${entry}`)
+  }
+
+  if (nonNullPartial.length > 0) {
+    console.log(
+      `\nNON-NULLABLE PARTIAL (${nonNullPartial.length}) — these error the whole query, not a field:`,
+    )
+    for (const entry of nonNullPartial.sort(alphabetical)) console.log(`  ${entry}`)
+  }
+
+  if (operationFindings.length > 0) {
+    console.log(
+      `\nOPERATION-SCOPED (${operationFindings.length}) — a served document requests what its select does not produce:`,
+    )
+    for (const entry of operationFindings.sort(alphabetical)) console.log(`  ${entry}`)
+  }
+
+  if (verbose && partial.length > 0) {
+    console.log(
+      `\nPARTIAL (${partial.length}) — advisory; thinner list selects are usually correct:`,
+    )
+    for (const entry of partial.sort(alphabetical)) console.log(`  ${entry}`)
+  } else if (partial.length > 0) {
+    console.log(
+      `\nPARTIAL: ${partial.length} field(s) present in some selects but not others (--verbose to list).`,
+    )
+  }
+
+  if (skipped.length > 0) {
+    console.log(
+      `\nNOT CHECKED (${skipped.length}): no named select constant maps to these models — ` +
+        `generated CRUD or inline selects. ${verbose ? skipped.sort(alphabetical).join(', ') : '--verbose to list'}`,
+    )
+  }
+
+  const failures = missing.length + nonNullPartial.length + operationFindings.length
+  if (failures === 0) {
+    if (checkedModels === 0 && checkedPaths === 0) {
+      // Checking zero models is not coverage proof — a repo that returns GraphQL via full-scalar
+      // Prisma includes / generated CRUD (no narrowed named selects) would otherwise read a hollow
+      // pass as verified coverage. Distinguish "no constants at all" from "constants parsed but none
+      // mapped to a checkable model/operation" so the notice is accurate (fleet-upstream #115).
+      console.log(
+        constants.length === 0
+          ? '\n⚠️  Checked 0 models and 0 operation paths — no named select constants were found in ' +
+              'the search roots. This is NOT fragment-coverage proof; the verifier had nothing to check.'
+          : `\n⚠️  Checked 0 models and 0 operation paths — ${constants.length} select constant(s) were ` +
+              'parsed but none mapped to a checkable model or operation. This is NOT fragment-coverage proof.',
+      )
+    } else {
+      console.log('\nNo fragment field is unproduced by its model’s selects.')
+    }
+  }
+  process.exitCode = failures > 0 ? 1 : 0
+}
+
+// Exported rather than self-invoked: the package's bin calls this, so the parser stays importable
+// for unit tests. The previous `import.meta.url === pathToFileURL(process.argv[1]).href` guard was
+// the only ESM-only construct in the TypeScript sources, and keeping it would have forced the whole
+// package to NodeNext ESM — which means explicit .js extensions on every relative import.
+export const runCli = async (): Promise<void> => {
+  await main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+}

--- a/doctor/src/verify-prisma-client.ts
+++ b/doctor/src/verify-prisma-client.ts
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Runs immediately after `prisma generate` in the db-update chain.
+//
+// A concurrent generate — most often `db-update` started while a dev server triggers its own — can
+// write the client truncated while still reporting success. Nothing downstream notices: the output
+// directory is gitignored, and Nx hashes task inputs rather than outputs, so an unchanged schema
+// produces an unchanged cache key regardless of what was actually written.
+//
+// Left alone, the first symptom appears much later and points nowhere near the cause. `client.ts`
+// re-exports `enums.ts`, so every enum resolves to undefined at runtime, `registerEnumType` stores
+// an undefined ref, and the API dies building the GraphQL schema with "Cannot convert undefined or
+// null to object" — a message naming neither Prisma nor this file. Failing here keeps the error
+// next to the thing that caused it.
+
+const schemaDir = 'libs/api/prisma/src/lib/schemas'
+const enumsPath = 'libs/api/prisma/src/lib/prisma-generated/enums.ts'
+
+// Prisma supports a split schema directory (datasource/generator in one file, models and enums in
+// others). Read enums from EVERY .prisma file in the dir, not just schema.prisma — a split-schema repo
+// (mi-core has ~29 files) would otherwise find zero enums in schema.prisma and pass without verifying
+// anything (fleet-upstream #125).
+const getDeclaredEnums = (): string[] => {
+  if (!existsSync(schemaDir)) return []
+  const enums: string[] = []
+  for (const entry of readdirSync(schemaDir)) {
+    if (!entry.endsWith('.prisma')) continue
+    for (const match of readFileSync(join(schemaDir, entry), 'utf8').matchAll(/^enum\s+(\w+)/gm)) {
+      enums.push(match[1])
+    }
+  }
+  return enums
+}
+
+const fail = (message: string): never => {
+  console.error(`\nPrisma client verification failed.\n\n${message}\n`)
+  console.error('Re-run: pnpm prisma:generate')
+  console.error(
+    'Then rebuild with: pnpm nx build api --skip-nx-cache  (Nx will otherwise reuse the stale bundle)\n',
+  )
+  process.exit(1)
+}
+
+const declaredEnums = getDeclaredEnums()
+if (declaredEnums.length === 0) process.exit(0)
+
+if (!existsSync(enumsPath)) {
+  fail(
+    `The Prisma schema declares ${declaredEnums.length} enum(s) but ${enumsPath} was not written.`,
+  )
+}
+
+const source = readFileSync(enumsPath, 'utf8')
+const missing = declaredEnums.filter(name => !source.includes(`export const ${name} =`))
+
+if (missing.length > 0) {
+  fail(
+    `${enumsPath} is missing ${missing.length} of ${declaredEnums.length} enum(s): ${missing.join(', ')}.\n` +
+      'These would be undefined at runtime and the API would fail while building the GraphQL schema.',
+  )
+}
+
+console.log(`Prisma client verified: ${declaredEnums.length} enum(s) generated.`)

--- a/doctor/src/verify-select-coverage.mjs
+++ b/doctor/src/verify-select-coverage.mjs
@@ -182,7 +182,7 @@ for (const root of searchRoots) {
  * comment and the declaration would read as intervening code and discard the annotation.
  */
 const declarationOf = (source, name) =>
-  new RegExp(`\\b(?:export\\s+)?(?:const|let|var)\\s+${name}\\s*(?::[^=]+)?=\\s*`).exec(source)
+  new RegExp(String.raw`\b(?:export\s+)?(?:const|let|var)\s+${name}\s*(?::[^=]+)?=\s*`).exec(source)
 
 /**
  * Names of exported constants whose value is an object literal — the candidate selects in a file.
@@ -216,7 +216,7 @@ const annotationFor = (source, name, tag) => {
   const commentStart = preceding.lastIndexOf('/**', commentEnd)
   if (commentStart === -1) return []
   const jsdoc = preceding.slice(commentStart + 3, commentEnd)
-  const found = [...jsdoc.matchAll(new RegExp(`@${tag}\\s+([^\\n*]+)`, 'g'))].pop()
+  const found = [...jsdoc.matchAll(new RegExp(String.raw`@${tag}\s+([^\n*]+)`, 'g'))].pop()
   return found
     ? found[1]
         .split(',')
@@ -336,7 +336,7 @@ const nestedProblems = []
 const unresolved = []
 const nullableGaps = []
 
-for (const file of selectFiles.sort((left, right) => left.localeCompare(right))) {
+for (const file of [...selectFiles].sort((left, right) => left.localeCompare(right))) {
   const source = readFileSync(file, 'utf8')
   const relativePath = relative(cwd, file)
   // Discovery deliberately shares the declaration shapes the readers below accept. It previously
@@ -377,7 +377,8 @@ for (const file of selectFiles.sort((left, right) => left.localeCompare(right)))
       for (const [field, information] of Object.entries(graphql)) {
         if (!prismaScalars[currentModel].has(field)) continue
         if (keys.has(field) || omits.has(field)) continue
-        ;(information.nonNull ? hard : soft).push(field)
+        const bucket = information.nonNull ? hard : soft
+        bucket.push(field)
       }
       if (hard.length > 0) {
         const bucket = depth === 0 ? problems : nestedProblems
@@ -385,7 +386,7 @@ for (const file of selectFiles.sort((left, right) => left.localeCompare(right)))
           file: relativePath,
           constant: path,
           model: currentModel,
-          missing: hard.sort((left, right) => left.localeCompare(right)),
+          missing: [...hard].sort((left, right) => left.localeCompare(right)),
         })
       }
       if (soft.length > 0) {
@@ -393,7 +394,7 @@ for (const file of selectFiles.sort((left, right) => left.localeCompare(right)))
           file: relativePath,
           constant: path,
           model: currentModel,
-          missing: soft.sort((left, right) => left.localeCompare(right)),
+          missing: [...soft].sort((left, right) => left.localeCompare(right)),
         })
       }
 

--- a/doctor/src/verify-select-coverage.mjs
+++ b/doctor/src/verify-select-coverage.mjs
@@ -110,7 +110,7 @@ if (!schemaDirectory) {
 }
 const datamodel = readdirSync(schemaDirectory)
   .filter(file => file.endsWith('.prisma'))
-  .sort()
+  .sort((left, right) => left.localeCompare(right))
   .map(file => readFileSync(join(schemaDirectory, file), 'utf8'))
   .join('\n')
 
@@ -336,7 +336,7 @@ const nestedProblems = []
 const unresolved = []
 const nullableGaps = []
 
-for (const file of selectFiles.sort()) {
+for (const file of selectFiles.sort((left, right) => left.localeCompare(right))) {
   const source = readFileSync(file, 'utf8')
   const relativePath = relative(cwd, file)
   // Discovery deliberately shares the declaration shapes the readers below accept. It previously
@@ -385,7 +385,7 @@ for (const file of selectFiles.sort()) {
           file: relativePath,
           constant: path,
           model: currentModel,
-          missing: hard.sort(),
+          missing: hard.sort((left, right) => left.localeCompare(right)),
         })
       }
       if (soft.length > 0) {
@@ -393,7 +393,7 @@ for (const file of selectFiles.sort()) {
           file: relativePath,
           constant: path,
           model: currentModel,
-          missing: soft.sort(),
+          missing: soft.sort((left, right) => left.localeCompare(right)),
         })
       }
 

--- a/doctor/src/verify-select-coverage.mjs
+++ b/doctor/src/verify-select-coverage.mjs
@@ -1,0 +1,468 @@
+#!/usr/bin/env node
+/**
+ * Verify explicit Prisma select constants COVER the GraphQL type they answer for.
+ *
+ * This is the reverse of tools/verify-selects.mjs. That tool asks "is every field in
+ * the select a real Prisma field?" — it catches selects that Prisma rejects. This one
+ * asks the question that broke `me`: "is every field the GraphQL type exposes present
+ * in the select?"
+ *
+ * It matters because a resolver returns a whole generated model type. `me: User` lets a
+ * client request any field on `User`, no matter which fields the SDK documents the select
+ * was derived from happen to use. When the select omits one:
+ *
+ *   nullable field      -> silently returns null. Nothing errors. Worst case.
+ *   non-nullable field  -> the whole query fails with
+ *                          "Cannot return null for non-nullable field User.pdMember."
+ *
+ * Deriving a select from "the fields our documents ask for" is therefore not sufficient.
+ * Typecheck cannot see this: the select is a plain object and the mismatch only exists
+ * against the SDL.
+ *
+ * What it gates on, and why the three classes differ:
+ *
+ *   top-level, non-nullable  GATED. A guaranteed hard failure whenever the field is
+ *                            requested.
+ *   nested, non-nullable     Reported as a count; --strict-nested to list and gate.
+ *                            Widening a nested select can expose fields from another
+ *                            user's row. The real fix is often a purpose-built output.
+ *   nullable, any depth      --warn-nullable only. Silent nulls, but narrowing is
+ *                            frequently deliberate.
+ *
+ * A deliberate omission is declared, not hidden. Annotate the constant:
+ *
+ *   /** @select-omits redFlagged, tokenVersion *\/
+ *   const USER_SELF_SCALARS = { ... }
+ *
+ * Declared omissions still error at runtime if requested — that is the intent. Keeping a
+ * credential or moderation column out of a self-read is worth an error; a silent leak is
+ * not. The annotation records the decision so review sees a choice rather than a gap.
+ *
+ * Omissions and fields are both inherited through `...SPREAD` of another constant in the
+ * same file, so a shared base declares once for every select that spreads it.
+ *
+ * Usage:
+ *   node tools/verify-select-coverage.mjs [--json] [--warn-nullable] [--strict-nested] [root ...]
+ *
+ * Requires api-schema.graphql, which the API emits at boot. Run it after a boot;
+ * a stale schema reports stale results.
+ */
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+
+const SCHEMA_DIRECTORY_CANDIDATES = [
+  'libs/api/prisma/src/lib/schemas',
+  'prisma',
+  'libs/api/prisma/src/lib',
+]
+const DEFAULT_SEARCH_ROOTS = ['libs/api/custom/src', 'libs/api/core', 'apps/api/src']
+const SDL_PATH = 'api-schema.graphql'
+
+const PRISMA_SCALARS = new Set([
+  'String',
+  'Int',
+  'Float',
+  'Boolean',
+  'DateTime',
+  'Json',
+  'Decimal',
+  'BigInt',
+  'Bytes',
+])
+
+const cwd = process.cwd()
+const argv = process.argv.slice(2)
+const asJson = argv.includes('--json')
+const warnNullable = argv.includes('--warn-nullable')
+const strictNested = argv.includes('--strict-nested')
+const roots = argv.filter(argument => !argument.startsWith('--'))
+const searchRoots = roots.length > 0 ? roots : DEFAULT_SEARCH_ROOTS
+
+// ── GraphQL SDL ──────────────────────────────────────────────────────────────
+const sdlPath = resolve(cwd, SDL_PATH)
+if (!existsSync(sdlPath)) {
+  console.error(`verify-select-coverage: ${SDL_PATH} not found. Boot the API once to emit it.`)
+  process.exit(2)
+}
+const sdl = readFileSync(sdlPath, 'utf8')
+
+const graphqlTypes = {}
+for (const match of sdl.matchAll(/^type (\w+) \{\n([\s\S]*?)^\}/gm)) {
+  const [, name, body] = match
+  const fields = {}
+  for (const line of body.split('\n')) {
+    const field = line.match(/^ {2}(\w+)(\([^)]*\))?: (.+)$/)
+    if (field) fields[field[1]] = { nonNull: field[3].trim().endsWith('!') }
+  }
+  graphqlTypes[name] = fields
+}
+
+// ── Prisma datamodel ─────────────────────────────────────────────────────────
+const schemaDirectory = SCHEMA_DIRECTORY_CANDIDATES.map(candidate => resolve(cwd, candidate)).find(
+  candidate =>
+    existsSync(candidate) && readdirSync(candidate).some(file => file.endsWith('.prisma')),
+)
+if (!schemaDirectory) {
+  console.error(
+    `verify-select-coverage: no .prisma schema under ${SCHEMA_DIRECTORY_CANDIDATES.join(', ')}`,
+  )
+  process.exit(2)
+}
+const datamodel = readdirSync(schemaDirectory)
+  .filter(file => file.endsWith('.prisma'))
+  .sort()
+  .map(file => readFileSync(join(schemaDirectory, file), 'utf8'))
+  .join('\n')
+
+const enumNames = new Set([...datamodel.matchAll(/^enum (\w+) \{/gm)].map(match => match[1]))
+const modelNames = new Set([...datamodel.matchAll(/^model (\w+) \{/gm)].map(match => match[1]))
+
+/** model -> set of selectable scalar columns (relations excluded: they need their own select) */
+const prismaScalars = {}
+/** model -> { relationField: targetModel } */
+const prismaRelations = {}
+for (const match of datamodel.matchAll(/^model (\w+) \{\n([\s\S]*?)^\}/gm)) {
+  const [, name, body] = match
+  const columns = new Set()
+  const relations = {}
+  for (const line of body.split('\n')) {
+    const field = line.match(/^\s+(\w+)\s+(\w+)(\[\])?/)
+    if (!field) continue
+    const [, column, type] = field
+    // An enum LIST (`TrainerType[]`) is an ordinary selectable scalar column, exactly like a scalar
+    // list — list-ness no longer affects classification. The old `&& !list` dropped enum lists from
+    // coverage entirely, the silent-skip shape behind a login outage (fleet-upstream #129).
+    if (PRISMA_SCALARS.has(type) || enumNames.has(type)) columns.add(column)
+    else if (modelNames.has(type)) relations[column] = type
+  }
+  prismaScalars[name] = columns
+  prismaRelations[name] = relations
+}
+
+// ── select constants ─────────────────────────────────────────────────────────
+const selectFiles = []
+const walk = directory => {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) walk(path)
+    else if (entry.name.endsWith('.select.ts')) selectFiles.push(path)
+  }
+}
+for (const root of searchRoots) {
+  const absolute = resolve(cwd, root)
+  if (existsSync(absolute)) walk(absolute)
+}
+
+/**
+ * Body of a named select constant, however it happens to be declared.
+ *
+ * The previous pattern required the exact shape `const NAME = {` … `\n} as const`, which silently
+ * returned nothing for two forms that occur in real projects: a type annotation
+ * (`const NAME: Prisma.XSelect = {`) and a constant with no `as const` suffix. When a `...SPREAD`
+ * cannot be resolved the fields it contributes are simply absent, so the caller reports them as
+ * missing — a false positive, in a checker that gates CI. A checker that fails builds for fields
+ * that are in fact selected gets switched off, which costs more than the check was worth.
+ *
+ * Brace matching replaces the non-greedy scan so the terminator no longer has to be guessed, and
+ * the value must actually begin with `{`: without that guard a non-object constant would send
+ * `objectBodyAt` hunting forward for an unrelated brace elsewhere in the file.
+ */
+/**
+ * The declaration head of a named constant, tolerant of the shapes these projects actually use:
+ * an `export` prefix, `let`/`var`, and a type annotation.
+ *
+ * Both readers below share this deliberately. They previously carried separate patterns and drifted
+ * apart, so widening one to accept `const NAME: Prisma.XSelect = {` left the other still blind to
+ * it — and that reader is the one that finds `@select-omits` and `@prisma-model`. A base whose
+ * omissions were declared but not seen reports those fields as missing, which is the same false
+ * positive this file was fixing, one layer up.
+ *
+ * The match starts at `export` when present rather than at `const`. `annotationFor` slices the text
+ * before the match to find the JSDoc immediately above it, and a stray `export ` left between the
+ * comment and the declaration would read as intervening code and discard the annotation.
+ */
+const declarationOf = (source, name) =>
+  new RegExp(`\\b(?:export\\s+)?(?:const|let|var)\\s+${name}\\s*(?::[^=]+)?=\\s*`).exec(source)
+
+/**
+ * Names of exported constants whose value is an object literal — the candidate selects in a file.
+ *
+ * Only exported names are candidates, matching the previous behaviour: a module-private constant is
+ * a building block reached through a spread, not a select the API returns, and checking it directly
+ * would report the base's deliberate partiality as a defect.
+ */
+const exportedConstantNames = source => [
+  ...new Set(
+    [...source.matchAll(/\bexport\s+(?:const|let|var)\s+(\w+)\s*(?::[^=]+)?=\s*\{/g)].map(
+      match => match[1],
+    ),
+  ),
+]
+
+const constantBody = (source, name) => {
+  const declaration = declarationOf(source, name)
+  if (!declaration) return null
+  const cursor = declaration.index + declaration[0].length
+  if (source[cursor] !== '{') return null
+  return objectBodyAt(source, cursor)
+}
+
+const annotationFor = (source, name, tag) => {
+  const declaration = declarationOf(source, name)
+  if (!declaration) return []
+  const preceding = source.slice(0, declaration.index)
+  const commentEnd = preceding.lastIndexOf('*/')
+  if (commentEnd === -1 || preceding.slice(commentEnd + 2).trim() !== '') return []
+  const commentStart = preceding.lastIndexOf('/**', commentEnd)
+  if (commentStart === -1) return []
+  const jsdoc = preceding.slice(commentStart + 3, commentEnd)
+  const found = [...jsdoc.matchAll(new RegExp(`@${tag}\\s+([^\\n*]+)`, 'g'))].pop()
+  return found
+    ? found[1]
+        .split(',')
+        .map(value => value.trim())
+        .filter(Boolean)
+    : []
+}
+
+const pascalCase = value =>
+  value
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map(word => word[0].toUpperCase() + word.slice(1).toLowerCase())
+    .join('')
+
+const constantModelCandidates = name => {
+  const words = name
+    .replace(/_?SELECT.*$/, '')
+    .split('_')
+    .filter(Boolean)
+  const candidates = []
+  for (let length = words.length; length > 0; length--) {
+    for (let start = 0; start + length <= words.length; start++) {
+      candidates.push(pascalCase(words.slice(start, start + length).join('_')))
+    }
+  }
+  return candidates
+}
+
+/** Body of the object literal that starts at the `{` on or after `from`. */
+const objectBodyAt = (text, from) => {
+  const open = text.indexOf('{', from)
+  if (open < 0) return null
+  let depth = 0
+  for (let index = open; index < text.length; index++) {
+    if (text[index] === '{') depth++
+    else if (text[index] === '}') {
+      depth--
+      if (depth === 0) return text.slice(open + 1, index)
+    }
+  }
+  return null
+}
+
+/**
+ * Top-level entries of a select body, following `...OTHER` spreads within the file. `nested`
+ * maps a relation key to the body of its inner `select: { ... }`, so the caller can recurse into
+ * it against the relation's target model.
+ */
+const resolveSelect = (source, body, seen = new Set()) => {
+  const keys = new Set()
+  const omits = new Set()
+  const nested = {}
+  let depth = 0
+  const lines = body.split('\n')
+  let offset = 0
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (depth === 0) {
+      const inlineOmit = trimmed.match(/@select-omits\s+([^\n*]+)/)
+      if (inlineOmit) {
+        for (const field of inlineOmit[1]
+          .split(',')
+          .map(value => value.trim())
+          .filter(Boolean)) {
+          omits.add(field)
+        }
+      }
+      const key = trimmed.match(/^(\w+):/)
+      if (key) {
+        keys.add(key[1])
+        const rest = body.slice(offset + line.indexOf(':') + 1)
+        if (rest.trimStart().startsWith('{')) {
+          const outer = objectBodyAt(rest, 0)
+          if (outer) {
+            const selectAt = outer.search(/\bselect:/)
+            if (selectAt >= 0) nested[key[1]] = objectBodyAt(outer, selectAt)
+          }
+        }
+      }
+      const spread = trimmed.match(/^\.\.\.([A-Z][A-Z0-9_]*)\b/)
+      if (spread && !seen.has(spread[1])) {
+        seen.add(spread[1])
+        const inner = constantBody(source, spread[1])
+        if (inner) {
+          const resolved = resolveSelect(source, inner, seen)
+          for (const field of resolved.keys) keys.add(field)
+          for (const omitted of resolved.omits) omits.add(omitted)
+          for (const [field, select] of Object.entries(resolved.nested)) {
+            nested[field] ??= select
+          }
+          for (const omitted of annotationFor(source, spread[1], 'select-omits')) {
+            omits.add(omitted)
+          }
+        }
+      }
+    }
+    depth += (line.match(/\{/g) ?? []).length - (line.match(/\}/g) ?? []).length
+    offset += line.length + 1
+  }
+  return { keys, omits, nested }
+}
+
+const modelFor = (source, name, file) => {
+  const annotated = annotationFor(source, name, 'prisma-model')[0]
+  if (annotated) return annotated
+  for (const candidate of constantModelCandidates(name)) {
+    if (prismaScalars[candidate]) return candidate
+  }
+  const base = file.split('/').pop().replace('.select.ts', '')
+  const pascal = pascalCase(base)
+  return prismaScalars[pascal] ? pascal : null
+}
+
+const problems = []
+const nestedProblems = []
+const unresolved = []
+const nullableGaps = []
+
+for (const file of selectFiles.sort()) {
+  const source = readFileSync(file, 'utf8')
+  const relativePath = relative(cwd, file)
+  // Discovery deliberately shares the declaration shapes the readers below accept. It previously
+  // required `export const NAME = {` … `\n} as const` exactly, which meant a type-annotated select
+  // was never discovered at all: not checked, not reported unresolved, simply invisible. That is a
+  // worse failure than the false positive this file set out to fix, because it reports success by
+  // omission — the check passes precisely because it looked at nothing.
+  for (const name of exportedConstantNames(source)) {
+    const body = constantBody(source, name)
+    if (body === null) continue
+    const model = modelFor(source, name, file)
+    if (!model || !prismaScalars[model]) {
+      unresolved.push({ file: relativePath, constant: name, reason: 'model not resolved' })
+      continue
+    }
+    const graphqlType = graphqlTypes[model]
+    if (!graphqlType) {
+      unresolved.push({
+        file: relativePath,
+        constant: name,
+        reason: `no GraphQL type ${model}`,
+      })
+      continue
+    }
+
+    const walkSelect = (currentModel, selectBody, path, depth = 0) => {
+      if (depth > 6) return
+      const graphql = graphqlTypes[currentModel]
+      if (!graphql || !prismaScalars[currentModel]) return
+
+      const { keys, omits, nested } = resolveSelect(source, selectBody)
+      if (depth === 0) {
+        for (const omitted of annotationFor(source, name, 'select-omits')) omits.add(omitted)
+      }
+
+      const hard = []
+      const soft = []
+      for (const [field, information] of Object.entries(graphql)) {
+        if (!prismaScalars[currentModel].has(field)) continue
+        if (keys.has(field) || omits.has(field)) continue
+        ;(information.nonNull ? hard : soft).push(field)
+      }
+      if (hard.length > 0) {
+        const bucket = depth === 0 ? problems : nestedProblems
+        bucket.push({
+          file: relativePath,
+          constant: path,
+          model: currentModel,
+          missing: hard.sort(),
+        })
+      }
+      if (soft.length > 0) {
+        nullableGaps.push({
+          file: relativePath,
+          constant: path,
+          model: currentModel,
+          missing: soft.sort(),
+        })
+      }
+
+      for (const [key, innerBody] of Object.entries(nested)) {
+        const target = prismaRelations[currentModel]?.[key]
+        if (target && innerBody) walkSelect(target, innerBody, `${path}.${key}`, depth + 1)
+      }
+    }
+
+    walkSelect(model, body, name)
+  }
+}
+
+if (asJson) {
+  console.log(
+    JSON.stringify(
+      {
+        files: selectFiles.length,
+        problems,
+        nestedProblems,
+        unresolved,
+        nullableGaps: warnNullable ? nullableGaps : undefined,
+      },
+      null,
+      2,
+    ),
+  )
+} else {
+  console.log(`\nverify-select-coverage — ${selectFiles.length} file(s), SDL ${SDL_PATH}\n`)
+  for (const entry of unresolved) {
+    console.log(`?  ${entry.file} — ${entry.constant}: ${entry.reason}`)
+  }
+  for (const entry of problems) {
+    console.log(`✗  ${entry.file} — ${entry.constant} [${entry.model}]`)
+    console.log(`     omits ${entry.missing.length} non-nullable field(s); requesting any of`)
+    console.log('     them fails the whole query, it does not return null:')
+    console.log(`       ${entry.missing.join(', ')}`)
+    console.log('     add them, or declare intent with /** @select-omits ... */\n')
+  }
+  if (nestedProblems.length > 0) {
+    const fieldCount = nestedProblems.reduce((sum, entry) => sum + entry.missing.length, 0)
+    if (strictNested) {
+      for (const entry of nestedProblems) {
+        console.log(`✗  ${entry.file} — ${entry.constant} [${entry.model}]`)
+        console.log(`     ${entry.missing.length} non-nullable: ${entry.missing.join(', ')}\n`)
+      }
+    } else {
+      console.log(
+        `!  ${nestedProblems.length} nested select(s) omit ${fieldCount} non-nullable field(s).`,
+      )
+      console.log("   Latent, not gated: widening a nested select can expose another user's row.")
+      console.log('   The real fix is usually a purpose-built output type.')
+      console.log('   Run with --strict-nested to list them.\n')
+    }
+  }
+  if (warnNullable) {
+    for (const entry of nullableGaps) {
+      console.log(`!  ${entry.file} — ${entry.constant} [${entry.model}]`)
+      console.log(`     ${entry.missing.length} nullable field(s) return null if requested:`)
+      console.log(`       ${entry.missing.join(', ')}\n`)
+    }
+  }
+  if (selectFiles.length === 0) {
+    console.log('no reusable *.select.ts files discovered; nothing was checked\n')
+  } else if (problems.length === 0 && unresolved.length === 0) {
+    console.log('every top-level select covers the non-nullable surface of its GraphQL type\n')
+  }
+}
+
+const failed =
+  problems.length > 0 || unresolved.length > 0 || (strictNested && nestedProblems.length > 0)
+process.exit(failed ? 1 : 0)

--- a/doctor/src/verify-select-coverage.spec.mjs
+++ b/doctor/src/verify-select-coverage.spec.mjs
@@ -1,0 +1,382 @@
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const toolPath = fileURLToPath(new URL('./verify-select-coverage.mjs', import.meta.url))
+const workspaces = []
+
+const writeFixture = (workspace, path, contents) => {
+  const absolute = join(workspace, path)
+  mkdirSync(dirname(absolute), { recursive: true })
+  writeFileSync(absolute, contents)
+}
+
+const createWorkspace = selectSource => {
+  const workspace = mkdtempSync(join(tmpdir(), 'verify-select-coverage-'))
+  workspaces.push(workspace)
+
+  writeFixture(
+    workspace,
+    'libs/api/prisma/src/lib/schemas/schema.prisma',
+    `
+      model User {
+        id    String   @id
+        email String
+        dob   DateTime?
+        posts Post[]
+      }
+
+      model Post {
+        id       String @id
+        title    String
+        authorId String
+        author   User   @relation(fields: [authorId], references: [id])
+      }
+    `.replace(/^ {6}/gm, ''),
+  )
+  writeFixture(
+    workspace,
+    'api-schema.graphql',
+    `
+      type User {
+        id: String!
+        email: String!
+        dob: DateTime
+        posts: [Post!]!
+      }
+
+      type Post {
+        id: String!
+        title: String!
+        authorId: String!
+        author: User!
+      }
+    `.replace(/^ {6}/gm, ''),
+  )
+  writeFixture(workspace, 'libs/api/custom/src/lib/user/user.select.ts', selectSource)
+  return workspace
+}
+
+const runTool = (workspace, ...args) =>
+  spawnSync(process.execPath, [toolPath, '--json', ...args], {
+    cwd: workspace,
+    encoding: 'utf8',
+  })
+
+afterEach(() => {
+  for (const workspace of workspaces.splice(0)) {
+    rmSync(workspace, { recursive: true, force: true })
+  }
+})
+
+describe('verify-select-coverage', () => {
+  it('fails when a top-level select omits a non-nullable GraphQL scalar', () => {
+    const workspace = createWorkspace(`
+export const USER_SELECT = {
+  id: true,
+} as const
+`)
+
+    const result = runTool(workspace)
+
+    expect(result.stderr).toBe('')
+    expect(result.status).toBe(1)
+    expect(JSON.parse(result.stdout).problems).toEqual([
+      {
+        file: 'libs/api/custom/src/lib/user/user.select.ts',
+        constant: 'USER_SELECT',
+        model: 'User',
+        missing: ['email'],
+      },
+    ])
+  })
+
+  it('counts a non-nullable enum LIST column as required coverage (#129)', () => {
+    // An enum array (`TrainerType[]`) is an ordinary selectable scalar column; the old `&& !list`
+    // dropped it, so a select omitting it passed silently.
+    const workspace = mkdtempSync(join(tmpdir(), 'verify-select-coverage-'))
+    workspaces.push(workspace)
+    writeFixture(
+      workspace,
+      'libs/api/prisma/src/lib/schemas/schema.prisma',
+      'enum TrainerType {\n  A\n  B\n}\n\nmodel User {\n  id          String        @id\n  trainerType TrainerType[]\n}\n',
+    )
+    writeFixture(
+      workspace,
+      'api-schema.graphql',
+      'type User {\n  id: String!\n  trainerType: [TrainerType!]!\n}\n',
+    )
+    writeFixture(
+      workspace,
+      'libs/api/custom/src/lib/user/user.select.ts',
+      '\nexport const USER_SELECT = {\n  id: true,\n} as const\n',
+    )
+
+    const result = runTool(workspace)
+
+    expect(result.stderr).toBe('')
+    expect(result.status).toBe(1)
+    expect(JSON.parse(result.stdout).problems).toEqual([
+      {
+        file: 'libs/api/custom/src/lib/user/user.select.ts',
+        constant: 'USER_SELECT',
+        model: 'User',
+        missing: ['trainerType'],
+      },
+    ])
+  })
+
+  it('accepts a deliberate omission and reports nullable gaps only when requested', () => {
+    const workspace = createWorkspace(`
+/** @select-omits email */
+export const USER_SELECT = {
+  id: true,
+} as const
+`)
+
+    const normal = runTool(workspace)
+    const withNullable = runTool(workspace, '--warn-nullable')
+
+    expect(normal.status).toBe(0)
+    expect(JSON.parse(normal.stdout).nullableGaps).toBeUndefined()
+    expect(JSON.parse(withNullable.stdout).nullableGaps).toEqual([
+      {
+        file: 'libs/api/custom/src/lib/user/user.select.ts',
+        constant: 'USER_SELECT',
+        model: 'User',
+        missing: ['dob'],
+      },
+    ])
+  })
+
+  it('reports nested non-nullable gaps without gating unless strict nested mode is enabled', () => {
+    const workspace = createWorkspace(`
+export const USER_SELECT = {
+  id: true,
+  email: true,
+  posts: {
+    select: {
+      id: true,
+    },
+  },
+} as const
+`)
+
+    const advisory = runTool(workspace)
+    const strict = runTool(workspace, '--strict-nested')
+
+    expect(advisory.status).toBe(0)
+    expect(strict.status).toBe(1)
+    expect(JSON.parse(strict.stdout).nestedProblems).toEqual([
+      {
+        file: 'libs/api/custom/src/lib/user/user.select.ts',
+        constant: 'USER_SELECT.posts',
+        model: 'Post',
+        missing: ['authorId', 'title'],
+      },
+    ])
+  })
+
+  it('infers a helper model from the constant name before falling back to the filename', () => {
+    const workspace = createWorkspace(`
+export const POST_SUMMARY_SELECT = {
+  id: true,
+  title: true,
+  authorId: true,
+} as const
+`)
+
+    const result = runTool(workspace)
+
+    expect(result.status).toBe(0)
+    expect(JSON.parse(result.stdout)).toMatchObject({ problems: [], unresolved: [] })
+  })
+
+  it('does not leak a deliberate omission annotation to the following constant', () => {
+    const workspace = createWorkspace(`
+/** @select-omits email */
+export const USER_SELF_SELECT = {
+  id: true,
+} as const
+
+export const USER_OTHER_SELECT = {
+  id: true,
+} as const
+`)
+
+    const result = runTool(workspace)
+
+    expect(result.status).toBe(1)
+    expect(JSON.parse(result.stdout).problems).toEqual([
+      {
+        file: 'libs/api/custom/src/lib/user/user.select.ts',
+        constant: 'USER_OTHER_SELECT',
+        model: 'User',
+        missing: ['email'],
+      },
+    ])
+  })
+
+  it('does not span two JSDocs when resolving the nearest model annotation', () => {
+    const workspace = createWorkspace(`
+/** @prisma-model Post */
+const POST_BASE = {
+  id: true,
+}
+
+/** The complete user select. */
+export const USER_SELECT = {
+  id: true,
+  email: true,
+} as const
+`)
+
+    const result = runTool(workspace)
+
+    expect(result.status).toBe(0)
+    expect(JSON.parse(result.stdout)).toMatchObject({ problems: [], unresolved: [] })
+  })
+
+  /**
+   * A spread whose base constant cannot be located contributes nothing, so its fields are reported
+   * missing even though they are selected. That is a false positive in a check that gates CI, and
+   * a check that fails builds over fields which are in fact present gets switched off — costing
+   * more than the check was ever worth. These cover the declaration shapes that previously did not
+   * resolve.
+   */
+  it('resolves a spread of an exported base constant', () => {
+    // The base carries every field and the spread carries all of them, so a passing run is only
+    // possible if the spread resolved. An exported base is itself checked as a select for the
+    // model its name resolves to, which is why it must be complete here rather than partial.
+    const workspace = createWorkspace(`
+export const USER_BASE = {
+  id: true,
+  email: true,
+} as const
+
+export const USER_SELECT = {
+  ...USER_BASE,
+} as const
+`)
+
+    const result = runTool(workspace)
+
+    expect(result.status).toBe(0)
+    expect(JSON.parse(result.stdout)).toMatchObject({ problems: [], unresolved: [] })
+  })
+
+  it('resolves a spread of a type-annotated base constant', () => {
+    const workspace = createWorkspace(`
+const USER_BASE: Record<string, boolean> = {
+  email: true,
+}
+
+export const USER_SELECT = {
+  ...USER_BASE,
+  id: true,
+} as const
+`)
+
+    const result = runTool(workspace)
+
+    expect(result.status).toBe(0)
+    expect(JSON.parse(result.stdout)).toMatchObject({ problems: [], unresolved: [] })
+  })
+
+  it('resolves a spread of a base constant declared without as const', () => {
+    // The base is declared AFTER the select and carries no `as const`. That ordering matters: the
+    // previous non-greedy scan searched forward for the next `\n} as const` in the file, so a base
+    // followed by another constant would silently capture that neighbour's body instead and could
+    // appear to work by accident. With nothing after it to span to, the old matcher found nothing.
+    const workspace = createWorkspace(`
+export const USER_SELECT = {
+  ...USER_BASE,
+  id: true,
+} as const
+
+const USER_BASE = {
+  email: true,
+}
+`)
+
+    const result = runTool(workspace)
+
+    expect(result.status).toBe(0)
+    expect(JSON.parse(result.stdout)).toMatchObject({ problems: [], unresolved: [] })
+  })
+
+  it('honours @select-omits on a type-annotated base constant', () => {
+    // The annotation reader and the body reader used separate declaration patterns, so widening
+    // the body reader to accept a type annotation left the annotation reader still blind to it.
+    // A base whose omissions are declared but not seen reports those fields as missing — the same
+    // false positive, one layer up.
+    const workspace = createWorkspace(`
+/** @select-omits email */
+const USER_BASE: Record<string, boolean> = {
+  id: true,
+}
+
+export const USER_SELECT = {
+  ...USER_BASE,
+} as const
+`)
+
+    const result = runTool(workspace)
+
+    expect(result.status).toBe(0)
+    expect(JSON.parse(result.stdout)).toMatchObject({ problems: [], unresolved: [] })
+  })
+
+  it('honours @prisma-model on a type-annotated constant', () => {
+    // The same reader resolves the model override. Annotating Post inside user.select.ts is what
+    // makes this discriminate: if the annotation is missed the constant falls back to the model
+    // implied by the filename, so the run still reports a problem — just against the wrong model,
+    // naming User's missing column rather than Post's. Asserting status alone would pass either way.
+    const workspace = createWorkspace(`
+/** @prisma-model Post */
+export const ACCOUNT_SELECT: Record<string, boolean> = {
+  id: true,
+}
+`)
+
+    const result = runTool(workspace)
+
+    expect(result.status).toBe(1)
+    expect(JSON.parse(result.stdout).problems).toEqual([
+      {
+        file: 'libs/api/custom/src/lib/user/user.select.ts',
+        constant: 'ACCOUNT_SELECT',
+        model: 'Post',
+        missing: ['authorId', 'title'],
+      },
+    ])
+  })
+
+  it('still reports a genuinely missing field when the spread resolves', () => {
+    // The counterpart to the three above: resolution must not become a way to pass by accident.
+    const workspace = createWorkspace(`
+const USER_BASE = {
+  id: true,
+}
+
+export const USER_SELECT = {
+  ...USER_BASE,
+} as const
+`)
+
+    const result = runTool(workspace)
+
+    expect(result.status).toBe(1)
+    expect(JSON.parse(result.stdout).problems).toEqual([
+      {
+        file: 'libs/api/custom/src/lib/user/user.select.ts',
+        constant: 'USER_SELECT',
+        model: 'User',
+        missing: ['email'],
+      },
+    ])
+  })
+})

--- a/doctor/src/verify-selects.mjs
+++ b/doctor/src/verify-selects.mjs
@@ -1,0 +1,607 @@
+#!/usr/bin/env node
+/**
+ * Verify explicit Prisma select constants against the database schema.
+ *
+ * The admin-CRUD boundary migration replaces createSelect(info) with explicit select constants.
+ * createSelect filtered GraphQL-only @ResolveField values through DATABASE_MODELS before they
+ * reached Prisma. An explicit select has no runtime filter, TypeScript can accept extra fields,
+ * and mocked unit tests do not ask Prisma to validate the query. A bad field therefore fails only
+ * when an authenticated operation executes against a real database.
+ *
+ * This tool reports fields that Prisma cannot select, empty nested selects left by unresolved
+ * fragments, and constants whose Prisma model cannot be inferred.
+ *
+ * Usage:
+ *   node tools/verify-selects.mjs [--json] [root ...]
+ *
+ * Model resolution uses the constant name, an unambiguous relation name, and then the filename.
+ * Override an ambiguous constant with a comment immediately before it:
+ *
+ *   /** @prisma-model GroupMember *\/
+ *   export const SETTINGS_SELECT = { ... }
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { basename, isAbsolute, join, relative, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export const SCHEMA_DIRECTORY_CANDIDATES = [
+  'libs/api/prisma/src/lib/schemas',
+  'prisma',
+  'libs/api/prisma/src/lib',
+]
+
+export const DEFAULT_SEARCH_ROOTS = ['libs/api/custom/src', 'libs/api/core', 'apps/api/src']
+
+export const REPO_CONFIG_PATH = '.nestled-updates/doctor.config.json'
+
+export const DEFAULT_SELECT_FILE_SUFFIXES = ['.select.ts']
+
+/**
+ * The few things about a repo's LAYOUT that enforcement cannot assume.
+ *
+ * Deliberately tiny, and deliberately not a general escape hatch: this declares where to look, never
+ * what to accept. A repo that keeps select constants beside the resolver that owns them is laid out
+ * differently, not held to a weaker rule.
+ *
+ * It exists because the alternative is editing the checker in place — which muzebook had to do, and
+ * which stops being possible at all once these tools ship as a package.
+ */
+export const readRepoConfig = (cwd = process.cwd()) => {
+  const configPath = resolve(cwd, REPO_CONFIG_PATH)
+  if (!existsSync(configPath)) return { selectFileSuffixes: DEFAULT_SELECT_FILE_SUFFIXES }
+
+  let parsed
+  try {
+    parsed = JSON.parse(readFileSync(configPath, 'utf8'))
+  } catch {
+    // Fail loudly rather than silently scanning nothing: a malformed config that quietly reverted
+    // to the default would make this checker pass by verifying an empty set.
+    throw new Error(`${REPO_CONFIG_PATH} is not valid JSON`)
+  }
+
+  // A config file that exists is a statement of intent to configure. Silently defaulting on a typoed
+  // key — or accepting an empty list — would scan zero files and pass, in exactly the repos that
+  // wrote this file BECAUSE the default finds nothing for them. Absent file: default. Present file:
+  // say what you mean.
+  const declared = parsed?.selectFileSuffixes
+  if (
+    !Array.isArray(declared) ||
+    declared.length === 0 ||
+    declared.some(suffix => typeof suffix !== 'string' || !suffix)
+  ) {
+    throw new Error(
+      `${REPO_CONFIG_PATH}: selectFileSuffixes must be a non-empty array of non-empty strings`,
+    )
+  }
+
+  return { selectFileSuffixes: declared }
+}
+
+/**
+ * Keys whose object value contains model FIELDS, so their contents are validated as columns.
+ *
+ * `where` and `orderBy` are deliberately absent: their contents are Prisma filter/sort grammar,
+ * not a field namespace. Recursing into `where: { id: { equals: x } }` validated `equals` as a
+ * column of the model and reported it as not-a-column. They are skipped wholesale by
+ * SKIPPED_STRUCTURAL_KEYS below.
+ */
+const FIELD_BEARING_KEYS = new Set(['select', 'include'])
+
+/** Structural keys whose contents are not model fields and must not be walked. */
+const SKIPPED_STRUCTURAL_KEYS = new Set([
+  'where',
+  'orderBy',
+  'take',
+  'skip',
+  'cursor',
+  'distinct',
+  'by',
+  'having',
+  '_count',
+  '_avg',
+  '_sum',
+  '_min',
+  '_max',
+])
+
+const STRUCTURAL_KEYS = new Set([
+  'select',
+  'where',
+  'orderBy',
+  'take',
+  'skip',
+  'include',
+  'distinct',
+])
+
+const alphabetical = (left, right) => left.localeCompare(right)
+const normalizePath = path => path.replaceAll('\\', '/')
+
+const schemaDirectory = cwd =>
+  SCHEMA_DIRECTORY_CANDIDATES.map(candidate => resolve(cwd, candidate)).find(
+    candidate =>
+      existsSync(candidate) && readdirSync(candidate).some(file => file.endsWith('.prisma')),
+  )
+
+const readDatamodel = cwd => {
+  const directory = schemaDirectory(cwd)
+  if (!directory) {
+    throw new Error(`No .prisma schema found under: ${SCHEMA_DIRECTORY_CANDIDATES.join(', ')}`)
+  }
+
+  return readdirSync(directory)
+    .filter(file => file.endsWith('.prisma'))
+    .sort(alphabetical)
+    .map(file => readFileSync(join(directory, file), 'utf8'))
+    .join('\n')
+}
+
+const modelsFromDmmf = dmmf =>
+  Object.fromEntries(
+    dmmf.datamodel.models.map(model => [
+      model.name,
+      Object.fromEntries(
+        model.fields.map(field => [field.name, field.kind === 'object' ? field.type : null]),
+      ),
+    ]),
+  )
+
+/** `name Type[]?` -> [name, relationTarget|null]. Null for scalars, comments and block attributes. */
+const parseFieldLine = line => {
+  const trimmed = line.trim()
+  if (!trimmed || trimmed.startsWith('//') || trimmed.startsWith('@@')) return null
+
+  const [name, rawType] = trimmed.split(/\s+/)
+  if (!rawType) return null
+
+  const type = rawType.replaceAll('[', '').replaceAll(']', '').replaceAll('?', '')
+  return [name, /^[A-Z]/.test(type) ? type : null]
+}
+
+/**
+ * A capitalised type is only a relation if the model it names was actually parsed. Enums and
+ * unresolvable types look identical to relations at this level, so they are demoted to scalars.
+ */
+const pruneUnresolvedRelations = models => {
+  for (const fields of Object.values(models)) {
+    for (const [field, relationTarget] of Object.entries(fields)) {
+      if (relationTarget && !models[relationTarget]) fields[field] = null
+    }
+  }
+  return models
+}
+
+export const parseDatamodelFallback = datamodel => {
+  const models = {}
+  let modelName
+  let fields
+
+  for (const line of datamodel.split('\n')) {
+    if (!modelName) {
+      const modelMatch = /^\s*model\s+(\w+)\s*\{/.exec(line)
+      if (modelMatch) {
+        modelName = modelMatch[1]
+        fields = {}
+      }
+      continue
+    }
+
+    if (/^\s*\}/.test(line)) {
+      models[modelName] = fields
+      modelName = undefined
+      fields = undefined
+      continue
+    }
+
+    const parsed = parseFieldLine(line)
+    if (parsed) fields[parsed[0]] = parsed[1]
+  }
+
+  return pruneUnresolvedRelations(models)
+}
+
+const defaultInternalsLoader = () => import('@prisma/internals')
+
+export const loadModels = async ({
+  cwd = process.cwd(),
+  internalsLoader = defaultInternalsLoader,
+} = {}) => {
+  const datamodel = readDatamodel(cwd)
+  try {
+    const internals = await internalsLoader()
+    const getDMMF = internals.default?.getDMMF ?? internals.getDMMF
+    if (typeof getDMMF !== 'function') throw new Error('@prisma/internals has no getDMMF export')
+    const dmmf = await getDMMF({ datamodel })
+    return { models: modelsFromDmmf(dmmf), source: '@prisma/internals' }
+  } catch {
+    return { models: parseDatamodelFallback(datamodel), source: 'regex fallback' }
+  }
+}
+
+const displayPath = (cwd, path) => {
+  const pathFromCwd = relative(cwd, path)
+  return normalizePath(pathFromCwd.startsWith('..') ? path : pathFromCwd)
+}
+
+export const findSelectFiles = ({
+  cwd = process.cwd(),
+  roots = DEFAULT_SEARCH_ROOTS,
+  selectFileSuffixes = readRepoConfig(cwd).selectFileSuffixes,
+} = {}) => {
+  const files = []
+  const walk = directory => {
+    if (!existsSync(directory)) return
+    for (const entry of readdirSync(directory)) {
+      if (entry === 'node_modules') continue
+      const path = join(directory, entry)
+      const stat = statSync(path)
+      if (stat.isDirectory()) walk(path)
+      else {
+        const suffix = selectFileSuffixes.find(candidate => entry.endsWith(candidate))
+        if (suffix) {
+          files.push({
+            absolutePath: path,
+            file: displayPath(cwd, path),
+            // A dedicated .select.ts file holds nothing but selects, so every exported const is
+            // one — including camelCase names, which real repos use. A shared file matched by an
+            // extra suffix also holds ordinary locals (`const where = {}`), so there a naming
+            // convention is the only way to tell a select from a local. Applying that convention
+            // everywhere would silently stop verifying camelCase selects in .select.ts files.
+            conventionalNamesOnly: suffix !== '.select.ts',
+          })
+        }
+      }
+    }
+  }
+
+  for (const root of roots) walk(isAbsolute(root) ? root : resolve(cwd, root))
+  return files.sort((left, right) => left.file.localeCompare(right.file))
+}
+
+const skipLineComment = (source, start) => {
+  let index = start
+  while (index < source.length && source[index] !== '\n') index += 1
+  return index
+}
+
+const skipBlockComment = (source, start) => {
+  let index = start
+  while (index < source.length) {
+    if (source[index] === '*' && source[index + 1] === '/') {
+      return index + 2
+    }
+    index += 1
+  }
+  return index
+}
+
+const copyQuotedValue = (source, start) => {
+  const quote = source[start]
+  let index = start + 1
+  while (index < source.length) {
+    if (source[index] === '\\') index += 2
+    else if (source[index] === quote) return index + 1
+    else index += 1
+  }
+  return index
+}
+
+const maskRange = source => source.replace(/[^\n]/g, ' ')
+
+const sanitizeSource = source => {
+  let result = ''
+  let index = 0
+  while (index < source.length) {
+    const character = source[index]
+    const next = source[index + 1]
+    if (character === '/' && next === '/') {
+      const end = skipLineComment(source, index + 2)
+      result += maskRange(source.slice(index, end))
+      index = end
+    } else if (character === '/' && next === '*') {
+      const end = skipBlockComment(source, index + 2)
+      result += maskRange(source.slice(index, end))
+      index = end
+    } else if (character === "'" || character === '"' || character === '`') {
+      const end = copyQuotedValue(source, index)
+      result += maskRange(source.slice(index, end))
+      index = end
+    } else {
+      result += character
+      index += 1
+    }
+  }
+  return result
+}
+
+const closingBrace = (source, start) => {
+  let depth = 0
+  for (let index = start; index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1
+    else if (source[index] === '}') {
+      depth -= 1
+      if (depth === 0) return index
+    }
+  }
+  return -1
+}
+
+const nestedSelectIsEmpty = (source, start) => {
+  const close = closingBrace(source, start)
+  if (close === -1) return false
+  const inner = source.slice(start + 1, close).replace(/select\s*:/g, '')
+  return !/\w/.test(inner)
+}
+
+const addFieldProblem = (problems, context, field) => {
+  if (!(field in context.models[context.model])) {
+    problems.push({
+      file: context.file,
+      path: [...context.path, field].join('.'),
+      model: context.model,
+      kind: 'not-a-column',
+    })
+  }
+}
+
+const addEmptySelectProblem = (problems, context, field) => {
+  problems.push({
+    file: context.file,
+    path: [...context.path, field].join('.'),
+    model: context.model,
+    kind: 'empty-select',
+  })
+}
+
+const checkProperty = (source, index, context, problems) => {
+  const match = /^(\w+)\s*:\s*/.exec(source.slice(index))
+  if (!match) return index + 1
+
+  const field = match[1]
+  const valueStart = index + match[0].length
+  if (SKIPPED_STRUCTURAL_KEYS.has(field)) {
+    // Skip the whole value. Its contents are Prisma grammar, not columns.
+    if (source[valueStart] !== '{') return valueStart
+    const close = closingBrace(source, valueStart)
+    return close === -1 ? source.length : close + 1
+  }
+  if (FIELD_BEARING_KEYS.has(field) || STRUCTURAL_KEYS.has(field)) {
+    return source[valueStart] === '{'
+      ? checkBlock(source, valueStart + 1, context, problems)
+      : valueStart
+  }
+  if (!context.models[context.model]) return valueStart
+
+  addFieldProblem(problems, context, field)
+  const relationTarget = context.models[context.model][field]
+  if (source[valueStart] !== '{') return valueStart
+  if (nestedSelectIsEmpty(source, valueStart)) addEmptySelectProblem(problems, context, field)
+
+  return checkBlock(
+    source,
+    valueStart + 1,
+    {
+      ...context,
+      model: relationTarget || context.model,
+      path: relationTarget ? [...context.path, field] : context.path,
+    },
+    problems,
+  )
+}
+
+function checkBlock(source, start, context, problems) {
+  let depth = 1
+  let index = start
+  while (index < source.length && depth > 0) {
+    if (source[index] === '{') {
+      depth += 1
+      index += 1
+    } else if (source[index] === '}') {
+      depth -= 1
+      index += 1
+    } else {
+      index = checkProperty(source, index, context, problems)
+    }
+  }
+  return index
+}
+
+const pascalCase = value =>
+  value
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map(word => word[0].toUpperCase() + word.slice(1).toLowerCase())
+    .join('')
+
+const constantModelCandidates = constantName => {
+  const words = constantName
+    .replace(/_?SELECT.*$/, '')
+    .split('_')
+    .filter(Boolean)
+  const candidates = []
+  for (let length = words.length; length > 0; length -= 1) {
+    for (let start = 0; start + length <= words.length; start += 1) {
+      candidates.push(pascalCase(words.slice(start, start + length).join('_')))
+    }
+  }
+  return candidates
+}
+
+const relationTargetForConstant = (models, constantName) => {
+  const words = constantName
+    .replace(/_?SELECT.*$/, '')
+    .toLowerCase()
+    .split('_')
+    .filter(Boolean)
+  const relationName = words
+    .map((word, index) => (index === 0 ? word : word[0].toUpperCase() + word.slice(1)))
+    .join('')
+  const targets = new Set(
+    Object.values(models)
+      .map(fields => fields[relationName])
+      .filter(Boolean),
+  )
+  return targets.size === 1 ? [...targets][0] : null
+}
+
+export const resolveModel = (models, constantName, file, annotatedModel) => {
+  if (annotatedModel) return models[annotatedModel] ? annotatedModel : null
+
+  for (const candidate of constantModelCandidates(constantName)) {
+    if (models[candidate]) return candidate
+  }
+
+  const relationTarget = relationTargetForConstant(models, constantName)
+  if (relationTarget) return relationTarget
+
+  const fromFile = pascalCase(basename(file).replace('.select.ts', ''))
+  return models[fromFile] ? fromFile : null
+}
+
+/**
+ * The nearest `@prisma-model` annotation that is genuinely *before* this constant.
+ *
+ * `previousEnd` is the closing brace of the previous constant, not its start. Scanning from the
+ * start would include the previous constant's whole body, so a `@prisma-model` mentioned inside
+ * it — in a comment or a string — would silently resolve THIS constant to that model.
+ */
+const annotationBefore = (rawSource, constantOffset, previousEnd) => {
+  const gap = rawSource.slice(previousEnd, constantOffset)
+  return [...gap.matchAll(/@prisma-model\s+(\w+)/g)].pop()?.[1]
+}
+
+export const CONVENTIONAL_SELECT_NAME = /^[A-Z][A-Z0-9_]*$/
+
+const verifyFile = ({ absolutePath, file, conventionalNamesOnly = false }, models) => {
+  const rawSource = readFileSync(absolutePath, 'utf8')
+  const source = sanitizeSource(rawSource)
+  const problems = []
+  const unresolved = []
+  let previousConstantEnd = 0
+
+  for (const match of source.matchAll(/(?:export\s+)?const\s+(\w+)\s*=\s*\{/g)) {
+    const constantOffset = match.index
+    // Count braces on the SANITIZED source: closingBrace() is not comment- or string-aware, and
+    // a `}` inside either would end the constant early, putting part of its body back into the
+    // next constant's annotation window. sanitizeSource() masks with spaces and is
+    // length-preserving, so these offsets are interchangeable with rawSource's.
+    const bodyStart = match.index + match[0].length - 1
+    const bodyEnd = closingBrace(source, bodyStart)
+    // Advance the annotation window for EVERY matched constant, skipped ones included, and keep the
+    // prior value for this constant's own lookup. A skipped local left inside the window would put
+    // its body in front of the next constant, so a @prisma-model mentioned in it would resolve that
+    // constant to the wrong model — exactly what this tracking exists to prevent.
+    const previousEnd = previousConstantEnd
+    previousConstantEnd = bodyEnd === -1 ? constantOffset : bodyEnd
+
+    // See conventionalNamesOnly above: in a shared file, an ordinary local is not an unresolvable
+    // select, and reporting it as one is the noise that gets a whole check switched off.
+    if (conventionalNamesOnly && !CONVENTIONAL_SELECT_NAME.test(match[1])) continue
+
+    const annotatedModel = annotationBefore(rawSource, constantOffset, previousEnd)
+    const model = resolveModel(models, match[1], file, annotatedModel)
+
+    if (!model) {
+      unresolved.push({ file, const: match[1] })
+      continue
+    }
+
+    checkBlock(
+      source,
+      match.index + match[0].length,
+      { models, file, model, path: [match[1]] },
+      problems,
+    )
+  }
+
+  return { problems, unresolved }
+}
+
+export const verifySelects = async ({
+  cwd = process.cwd(),
+  roots = DEFAULT_SEARCH_ROOTS,
+  internalsLoader = defaultInternalsLoader,
+} = {}) => {
+  const { models, source } = await loadModels({ cwd, internalsLoader })
+  const files = findSelectFiles({ cwd, roots })
+  const problems = []
+  const unresolved = []
+
+  for (const file of files) {
+    const result = verifyFile(file, models)
+    problems.push(...result.problems)
+    unresolved.push(...result.unresolved)
+  }
+
+  return { source, files: files.length, problems, unresolved }
+}
+
+const usage = `Usage:
+  node tools/verify-selects.mjs [--json] [root ...]
+
+Validates every *.select.ts constant under the configured roots against the Prisma schema.`
+
+const renderText = result => {
+  const lines = [`verify-selects — ${result.files} file(s), schema via ${result.source}`, '']
+  for (const problem of result.problems) {
+    const reason =
+      problem.kind === 'empty-select'
+        ? 'EMPTY select (invalid Prisma, selects nothing)'
+        : `not a column on ${problem.model}`
+    lines.push(`  ${problem.file}`, `      ${problem.path}  — ${reason}`)
+  }
+  for (const unresolved of result.unresolved) {
+    lines.push(
+      `  ${unresolved.file}`,
+      `      ${unresolved.const}  — cannot resolve model; add /** @prisma-model X */`,
+    )
+  }
+  lines.push(
+    result.problems.length || result.unresolved.length
+      ? `\n${result.problems.length} problem(s), ${result.unresolved.length} unresolved`
+      : '\nall selects verify against the schema',
+  )
+  return lines.join('\n')
+}
+
+const parseArguments = arguments_ => {
+  const asJson = arguments_.includes('--json')
+  const unknownOptions = arguments_.filter(
+    argument => argument.startsWith('--') && argument !== '--json' && argument !== '--',
+  )
+  if (unknownOptions.length > 0) throw new Error(`Unknown option(s): ${unknownOptions.join(', ')}`)
+  return { asJson, roots: arguments_.filter(argument => !argument.startsWith('--')) }
+}
+
+const errorMessage = error => {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  return JSON.stringify(error) ?? 'Unknown verify-selects failure'
+}
+
+export const runCli = async (arguments_ = process.argv.slice(2), cwd = process.cwd()) => {
+  if (arguments_.includes('--help') || arguments_.includes('-h')) {
+    console.log(usage)
+    return 0
+  }
+
+  let asJson = arguments_.includes('--json')
+  try {
+    const parsed = parseArguments(arguments_)
+    asJson = parsed.asJson
+    const result = await verifySelects({
+      cwd,
+      roots: parsed.roots.length > 0 ? parsed.roots : DEFAULT_SEARCH_ROOTS,
+    })
+    console.log(asJson ? JSON.stringify(result, null, 2) : renderText(result))
+    return result.problems.length || result.unresolved.length ? 1 : 0
+  } catch (error) {
+    const message = errorMessage(error)
+    if (asJson) console.log(JSON.stringify({ error: message }, null, 2))
+    else console.error(message)
+    return 2
+  }
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+if (isMain) process.exitCode = await runCli()

--- a/doctor/src/verify-selects.spec.mjs
+++ b/doctor/src/verify-selects.spec.mjs
@@ -1,0 +1,437 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, describe, expect, it } from 'vitest'
+import { loadModels, verifySelects,
+  readRepoConfig,
+  findSelectFiles,
+} from './verify-selects.mjs'
+
+const toolPath = fileURLToPath(new URL('./verify-selects.mjs', import.meta.url))
+const workspaces = []
+
+const writeFixture = (workspace, path, source) => {
+  const file = join(workspace, path)
+  mkdirSync(dirname(file), { recursive: true })
+  writeFileSync(file, source)
+}
+
+const createWorkspace = () => {
+  const workspace = mkdtempSync(join(tmpdir(), 'verify-selects-'))
+  workspaces.push(workspace)
+  writeFixture(
+    workspace,
+    'libs/api/prisma/src/lib/schemas/schema.prisma',
+    `
+      datasource db {
+        provider = "postgresql"
+      }
+
+      generator client {
+        provider = "prisma-client"
+        output = "../generated"
+      }
+
+      model User {
+        id    String @id
+        posts Post[]
+      }
+
+      model Post {
+        id       String @id
+        authorId String?
+        author   User? @relation(fields: [authorId], references: [id])
+      }
+    `,
+  )
+  return workspace
+}
+
+afterEach(() => {
+  for (const workspace of workspaces.splice(0)) rmSync(workspace, { recursive: true, force: true })
+})
+
+describe('verify-selects', () => {
+  it('loads authoritative DMMF and reports invalid fields and empty nested selects', async () => {
+    const workspace = createWorkspace()
+    writeFixture(
+      workspace,
+      'custom-selects/user.select.ts',
+      `
+        export const USER_SELECT = {
+          id: true,
+          posts: { select: { id: true } },
+        }
+
+        export const USER_BAD_SELECT = {
+          likesCount: true,
+          posts: { select: {} },
+        }
+      `,
+    )
+
+    const result = await verifySelects({ cwd: workspace, roots: ['custom-selects'] })
+
+    expect(result.source).toBe('@prisma/internals')
+    expect(result.problems).toEqual([
+      {
+        file: 'custom-selects/user.select.ts',
+        kind: 'not-a-column',
+        model: 'User',
+        path: 'USER_BAD_SELECT.likesCount',
+      },
+      {
+        file: 'custom-selects/user.select.ts',
+        kind: 'empty-select',
+        model: 'User',
+        path: 'USER_BAD_SELECT.posts',
+      },
+    ])
+    expect(result.unresolved).toEqual([])
+  })
+
+  it('walks relations and scopes model overrides to the constant they precede', async () => {
+    const workspace = createWorkspace()
+    writeFixture(
+      workspace,
+      'custom-selects/settings.select.ts',
+      `
+        const AUTHOR_SELECT = {
+          id: true,
+          anotherMissingUserField: true,
+        }
+
+        const MEMBER_USER_SELECT = { id: true }
+
+        /** @prisma-model Post */
+        export const SETTINGS_SELECT = {
+          id: true,
+          author: { select: { missingUserField: true } },
+        }
+
+        export const MYSTERY_SELECT = { id: true }
+      `,
+    )
+
+    const result = await verifySelects({ cwd: workspace, roots: ['custom-selects'] })
+
+    expect(result.problems).toEqual([
+      {
+        file: 'custom-selects/settings.select.ts',
+        kind: 'not-a-column',
+        model: 'User',
+        path: 'AUTHOR_SELECT.anotherMissingUserField',
+      },
+      {
+        file: 'custom-selects/settings.select.ts',
+        kind: 'not-a-column',
+        model: 'User',
+        path: 'SETTINGS_SELECT.author.missingUserField',
+      },
+    ])
+    expect(result.unresolved).toEqual([
+      { file: 'custom-selects/settings.select.ts', const: 'MYSTERY_SELECT' },
+    ])
+  })
+
+  it('uses the regex schema fallback when Prisma internals are unavailable', async () => {
+    const workspace = createWorkspace()
+    const result = await loadModels({
+      cwd: workspace,
+      internalsLoader: async () => {
+        throw new Error('not installed')
+      },
+    })
+
+    expect(result.source).toBe('regex fallback')
+    expect(result.models.User).toEqual({ id: null, posts: 'Post' })
+  })
+
+  it('supports configurable roots, JSON output, and a non-zero finding exit', () => {
+    const workspace = createWorkspace()
+    writeFixture(
+      workspace,
+      'chosen/user.select.ts',
+      'export const USER_SELECT = { friendsCount: true }',
+    )
+    writeFixture(workspace, 'ignored/user.select.ts', 'export const USER_SELECT = { id: true }')
+
+    const result = spawnSync(process.execPath, [toolPath, '--json', 'chosen'], {
+      cwd: workspace,
+      encoding: 'utf8',
+    })
+
+    expect(result.status).toBe(1)
+    const report = JSON.parse(result.stdout)
+    expect(report.files).toBe(1)
+    expect(report.problems).toHaveLength(1)
+    expect(report.problems[0].path).toBe('USER_SELECT.friendsCount')
+    expect(result.stderr).toBe('')
+  })
+
+  it('exits successfully when every discovered select is valid', () => {
+    const workspace = createWorkspace()
+    writeFixture(workspace, 'chosen/user.select.ts', 'export const USER_SELECT = { id: true }')
+
+    expect(() =>
+      execFileSync(process.execPath, [toolPath, 'chosen'], {
+        cwd: workspace,
+        encoding: 'utf8',
+      }),
+    ).not.toThrow()
+  })
+
+  it('does not validate Prisma filter grammar inside where/orderBy as columns', async () => {
+    const workspace = createWorkspace()
+    writeFixture(
+      workspace,
+      'custom-selects/user.select.ts',
+      `
+        export const USER_SELECT = {
+          id: true,
+          posts: {
+            where: { id: { equals: 'x' }, author: { is: { id: 'y' } } },
+            orderBy: { id: 'desc' },
+            take: 5,
+            select: { id: true },
+          },
+        }
+      `,
+    )
+
+    const result = await verifySelects({ cwd: workspace, roots: ['custom-selects'] })
+
+    // `equals` and `is` are filter operators, not columns on Post. Walking them reported them
+    // as not-a-column, which made the tool unusable on any select carrying a where clause.
+    expect(result.problems).toEqual([])
+  })
+
+  it('still reports a genuine bad column that sits alongside a where clause', async () => {
+    const workspace = createWorkspace()
+    writeFixture(
+      workspace,
+      'custom-selects/user.select.ts',
+      `
+        export const USER_SELECT = {
+          posts: {
+            where: { id: { equals: 'x' } },
+            select: { likesCount: true },
+          },
+        }
+      `,
+    )
+
+    const result = await verifySelects({ cwd: workspace, roots: ['custom-selects'] })
+
+    // Skipping `where` must not blind the tool to the select beside it.
+    expect(result.problems).toEqual([
+      {
+        file: 'custom-selects/user.select.ts',
+        path: 'USER_SELECT.posts.likesCount',
+        model: 'Post',
+        kind: 'not-a-column',
+      },
+    ])
+  })
+
+  it('does not let a @prisma-model inside one constant resolve the next one', async () => {
+    const workspace = createWorkspace()
+    writeFixture(
+      workspace,
+      'custom-selects/misc.select.ts',
+      `
+        export const FIRST_SELECT = {
+          id: true,
+          // @prisma-model User  <- mentioned INSIDE this constant, not before the next one
+        }
+
+        export const TOTALLY_UNKNOWN_THING = {
+          id: true,
+        }
+      `,
+    )
+
+    const result = await verifySelects({ cwd: workspace, roots: ['custom-selects'] })
+
+    // Both are unresolvable by name. Scanning from the previous constant's START swept up the
+    // annotation in its body and silently validated TOTALLY_UNKNOWN_THING against User.
+    expect(result.unresolved.map(entry => entry.const).sort()).toEqual([
+      'FIRST_SELECT',
+      'TOTALLY_UNKNOWN_THING',
+    ])
+  })
+
+  it('still honours a @prisma-model annotation placed before its constant', async () => {
+    const workspace = createWorkspace()
+    writeFixture(
+      workspace,
+      'custom-selects/misc.select.ts',
+      `
+        export const FIRST_SELECT = { id: true }
+
+        // @prisma-model Post
+        export const TOTALLY_UNKNOWN_THING = {
+          likesCount: true,
+        }
+      `,
+    )
+
+    const result = await verifySelects({ cwd: workspace, roots: ['custom-selects'] })
+
+    // Tightening the scan window must not break the annotation's actual purpose.
+    expect(result.unresolved.map(entry => entry.const)).toEqual(['FIRST_SELECT'])
+    expect(result.problems).toEqual([
+      {
+        file: 'custom-selects/misc.select.ts',
+        path: 'TOTALLY_UNKNOWN_THING.likesCount',
+        model: 'Post',
+        kind: 'not-a-column',
+      },
+    ])
+  })
+
+  it('is not fooled by a closing brace inside a comment or string', async () => {
+    const workspace = createWorkspace()
+    writeFixture(
+      workspace,
+      'custom-selects/misc.select.ts',
+      `
+        export const FIRST_SELECT = {
+          id: true,
+          // a closing brace in a comment: }  then @prisma-model User
+        }
+
+        export const TOTALLY_UNKNOWN_THING = {
+          id: true,
+        }
+      `,
+    )
+
+    const result = await verifySelects({ cwd: workspace, roots: ['custom-selects'] })
+
+    // closingBrace() is not comment-aware, so counting braces on the raw source ended the first
+    // constant at the `}` in that comment — putting the rest of its body, annotation included,
+    // back into the next constant's window. Counting on the sanitized source fixes it; the mask
+    // is length-preserving, so the offsets still line up with rawSource for the annotation scan.
+    expect(result.unresolved.map(entry => entry.const).sort()).toEqual([
+      'FIRST_SELECT',
+      'TOTALLY_UNKNOWN_THING',
+    ])
+  })
+})
+
+// The skipped-local bug: `continue` used to skip advancing previousConstantEnd, so the skipped
+// local's body stayed inside the NEXT constant's annotation window, and a @prisma-model mentioned
+// in it resolved that constant to the wrong model. annotationBefore exists precisely to prevent
+// this, and the skip quietly defeated it.
+describe('annotation window with skipped constants', () => {
+  it("does not let a skipped local's body annotate the next select", async () => {
+    const workspace = createWorkspace()
+    writeFixture(
+      workspace,
+      '.nestled-updates/doctor.config.json',
+      JSON.stringify({ selectFileSuffixes: ['.select.ts', '.resolver.ts'] }),
+    )
+    writeFixture(
+      workspace,
+      'custom-selects/user.resolver.ts',
+      `
+        /** @prisma-model User */
+        export const FIRST_SELECT = {
+          id: true,
+        }
+
+        const where = {
+          // @prisma-model Post
+          id: true,
+        }
+
+        export const USER_SELECT = {
+          posts: { select: { id: true } },
+        }
+      `,
+    )
+
+    const result = await verifySelects({ cwd: workspace, roots: ['custom-selects'] })
+
+    // \`posts\` is valid on User and absent from Post. If the skipped \`where\` body stays in the
+    // annotation window, USER_SELECT resolves to Post and this reports an invalid field.
+    expect(result.problems).toEqual([])
+    // And the ordinary local is not itself reported as an unresolvable select.
+    expect(result.unresolved.map((entry) => entry.const)).not.toContain('where')
+  })
+})
+
+describe('repo layout config', () => {
+  const withRepo = (files) => {
+    const repo = mkdtempSync(join(tmpdir(), 'verify-selects-config-'))
+    for (const [relative, contents] of Object.entries(files)) {
+      const full = join(repo, relative)
+      mkdirSync(dirname(full), { recursive: true })
+      writeFileSync(full, contents)
+    }
+    return repo
+  }
+
+  it('defaults to .select.ts when no config is present', () => {
+    expect(readRepoConfig(withRepo({})).selectFileSuffixes).toEqual(['.select.ts'])
+  })
+
+  it('honours declared suffixes', () => {
+    const repo = withRepo({
+      '.nestled-updates/doctor.config.json': JSON.stringify({
+        selectFileSuffixes: ['.select.ts', '.resolver.ts'],
+      }),
+    })
+
+    expect(readRepoConfig(repo).selectFileSuffixes).toEqual(['.select.ts', '.resolver.ts'])
+  })
+
+  // Silently reverting to the default would make this checker pass by verifying an empty set.
+  it('throws on malformed config rather than quietly scanning nothing', () => {
+    expect(() => readRepoConfig(withRepo({ '.nestled-updates/doctor.config.json': '{ not json' }))).toThrow(
+      'not valid JSON',
+    )
+    expect(() =>
+      readRepoConfig(
+        withRepo({ '.nestled-updates/doctor.config.json': JSON.stringify({ selectFileSuffixes: 'x' }) }),
+      ),
+    ).toThrow('array of non-empty strings')
+  })
+
+  // A dedicated select file holds nothing but selects, so camelCase names are real selects there —
+  // mi-core has courseOverviewSelect. Requiring SCREAMING_SNAKE everywhere would stop verifying them.
+  // A config file that exists is intent to configure. Defaulting on a typoed key would scan zero
+  // files and pass, in exactly the repos that wrote the file BECAUSE the default finds nothing.
+  it('rejects a config that omits selectFileSuffixes or declares it empty', () => {
+    expect(() =>
+      readRepoConfig(
+        withRepo({ '.nestled-updates/doctor.config.json': JSON.stringify({ selectFileSufixes: ['.a.ts'] }) }),
+      ),
+    ).toThrow('non-empty array')
+
+    expect(() =>
+      readRepoConfig(
+        withRepo({ '.nestled-updates/doctor.config.json': JSON.stringify({ selectFileSuffixes: [] }) }),
+      ),
+    ).toThrow('non-empty array')
+  })
+
+  it('requires conventional names only for suffixes beyond .select.ts', () => {
+    const repo = withRepo({
+      'libs/api/custom/src/a.select.ts': 'export const courseOverviewSelect = { id: true }\n',
+      'libs/api/custom/src/b.resolver.ts': 'const where = { id: true }\nexport const GROUP_SELECT = { id: true }\n',
+      '.nestled-updates/doctor.config.json': JSON.stringify({
+        selectFileSuffixes: ['.select.ts', '.resolver.ts'],
+      }),
+    })
+
+    const found = findSelectFiles({ cwd: repo, roots: ['libs/api/custom/src'] })
+    const byName = Object.fromEntries(found.map((entry) => [entry.file.split('/').pop(), entry]))
+
+    expect(byName['a.select.ts'].conventionalNamesOnly).toBe(false)
+    expect(byName['b.resolver.ts'].conventionalNamesOnly).toBe(true)
+  })
+})

--- a/doctor/src/verify-selects.spec.mjs
+++ b/doctor/src/verify-selects.spec.mjs
@@ -257,7 +257,7 @@ describe('verify-selects', () => {
 
     // Both are unresolvable by name. Scanning from the previous constant's START swept up the
     // annotation in its body and silently validated TOTALLY_UNKNOWN_THING against User.
-    expect(result.unresolved.map(entry => entry.const).sort()).toEqual([
+    expect(result.unresolved.map(entry => entry.const).sort((left, right) => left.localeCompare(right))).toEqual([
       'FIRST_SELECT',
       'TOTALLY_UNKNOWN_THING',
     ])
@@ -315,7 +315,7 @@ describe('verify-selects', () => {
     // constant at the `}` in that comment — putting the rest of its body, annotation included,
     // back into the next constant's window. Counting on the sanitized source fixes it; the mask
     // is length-preserving, so the offsets still line up with rawSource for the annotation scan.
-    expect(result.unresolved.map(entry => entry.const).sort()).toEqual([
+    expect(result.unresolved.map(entry => entry.const).sort((left, right) => left.localeCompare(right))).toEqual([
       'FIRST_SELECT',
       'TOTALLY_UNKNOWN_THING',
     ])

--- a/doctor/tsconfig.json
+++ b/doctor/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node"
+  },
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }, { "path": "./tsconfig.spec.json" }]
+}

--- a/doctor/tsconfig.lib.json
+++ b/doctor/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/doctor/tsconfig.spec.json
+++ b/doctor/tsconfig.spec.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/doctor/vitest.config.ts
+++ b/doctor/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    globals: false,
+    environment: 'node',
+    // .mjs specs alongside .ts ones: the select verifiers are ESM by design.
+    include: ['src/**/*.spec.{ts,mjs}'],
+    reporters: ['default'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
         version: 2.17.3
       '@remix-run/dev':
         specifier: 2.17.3
-        version: 2.17.3(@remix-run/react@2.17.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(@remix-run/serve@2.17.3(typescript@5.7.3))(@types/node@20.19.24)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.7.3))(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)
+        version: 2.17.3(@remix-run/react@2.17.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(@remix-run/serve@2.17.3(typescript@5.7.3))(@types/node@20.19.24)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.7.3))(tsx@4.23.12)(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(yaml@2.8.1)
       '@remix-run/eslint-config':
         specifier: 2.17.3
         version: 2.17.3(eslint@9.39.1(jiti@2.4.2))(jest@30.0.5(@types/node@20.19.24)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.17.6))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.7.3)))(react@19.1.0)(typescript@5.7.3)
@@ -67,19 +67,19 @@ importers:
         version: 9.1.16(@types/react@19.1.0)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@storybook/addon-vitest':
         specifier: ^9.1.6
-        version: 9.1.16(@vitest/browser@3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(vitest@4.0.9))(@vitest/runner@4.0.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vitest@4.0.9)
+        version: 9.1.16(@vitest/browser@3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(vitest@4.0.9))(@vitest/runner@4.0.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vitest@4.0.9)
       '@tailwindcss/postcss':
         specifier: ^4.1.11
         version: 4.1.16
       '@tailwindcss/vite':
         specifier: ^4.1.11
-        version: 4.1.16(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))
+        version: 4.1.16(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
       '@vitest/browser':
         specifier: ^3.2.4
-        version: 3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(vitest@4.0.9)
+        version: 3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(vitest@4.0.9)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -136,7 +136,7 @@ importers:
         version: 7.8.2
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))
+        version: 5.1.4(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))
       yaml:
         specifier: ^2.8.0
         version: 2.8.1
@@ -179,16 +179,16 @@ importers:
         version: 22.5.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.17.6))(eslint@9.39.1(jiti@2.4.2))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.7.3))(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
       '@nx/react':
         specifier: 22.5.1
-        version: 22.5.1(@babel/core@7.28.5)(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.17.6)(eslint@9.39.1(jiti@2.4.2))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(vitest@4.0.9)
+        version: 22.5.1(@babel/core@7.28.5)(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.17.6)(eslint@9.39.1(jiti@2.4.2))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(vitest@4.0.9)
       '@nx/remix':
         specifier: 22.5.1
-        version: 22.5.1(dd3b36413fc769134e58109a065ac586)
+        version: 22.5.1(64158b3eb00707d132732480e42a244d)
       '@nx/storybook':
         specifier: 22.5.1
         version: 22.5.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.1(jiti@2.4.2))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
       '@nx/vite':
         specifier: 22.5.1
-        version: 22.5.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(vitest@4.0.9)
+        version: 22.5.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(vitest@4.0.9)
       '@nx/web':
         specifier: 22.5.1
         version: 22.5.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
@@ -203,7 +203,7 @@ importers:
         version: 7.3.0(prisma@7.3.0(@types/react@19.1.0)(magicast@0.3.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(typescript@5.7.3)
       '@storybook/react-vite':
         specifier: 10.2.9
-        version: 10.2.9(esbuild@0.17.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.52.5)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.6))
+        version: 10.2.9(esbuild@0.17.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.52.5)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.6))
       '@swc-node/register':
         specifier: 1.11.1
         version: 1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3)
@@ -251,10 +251,10 @@ importers:
         version: 8.46.2(eslint@9.39.1(jiti@2.4.2))(typescript@5.7.3)
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.7.0(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))
+        version: 4.7.0(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))
       '@vitest/coverage-v8':
         specifier: 4.0.9
-        version: 4.0.9(@vitest/browser@3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(vitest@4.0.9))(vitest@4.0.9)
+        version: 4.0.9(@vitest/browser@3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(vitest@4.0.9))(vitest@4.0.9)
       '@vitest/ui':
         specifier: 4.0.9
         version: 4.0.9(vitest@4.0.9)
@@ -347,16 +347,31 @@ importers:
         version: 6.2.1(encoding@0.1.13)(typanion@3.14.0)
       vite:
         specifier: 7.1.9
-        version: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+        version: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
       vite-plugin-dts:
         specifier: ~4.5.0
-        version: 4.5.4(@types/node@20.19.24)(rollup@4.52.5)(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))
+        version: 4.5.4(@types/node@20.19.24)(rollup@4.52.5)(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))
       vitest:
         specifier: 4.0.9
-        version: 4.0.9(@types/debug@4.1.12)(@types/node@20.19.24)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+        version: 4.0.9(@types/debug@4.1.12)(@types/node@20.19.24)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
+
+  doctor:
+    dependencies:
+      '@prisma/internals':
+        specifier: '>=6'
+        version: 7.3.0(magicast@0.3.5)(typescript@5.9.3)
+      graphql:
+        specifier: ^16.9.0
+        version: 16.12.0
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.12
+      typescript:
+        specifier: ^5.9.0
+        version: 5.9.3
 
   generators:
     dependencies:
@@ -368,7 +383,7 @@ importers:
         version: 22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
       '@nx/nest':
         specifier: 22.0.2
-        version: 22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(chokidar@4.0.3)(esbuild-register@3.6.0(esbuild@0.25.12))(eslint@9.39.1(jiti@2.6.1))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
+        version: 22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(chokidar@4.0.3)(esbuild-register@3.6.0(esbuild@0.28.2))(eslint@9.39.1(jiti@2.6.1))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
       '@prisma/internals':
         specifier: ^7.3.0
         version: 7.3.0(magicast@0.3.5)(typescript@5.9.3)
@@ -1344,6 +1359,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.17.6':
     resolution: {integrity: sha512-YnYSCceN/dUzUr5kdtUzB+wZprCafuD89Hs0Aqv9QSdwhYQybhXTaSTcrl6X/aWThn1a/j0eEpUBGOE7269REg==}
     engines: {node: '>=12'}
@@ -1364,6 +1385,12 @@ packages:
 
   '@esbuild/android-arm64@0.25.5':
     resolution: {integrity: sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1392,6 +1419,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.17.6':
     resolution: {integrity: sha512-MVcYcgSO7pfu/x34uX9u2QIZHmXAB7dEiLQC5bBl5Ryqtpj9lT2sg3gNDEsrPEmimSJW2FXIaxqSQ501YLDsZQ==}
     engines: {node: '>=12'}
@@ -1412,6 +1445,12 @@ packages:
 
   '@esbuild/android-x64@0.25.5':
     resolution: {integrity: sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1440,6 +1479,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.17.6':
     resolution: {integrity: sha512-xh2A5oPrYRfMFz74QXIQTQo8uA+hYzGWJFoeTE8EvoZGHb+idyV4ATaukaUvnnxJiauhs/fPx3vYhU4wiGfosg==}
     engines: {node: '>=12'}
@@ -1460,6 +1505,12 @@ packages:
 
   '@esbuild/darwin-x64@0.25.5':
     resolution: {integrity: sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1488,6 +1539,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.17.6':
     resolution: {integrity: sha512-Uh3HLWGzH6FwpviUcLMKPCbZUAFzv67Wj5MTwK6jn89b576SR2IbEp+tqUHTr8DIl0iDmBAf51MVaP7pw6PY5Q==}
     engines: {node: '>=12'}
@@ -1508,6 +1565,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.25.5':
     resolution: {integrity: sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1536,6 +1599,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.17.6':
     resolution: {integrity: sha512-7YdGiurNt7lqO0Bf/U9/arrPWPqdPqcV6JCZda4LZgEn+PTQ5SMEI4MGR52Bfn3+d6bNEGcWFzlIxiQdS48YUw==}
     engines: {node: '>=12'}
@@ -1556,6 +1625,12 @@ packages:
 
   '@esbuild/linux-arm@0.25.5':
     resolution: {integrity: sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1584,6 +1659,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.17.6':
     resolution: {integrity: sha512-y2NX1+X/Nt+izj9bLoiaYB9YXT/LoaQFYvCkVD77G/4F+/yuVXYCWz4SE9yr5CBMbOxOfBcy/xFL4LlOeNlzYQ==}
     engines: {node: '>=12'}
@@ -1604,6 +1685,12 @@ packages:
 
   '@esbuild/linux-loong64@0.25.5':
     resolution: {integrity: sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1632,6 +1719,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.17.6':
     resolution: {integrity: sha512-AmLhMzkM8JuqTIOhxnX4ubh0XWJIznEynRnZAVdA2mMKE6FAfwT2TWKTwdqMG+qEaeyDPtfNoZRpJbD4ZBv0Tg==}
     engines: {node: '>=12'}
@@ -1652,6 +1745,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.25.5':
     resolution: {integrity: sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1680,6 +1779,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.17.6':
     resolution: {integrity: sha512-SPUiz4fDbnNEm3JSdUW8pBJ/vkop3M1YwZAVwvdwlFLoJwKEZ9L98l3tzeyMzq27CyepDQ3Qgoba44StgbiN5Q==}
     engines: {node: '>=12'}
@@ -1700,6 +1805,12 @@ packages:
 
   '@esbuild/linux-s390x@0.25.5':
     resolution: {integrity: sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1728,6 +1839,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
@@ -1736,6 +1853,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.25.5':
     resolution: {integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1764,6 +1887,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
@@ -1772,6 +1901,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.25.5':
     resolution: {integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1800,8 +1935,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1830,6 +1977,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.17.6':
     resolution: {integrity: sha512-G95n7vP1UnGJPsVdKXllAJPtqjMvFYbN20e8RK8LVLhlTiSOH1sd7+Gt7rm70xiG+I5tM58nYgwWrLs6I1jHqg==}
     engines: {node: '>=12'}
@@ -1850,6 +2003,12 @@ packages:
 
   '@esbuild/win32-arm64@0.25.5':
     resolution: {integrity: sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1878,6 +2037,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.17.6':
     resolution: {integrity: sha512-n6d8MOyUrNp6G4VSpRcgjs5xj4A91svJSaiwLIDWVWEsZtpN5FA9NlBbZHDmAJc2e8e6SF4tkBD3HAvPF+7igA==}
     engines: {node: '>=12'}
@@ -1898,6 +2063,12 @@ packages:
 
   '@esbuild/win32-x64@0.25.5':
     resolution: {integrity: sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -6979,6 +7150,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -11761,6 +11937,11 @@ packages:
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
 
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
@@ -13838,6 +14019,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
   '@esbuild/android-arm64@0.17.6':
     optional: true
 
@@ -13848,6 +14032,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.25.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
     optional: true
 
   '@esbuild/android-arm@0.17.6':
@@ -13862,6 +14049,9 @@ snapshots:
   '@esbuild/android-arm@0.25.5':
     optional: true
 
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
   '@esbuild/android-x64@0.17.6':
     optional: true
 
@@ -13872,6 +14062,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.25.5':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.17.6':
@@ -13886,6 +14079,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
   '@esbuild/darwin-x64@0.17.6':
     optional: true
 
@@ -13896,6 +14092,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.25.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.17.6':
@@ -13910,6 +14109,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
   '@esbuild/freebsd-x64@0.17.6':
     optional: true
 
@@ -13920,6 +14122,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.25.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
   '@esbuild/linux-arm64@0.17.6':
@@ -13934,6 +14139,9 @@ snapshots:
   '@esbuild/linux-arm64@0.25.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
   '@esbuild/linux-arm@0.17.6':
     optional: true
 
@@ -13944,6 +14152,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.25.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
     optional: true
 
   '@esbuild/linux-ia32@0.17.6':
@@ -13958,6 +14169,9 @@ snapshots:
   '@esbuild/linux-ia32@0.25.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
   '@esbuild/linux-loong64@0.17.6':
     optional: true
 
@@ -13968,6 +14182,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.25.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.17.6':
@@ -13982,6 +14199,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
   '@esbuild/linux-ppc64@0.17.6':
     optional: true
 
@@ -13992,6 +14212,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.25.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.17.6':
@@ -14006,6 +14229,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
   '@esbuild/linux-s390x@0.17.6':
     optional: true
 
@@ -14016,6 +14242,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.25.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
   '@esbuild/linux-x64@0.17.6':
@@ -14030,10 +14259,16 @@ snapshots:
   '@esbuild/linux-x64@0.25.5':
     optional: true
 
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.5':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/netbsd-x64@0.17.6':
@@ -14048,10 +14283,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.5':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.5':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.17.6':
@@ -14066,7 +14307,13 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
   '@esbuild/sunos-x64@0.17.6':
@@ -14081,6 +14328,9 @@ snapshots:
   '@esbuild/sunos-x64@0.25.5':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
   '@esbuild/win32-arm64@0.17.6':
     optional: true
 
@@ -14091,6 +14341,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.25.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
     optional: true
 
   '@esbuild/win32-ia32@0.17.6':
@@ -14105,6 +14358,9 @@ snapshots:
   '@esbuild/win32-ia32@0.25.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
   '@esbuild/win32-x64@0.17.6':
     optional: true
 
@@ -14115,6 +14371,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.25.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1(jiti@2.4.2))':
@@ -14613,11 +14872,11 @@ snapshots:
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))':
     dependencies:
       glob: 13.0.5
       react-docgen-typescript: 2.4.0(typescript@5.7.3)
-      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
     optionalDependencies:
       typescript: 5.7.3
 
@@ -15696,7 +15955,7 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/jest@22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/jest@22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.2))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@jest/reporters': 30.2.0
       '@jest/test-result': 30.2.0
@@ -15704,7 +15963,7 @@ snapshots:
       '@nx/js': 22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.9.3)
       identity-obj-proxy: 3.0.0
-      jest-config: 30.2.0(@types/node@20.19.24)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.9.3))
+      jest-config: 30.2.0(@types/node@20.19.24)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.2))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.9.3))
       jest-resolve: 30.2.0
       jest-util: 30.0.5
       minimatch: 9.0.3
@@ -15870,13 +16129,13 @@ snapshots:
       - vue-tsc
       - webpack-cli
 
-  '@nx/nest@22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(chokidar@4.0.3)(esbuild-register@3.6.0(esbuild@0.25.12))(eslint@9.39.1(jiti@2.6.1))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/nest@22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(chokidar@4.0.3)(esbuild-register@3.6.0(esbuild@0.28.2))(eslint@9.39.1(jiti@2.6.1))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@nestjs/schematics': 11.0.9(chokidar@4.0.3)(typescript@5.9.3)
       '@nx/devkit': 22.0.2(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nx/eslint': 22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.1(jiti@2.6.1))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
       '@nx/js': 22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/node': 22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(eslint@9.39.1(jiti@2.6.1))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/node': 22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.2))(eslint@9.39.1(jiti@2.6.1))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -15922,12 +16181,12 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/node@22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(eslint@9.39.1(jiti@2.6.1))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/node@22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.2))(eslint@9.39.1(jiti@2.6.1))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@nx/devkit': 22.0.2(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nx/docker': 22.0.2(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nx/eslint': 22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.1(jiti@2.6.1))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/jest': 22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/jest': 22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.2))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
       '@nx/js': 22.0.2(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
       kill-port: 1.6.1
       tcp-port-used: 1.0.2
@@ -16060,7 +16319,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/react@22.5.1(@babel/core@7.28.5)(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.17.6)(eslint@9.39.1(jiti@2.4.2))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(vitest@4.0.9)':
+  '@nx/react@22.5.1(@babel/core@7.28.5)(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.17.6)(eslint@9.39.1(jiti@2.4.2))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(vitest@4.0.9)':
     dependencies:
       '@nx/devkit': 22.5.1(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nx/eslint': 22.5.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.1(jiti@2.4.2))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
@@ -16077,7 +16336,7 @@ snapshots:
       semver: 7.7.3
       tslib: 2.8.1
     optionalDependencies:
-      '@nx/vite': 22.5.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(vitest@4.0.9)
+      '@nx/vite': 22.5.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(vitest@4.0.9)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -16104,14 +16363,14 @@ snapshots:
       - vue-tsc
       - webpack-cli
 
-  '@nx/remix@22.5.1(dd3b36413fc769134e58109a065ac586)':
+  '@nx/remix@22.5.1(64158b3eb00707d132732480e42a244d)':
     dependencies:
       '@nx/devkit': 22.5.1(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nx/js': 22.5.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/react': 22.5.1(@babel/core@7.28.5)(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.17.6)(eslint@9.39.1(jiti@2.4.2))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(vitest@4.0.9)
+      '@nx/react': 22.5.1(@babel/core@7.28.5)(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.17.6)(eslint@9.39.1(jiti@2.4.2))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(vitest@4.0.9)
       '@nx/workspace': 22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.7.3)
-      '@remix-run/dev': 2.17.3(@remix-run/react@2.17.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(@remix-run/serve@2.17.3(typescript@5.7.3))(@types/node@20.19.24)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.7.3))(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)
+      '@remix-run/dev': 2.17.3(@remix-run/react@2.17.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(@remix-run/serve@2.17.3(typescript@5.7.3))(@types/node@20.19.24)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.7.3))(tsx@4.23.12)(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(yaml@2.8.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -16193,11 +16452,11 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@22.5.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(vitest@4.0.9)':
+  '@nx/vite@22.5.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(vitest@4.0.9)':
     dependencies:
       '@nx/devkit': 22.5.1(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nx/js': 22.5.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/vitest': 22.5.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(vitest@4.0.9)
+      '@nx/vitest': 22.5.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(vitest@4.0.9)
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.7.3)
       ajv: 8.17.1
       enquirer: 2.3.6
@@ -16205,8 +16464,8 @@ snapshots:
       semver: 7.7.3
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
-      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
-      vitest: 4.0.9(@types/debug@4.1.12)(@types/node@20.19.24)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
+      vitest: 4.0.9(@types/debug@4.1.12)(@types/node@20.19.24)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -16217,7 +16476,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vitest@22.5.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(vitest@4.0.9)':
+  '@nx/vitest@22.5.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.7.3)(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(vitest@4.0.9)':
     dependencies:
       '@nx/devkit': 22.5.1(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nx/js': 22.5.1(@babel/traverse@7.28.5)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.7.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.2.1(encoding@0.1.13)(typanion@3.14.0))
@@ -16225,8 +16484,8 @@ snapshots:
       semver: 7.7.3
       tslib: 2.8.1
     optionalDependencies:
-      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
-      vitest: 4.0.9(@types/debug@4.1.12)(@types/node@20.19.24)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
+      vitest: 4.0.9(@types/debug@4.1.12)(@types/node@20.19.24)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -17017,7 +17276,7 @@ snapshots:
 
   '@remix-run/css-bundle@2.17.3': {}
 
-  '@remix-run/dev@2.17.3(@remix-run/react@2.17.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(@remix-run/serve@2.17.3(typescript@5.7.3))(@types/node@20.19.24)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.7.3))(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)':
+  '@remix-run/dev@2.17.3(@remix-run/react@2.17.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(@remix-run/serve@2.17.3(typescript@5.7.3))(@types/node@20.19.24)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.7.3))(tsx@4.23.12)(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(yaml@2.8.1)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/generator': 7.28.5
@@ -17074,12 +17333,12 @@ snapshots:
       tar-fs: 2.1.4
       tsconfig-paths: 4.2.0
       valibot: 1.2.0(typescript@5.7.3)
-      vite-node: 3.2.4(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
       ws: 7.5.10
     optionalDependencies:
       '@remix-run/serve': 2.17.3(typescript@5.7.3)
       typescript: 5.7.3
-      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -17492,7 +17751,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-vitest@9.1.16(@vitest/browser@3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(vitest@4.0.9))(@vitest/runner@4.0.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vitest@4.0.9)':
+  '@storybook/addon-vitest@9.1.16(@vitest/browser@3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(vitest@4.0.9))(@vitest/runner@4.0.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vitest@4.0.9)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -17500,32 +17759,32 @@ snapshots:
       storybook: 10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       ts-dedent: 2.2.0
     optionalDependencies:
-      '@vitest/browser': 3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(vitest@4.0.9)
+      '@vitest/browser': 3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(vitest@4.0.9)
       '@vitest/runner': 4.0.9
-      vitest: 4.0.9(@types/debug@4.1.12)(@types/node@20.19.24)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vitest: 4.0.9(@types/debug@4.1.12)(@types/node@20.19.24)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.2.9(esbuild@0.17.6)(rollup@4.52.5)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.6))':
+  '@storybook/builder-vite@10.2.9(esbuild@0.17.6)(rollup@4.52.5)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.6))':
     dependencies:
-      '@storybook/csf-plugin': 10.2.9(esbuild@0.17.6)(rollup@4.52.5)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.6))
+      '@storybook/csf-plugin': 10.2.9(esbuild@0.17.6)(rollup@4.52.5)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.6))
       storybook: 10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       ts-dedent: 2.2.0
-      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.2.9(esbuild@0.17.6)(rollup@4.52.5)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.6))':
+  '@storybook/csf-plugin@10.2.9(esbuild@0.17.6)(rollup@4.52.5)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.6))':
     dependencies:
       storybook: 10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.17.6
       rollup: 4.52.5
-      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
       webpack: 5.102.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.6)
 
   '@storybook/csf-plugin@9.1.16(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
@@ -17557,11 +17816,11 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       storybook: 10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
-  '@storybook/react-vite@10.2.9(esbuild@0.17.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.52.5)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.6))':
+  '@storybook/react-vite@10.2.9(esbuild@0.17.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.52.5)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.6))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))
       '@rollup/pluginutils': 5.3.0(rollup@4.52.5)
-      '@storybook/builder-vite': 10.2.9(esbuild@0.17.6)(rollup@4.52.5)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.6))
+      '@storybook/builder-vite': 10.2.9(esbuild@0.17.6)(rollup@4.52.5)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.6))
       '@storybook/react': 10.2.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -17571,7 +17830,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.2.9(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tsconfig-paths: 4.2.0
-      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -17877,12 +18136,12 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.16
 
-  '@tailwindcss/vite@4.1.16(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))':
+  '@tailwindcss/vite@4.1.16(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))':
     dependencies:
       '@tailwindcss/node': 4.1.16
       '@tailwindcss/oxide': 4.1.16
       tailwindcss: 4.1.16
-      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
 
   '@testing-library/dom@10.4.0':
     dependencies:
@@ -18723,7 +18982,7 @@ snapshots:
       lodash: 4.17.21
       minimatch: 7.4.6
 
-  '@vitejs/plugin-react@4.7.0(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))':
+  '@vitejs/plugin-react@4.7.0(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -18731,20 +18990,20 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(vitest@4.0.9)':
+  '@vitest/browser@3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(vitest@4.0.9)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.2.4(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.21
       sirv: 3.0.2
       tinyrainbow: 2.0.0
-      vitest: 4.0.9(@types/debug@4.1.12)(@types/node@20.19.24)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vitest: 4.0.9(@types/debug@4.1.12)(@types/node@20.19.24)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
       ws: 8.18.3
     optionalDependencies:
       playwright: 1.56.1
@@ -18754,7 +19013,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.0.9(@vitest/browser@3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(vitest@4.0.9))(vitest@4.0.9)':
+  '@vitest/coverage-v8@4.0.9(@vitest/browser@3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(vitest@4.0.9))(vitest@4.0.9)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.9
@@ -18767,9 +19026,9 @@ snapshots:
       magicast: 0.5.2
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.9(@types/debug@4.1.12)(@types/node@20.19.24)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vitest: 4.0.9(@types/debug@4.1.12)(@types/node@20.19.24)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))(vitest@4.0.9)
+      '@vitest/browser': 3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))(vitest@4.0.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -18790,21 +19049,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@3.2.4(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
 
-  '@vitest/mocker@4.0.9(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.9(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.0.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -18840,7 +19099,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.9(@types/debug@4.1.12)(@types/node@20.19.24)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vitest: 4.0.9(@types/debug@4.1.12)(@types/node@20.19.24)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -20707,10 +20966,10 @@ snapshots:
       - supports-color
     optional: true
 
-  esbuild-register@3.6.0(esbuild@0.25.12):
+  esbuild-register@3.6.0(esbuild@0.28.2):
     dependencies:
       debug: 4.4.3
-      esbuild: 0.25.12
+      esbuild: 0.28.2
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -20822,6 +21081,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.5
       '@esbuild/win32-ia32': 0.25.5
       '@esbuild/win32-x64': 0.25.5
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   escalade@3.2.0: {}
 
@@ -22583,7 +22871,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.2.0(@types/node@20.19.24)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.9.3)):
+  jest-config@30.2.0(@types/node@20.19.24)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.2))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.5
       '@jest/get-type': 30.1.0
@@ -22611,7 +22899,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.24
-      esbuild-register: 3.6.0(esbuild@0.25.12)
+      esbuild-register: 3.6.0(esbuild@0.28.2)
       ts-node: 10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.19.24)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -26953,6 +27241,12 @@ snapshots:
       tslib: 1.14.1
       typescript: 5.7.3
 
+  tsx@4.23.12:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -27387,13 +27681,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.2.4(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -27408,7 +27702,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@4.5.4(@types/node@20.19.24)(rollup@4.52.5)(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)):
+  vite-plugin-dts@4.5.4(@types/node@20.19.24)(rollup@4.52.5)(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)):
     dependencies:
       '@microsoft/api-extractor': 7.54.0(@types/node@20.19.24)
       '@rollup/pluginutils': 5.3.0(rollup@4.52.5)
@@ -27421,19 +27715,19 @@ snapshots:
       magic-string: 0.30.21
       typescript: 5.7.3
     optionalDependencies:
-      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-tsconfig-paths@5.1.4(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)):
+  vite-tsconfig-paths@5.1.4(typescript@5.7.3)(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.7.3)
     optionalDependencies:
-      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -27452,7 +27746,7 @@ snapshots:
       sass-embedded: 1.93.3
       terser: 5.44.0
 
-  vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1):
+  vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -27469,12 +27763,13 @@ snapshots:
       sass: 1.93.3
       sass-embedded: 1.93.3
       terser: 5.44.0
+      tsx: 4.23.12
       yaml: 2.8.1
 
-  vitest@4.0.9(@types/debug@4.1.12)(@types/node@20.19.24)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1):
+  vitest@4.0.9(@types/debug@4.1.12)(@types/node@20.19.24)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.9
-      '@vitest/mocker': 4.0.9(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.9(vite@7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1))
       '@vitest/pretty-format': 4.0.9
       '@vitest/runner': 4.0.9
       '@vitest/snapshot': 4.0.9
@@ -27491,7 +27786,7 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.24)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.2)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - doctor
   - generators
   - upgrades
 


### PR DESCRIPTION
Phase 2's last item. ~7,400 lines of enforcement were copied verbatim into every repo; this makes them a dependency.

## Why it matters

A copy can be edited, and **an edited check reports clean while enforcing less**. That's why `convergence-status` had to hash enforcement files against the template to find drift at all — and it found some: cashcast, mi-core and muzebook are all running edited checks today.

As a package, the version a repo runs is a line in its lockfile.

## Five bins

| bin | replaces |
| --- | --- |
| `nestled-doctor` | `tsx scripts/doctor.ts` |
| `nestled-verify-selects` | `node tools/verify-selects.mjs` |
| `nestled-verify-select-coverage` | `node tools/verify-select-coverage.mjs` |
| `nestled-verify-fragments` | `tsx tools/verify-fragment-coverage.ts` |
| `nestled-verify-prisma-client` | `tsx scripts/verify-prisma-client.ts` |

All read the repo they run in from `process.cwd()`. Nothing about a repo is compiled in — which is what the enforcement-portability check in dev-template#162 exists to keep true.

## Three problems the move surfaced

None of which planning predicted, and all of which would have bitten mid-rollout:

**1. A broken import wearing five hats.** `verify-fragment-coverage.ts` imported `'../scripts/doctor-sdk-contract-analysis'` — correct when it lived in `tools/`, wrong now they're siblings. Because the import failed, `PrismaSelect` resolved to `unknown` and produced four *further* type errors. Fixing the path fixed all five.

**2. These files had never been typechecked.** `DatabaseFieldMetadata` declared `{ name, type }` while the code read `field.kind` — and the generated `database-models.ts` really does emit `kind`. Correct at runtime, invisible to the compiler, because `tsx` transpiles without typechecking. **Packaging is what typechecked them for the first time.**

**3. The fragments verifier dynamically imported the consumer's `database-models.ts`** — TypeScript *source*. Fine under `tsx`; impossible in a plain node process, which is what a packaged bin is. It now registers tsx's loader before reading it, and `tsx` is a dependency for exactly that reason.

Also replaced the one ESM-only construct (`import.meta.url` as a main guard) with an exported `runCli`, so the package stays CommonJS like `generators`. Keeping it would have forced NodeNext ESM and explicit `.js` extensions on every relative import — a large diff for one line's benefit.

## Verification

Against `nestled-dev-template`:

- **`nestled-doctor` output is byte-identical** to the in-repo copy's
- all five bins run: selects pass, fragments reports its usual "0 constants" notice, prisma-client verifies 10 enums, select-coverage exits 0

## What stays in the repo

The declarations, not the rules — exception files, baselines, and `doctor.config.json`. A repo declares **where to look** and **what it has been let off**; it doesn't get to change **what the rules are**. That's the point.

## Not in this PR

Switching `nestled-dev-template` to consume the package, and deleting the copies from eleven repos. The mirror can't propagate deletions, so that belongs in each repo's single convergence pass — with a version bump, since promotion excludes `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)