### PR TITLE
fix(doctor): declare tslib — 0.1.0 cannot run outside this workspace

### DIFF
--- a/doctor/package.json
+++ b/doctor/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@nestledjs/doctor",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
-  "description": "Nestled's enforcement checks — the doctor and its verifiers, shipped as a package so every repo runs provably identical rules",
+  "description": "Nestled's enforcement checks \u2014 the doctor and its verifiers, shipped as a package so every repo runs provably identical rules",
   "keywords": [
     "nestled",
     "doctor",
@@ -31,8 +31,9 @@
   },
   "dependencies": {
     "graphql": "^16.9.0",
-    "typescript": "^5.9.0",
-    "tsx": "^4.19.0"
+    "tslib": "^2.3.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.9.0"
   },
   "peerDependencies": {
     "@prisma/internals": ">=6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,6 +366,9 @@ importers:
       graphql:
         specifier: ^16.9.0
         version: 16.12.0
+      tslib:
+        specifier: ^2.3.0
+        version: 2.8.1
       tsx:
         specifier: ^4.19.0
         version: 4.23.12


### PR DESCRIPTION
**0.1.0 is broken.** The first real install of the published package failed on the first line:

```
Error: Cannot find module 'tslib'
Require stack:
- node_modules/@nestledjs/doctor/src/doctor-auth-analysis.js
```

`@nx/js:tsc` emits tslib helper imports — **nine** of the compiled files require it — and the dependency was never declared. `generators/package.json` lists it; doctor's didn't.

## The verification was the real defect

Every check I ran before publishing was from `dist/` **inside the workspace**, where the root `node_modules` resolves `tslib` for free. Byte-identical doctor output and five working bins proved the *code* was right and said nothing about whether the *package* could stand on its own. The one property that matters for a published artifact — does it work somewhere else — was the one I never tested.

Verified properly this time:

```
npm pack                                  → nestledjs-doctor-0.1.1.tgz
npm install <tarball>  (empty directory)  → all five bins present
<clean install>/bin/nestled-doctor        → runs mi-core to completion
```

And it produces the right downstream behaviour, not just a clean exit — mi-core's posture notice comes through with its reason intact:

> `[admin-crud-boundary] Generated CRUD is running at posture "authenticated", not admin-only — Emergency rollback 2026-08-13 (PR #1627) … denied 2,915 distinct users in one day …`

which is exactly what packaging was meant to preserve.

## Version

Bumped to **0.1.1**. 0.1.0 should be treated as unusable — it cannot run anywhere except this workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)