### PR TITLE
fix(doctor): recognise the whole @Ctx* decorator family as caller scoping

### DIFF
--- a/doctor/package.json
+++ b/doctor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestledjs/doctor",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/doctor/src/doctor-access-policy-analysis.spec.ts
+++ b/doctor/src/doctor-access-policy-analysis.spec.ts
@@ -141,6 +141,44 @@ describe('getUndeclaredAccessOperations', () => {
 
   // @CtxUser() is a PARAMETER decorator, so detection has to read the whole method — a scan of the
   // method's own decorators, or of its body alone, misses it.
+  // The template ships CtxUser, CtxOrganization AND CtxOrganizationId; repos add their own
+  // (muzebook has CtxOrganizationIdCached). An enumerated list would have to grow per repo, so the
+  // detector matches the @Ctx* shape. Getting this wrong produced 382 findings against muzebook
+  // claiming its scoped resolvers were unscoped.
+  it.each([
+    ['@CtxOrganization()', '@CtxOrganization() org: OrganizationContext'],
+    ['@CtxOrganizationId()', '@CtxOrganizationId() organizationId: string'],
+    ['a repo-local variant', '@CtxOrganizationIdCached() organizationId: string'],
+  ])('treats %s as caller scoping', (_label, parameter) => {
+    const undeclared = getUndeclaredAccessOperations(`
+      @Resolver()
+      class AlbumResolver {
+        @Query(() => [Album])
+        async userAlbums(${parameter}): Promise<Album[]> {
+          return this.data.album.findMany({ where: { organizationId } })
+        }
+      }
+    `)
+
+    expect(undeclared[0].callerScoped).toBe(true)
+  })
+
+  // NestJS's own @Context() injects the whole GraphQL context and is not caller scoping. "Ctx" is a
+  // literal prefix, so it must not match.
+  it('does not treat @Context() as caller scoping', () => {
+    const undeclared = getUndeclaredAccessOperations(`
+      @Resolver()
+      class ThingResolver {
+        @Query(() => String)
+        async thing(@Context() ctx: NestContextType, @Args('id') id: string): Promise<string> {
+          return this.data.thing.findFirst({ where: { id } })
+        }
+      }
+    `)
+
+    expect(undeclared[0].callerScoped).toBe(false)
+  })
+
   it('treats a @CtxUser() parameter as caller scoping', () => {
     const undeclared = getUndeclaredAccessOperations(`
       @Resolver()

--- a/doctor/src/doctor-access-policy-analysis.ts
+++ b/doctor/src/doctor-access-policy-analysis.ts
@@ -182,8 +182,20 @@ export const readStringObjectArray = (
  * it takes the caller, or reaches for the caller's identity when querying. Mirrors the anchor the
  * resolver-scope review uses.
  */
+// Any @Ctx* parameter decorator: the template ships CtxUser, CtxOrganization AND
+// CtxOrganizationId, and repos add their own (muzebook has CtxOrganizationIdCached). Matching the
+// SHAPE rather than an enumerated list is both correct and the only version that stays
+// repo-agnostic — an allowlist of names would have to grow every time a repo adds one, which is
+// repo-specific knowledge in a tool eleven repos share.
+//
+// The earlier pattern required `@CtxOrganization()` exactly, so `@CtxOrganizationId()` — the
+// template's own decorator, and the better one, since it hands a resolver only the id instead of a
+// context object carrying `permissions` — failed to match. muzebook uses it 195 times and had 382
+// findings claiming its scoped resolvers were unscoped.
+//
+// `@Ctx` is a literal prefix, so NestJS's own `@Context()` does not match.
 const CALLER_SCOPE_ANCHOR =
-  /@CtxUser\s*\(\)|@CtxOrganization\s*\(\)|\buser\.(?:id|organizationId|currentOrganizationId)\b|currentUser|organizationScoped/i
+  /@Ctx[A-Za-z]*\s*\(|\buser\.(?:id|organizationId|currentOrganizationId)\b|currentUser|organizationScoped/i
 
 export type UndeclaredAccessOperation = {
   className: string

--- a/doctor/src/doctor-access-policy-analysis.ts
+++ b/doctor/src/doctor-access-policy-analysis.ts
@@ -194,8 +194,11 @@ export const readStringObjectArray = (
 // findings claiming its scoped resolvers were unscoped.
 //
 // `@Ctx` is a literal prefix, so NestJS's own `@Context()` does not match.
+//
+// `[a-z]` rather than `[A-Za-z]`: the /i flag already makes them equivalent, and spelling both
+// ranges is a duplicated character class (S5869). The decorators are PascalCase and still match.
 const CALLER_SCOPE_ANCHOR =
-  /@Ctx[A-Za-z]*\s*\(|\buser\.(?:id|organizationId|currentOrganizationId)\b|currentUser|organizationScoped/i
+  /@Ctx[a-z]*\s*\(|\buser\.(?:id|organizationId|currentOrganizationId)\b|currentUser|organizationScoped/i
 
 export type UndeclaredAccessOperation = {
   className: string

--- a/doctor/src/doctor.ts
+++ b/doctor/src/doctor.ts
@@ -1535,10 +1535,11 @@ const checkUpgradeNoteImpactGate = () => {
   }
 }
 
+// Same @Ctx* family as CALLER_SCOPE_ANCHOR in doctor-access-policy-analysis — see the note there.
+// This copy was narrower still: it matched only @CtxUser(), so every organization-scoped resolver
+// read as unanchored.
 const hasContextScopeAnchor = (source: string): boolean =>
-  /@CtxUser\s*\(\)|\buser\.(?:id|organizationId|currentOrganizationId)\b|currentUser|organizationScoped/i.test(
-    source,
-  )
+  /@Ctx[A-Za-z]*\s*\(|\buser\.(?:id|organizationId|currentOrganizationId)\b|currentUser|organizationScoped/i.test(source)
 
 const usesInputIdInPrismaWhere = (source: string): boolean =>
   /\b(?:userId|organizationId|teamId|roleId|memberId|inviteId|subscriptionId|tokenId)\b/.test(

--- a/doctor/src/doctor.ts
+++ b/doctor/src/doctor.ts
@@ -1539,7 +1539,7 @@ const checkUpgradeNoteImpactGate = () => {
 // This copy was narrower still: it matched only @CtxUser(), so every organization-scoped resolver
 // read as unanchored.
 const hasContextScopeAnchor = (source: string): boolean =>
-  /@Ctx[A-Za-z]*\s*\(|\buser\.(?:id|organizationId|currentOrganizationId)\b|currentUser|organizationScoped/i.test(source)
+  /@Ctx[a-z]*\s*\(|\buser\.(?:id|organizationId|currentOrganizationId)\b|currentUser|organizationScoped/i.test(source)
 
 const usesInputIdInPrismaWhere = (source: string): boolean =>
   /\b(?:userId|organizationId|teamId|roleId|memberId|inviteId|subscriptionId|tokenId)\b/.test(


### PR DESCRIPTION
Found by muzebook during its convergence, and it was **my bug, not its drift**.

## What was wrong

The caller-scope detector matched `@CtxOrganization()` but not `@CtxOrganizationId()` — the `Id` broke the literal match. **The template ships both**, so a repo using `CtxOrganizationId` is following the template rather than diverging from it.

muzebook uses it **195 times** (against 17 for `@CtxOrganization()`) and got **382 findings** claiming its scoped resolvers were unscoped. `AlbumResolver.userAlbums` takes `@CtxOrganizationId()` and filters every query by it, and was reported as *"neither declares a permission nor scopes to the caller."*

`doctor.ts`'s copy was narrower still — only `@CtxUser()` — so every organization-scoped resolver also read as unanchored to the resolver-scope check.

## The obvious fix was the wrong one

The tempting answer was to tell muzebook to standardise on `@CtxOrganization()`. That would have made its code **worse**:

| | returns |
| --- | --- |
| `CtxOrganizationId` | just the organization id |
| `CtxOrganization` | the whole context — id, userId, roleId, roleName, **permissions** |

Both read the same already-resolved `req.organizationContext`, so there's no cost difference — only a least-privilege one. Handing a resolver the full context invites exactly the ad-hoc in-body authorization the access-policy check exists to discourage. **muzebook's convention is the better default**, and 195 renames to satisfy a regex would have been the wrong trade twice over.

## The fix

Both detectors now match the `@Ctx*` **shape**. That's deliberate, not lazy: the template ships three of these decorators and repos add their own (muzebook has `CtxOrganizationIdCached`), so an enumerated list would put repo-specific knowledge in a tool eleven repos share — the thing dev-template#162 exists to prevent.

`@Ctx` is a literal prefix, so NestJS's own `@Context()` still correctly does **not** match. There's a spec for that, plus specs for each decorator variant.

## Verification

| | |
| --- | --- |
| muzebook | **244 findings → 70** |
| survivors | real: 16 on class-level admin-gated resolvers, 47 elsewhere |
| nestled-dev-template | passes |
| cashcast | passes |
| tests | 165 across 10 files |

Version **0.1.2**.

## Follow-up worth deciding separately

16 of muzebook's survivors are operations on classes with `@UseGuards(GqlAuthAdminGuard)` + `@AdminOnly()` — superadmin-only, therefore authorized, but by a coarse gate rather than a permission. The check currently recognises two mechanisms (declared permission, caller scoping) and not that third one, so it reports them as unauthorized.

Whether that should become a recognised mechanism, a review-level notice, or stay a failure is a policy call about how hard to push toward per-operation RBAC — not something to settle inside this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)