### PR TITLE
fix(doctor): a verifier that checked nothing must not report success

### DIFF
--- a/doctor/bin/nestled-verify-fragments.js
+++ b/doctor/bin/nestled-verify-fragments.js
@@ -1,3 +1,8 @@
 #!/usr/bin/env node
+// runCli sets process.exitCode itself, but it is async: awaiting it is what guarantees the code is
+// set before the process settles.
 const { runCli } = require('../src/verify-fragment-coverage.js')
-void runCli()
+Promise.resolve(runCli()).catch((error) => {
+  console.error(error)
+  process.exitCode = 2
+})

--- a/doctor/bin/nestled-verify-selects.js
+++ b/doctor/bin/nestled-verify-selects.js
@@ -1,3 +1,13 @@
 #!/usr/bin/env node
 // .mjs stays ESM regardless of the package type, so reach it with a dynamic import.
-import('../src/verify-selects.mjs').then(({ runCli }) => runCli())
+// The exit code must be carried back deliberately: `.then(({ runCli }) => runCli())` discarded it,
+// so this bin reported success for every run, including ones that found real problems.
+import('../src/verify-selects.mjs')
+  .then(({ runCli }) => runCli())
+  .then((code) => {
+    process.exitCode = code
+  })
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 2
+  })

--- a/doctor/src/verify-fragment-coverage.ts
+++ b/doctor/src/verify-fragment-coverage.ts
@@ -67,6 +67,7 @@ import {
   type GraphqlSource,
   type PrismaSelect,
 } from './doctor-sdk-contract-analysis'
+import { reportNothingChecked } from './verify-selects.mjs'
 
 /**
  * Load DATABASE_MODELS from the consuming repo's TypeScript source.
@@ -925,7 +926,14 @@ const main = async (): Promise<void> => {
       console.log('\nNo fragment field is unproduced by its model’s selects.')
     }
   }
-  process.exitCode = failures > 0 ? 1 : 0
+  if (failures > 0) {
+    process.exitCode = 1
+    return
+  }
+  // It already says "This is NOT fragment-coverage proof" and then exited 0, which is the same
+  // contradiction in words rather than in code. A repo that declares it has no selects passes; one
+  // that does not has either lost its selects to a rename or never declared the fact.
+  process.exitCode = checkedModels === 0 && checkedPaths === 0 ? reportNothingChecked('verify-fragments') : 0
 }
 
 // Exported rather than self-invoked: the package's bin calls this, so the parser stays importable

--- a/doctor/src/verify-fragment-coverage.ts
+++ b/doctor/src/verify-fragment-coverage.ts
@@ -67,7 +67,6 @@ import {
   type GraphqlSource,
   type PrismaSelect,
 } from './doctor-sdk-contract-analysis'
-import { reportNothingChecked } from './verify-selects.mjs'
 
 /**
  * Load DATABASE_MODELS from the consuming repo's TypeScript source.
@@ -933,7 +932,14 @@ const main = async (): Promise<void> => {
   // It already says "This is NOT fragment-coverage proof" and then exited 0, which is the same
   // contradiction in words rather than in code. A repo that declares it has no selects passes; one
   // that does not has either lost its selects to a rename or never declared the fact.
-  process.exitCode = checkedModels === 0 && checkedPaths === 0 ? reportNothingChecked('verify-fragments') : 0
+  if (checkedModels > 0 || checkedPaths > 0) {
+    process.exitCode = 0
+    return
+  }
+  // Imported here, not at the top: this module is consumed as CommonJS, and a static import of an
+  // .mjs compiles to require(), which throws ERR_REQUIRE_ASYNC_MODULE before main() ever runs.
+  const { reportNothingChecked } = await import('./verify-selects.mjs')
+  process.exitCode = reportNothingChecked('verify-fragments')
 }
 
 // Exported rather than self-invoked: the package's bin calls this, so the parser stays importable

--- a/doctor/src/verify-select-coverage.mjs
+++ b/doctor/src/verify-select-coverage.mjs
@@ -49,33 +49,22 @@
  */
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { join, relative, resolve } from 'node:path'
+import { reportNothingChecked } from './verify-selects.mjs'
 
-const SCHEMA_DIRECTORY_CANDIDATES = [
-  'libs/api/prisma/src/lib/schemas',
-  'prisma',
-  'libs/api/prisma/src/lib',
-]
+let nothingChecked = false
+
+const SCHEMA_DIRECTORY_CANDIDATES = ['libs/api/prisma/src/lib/schemas', 'prisma', 'libs/api/prisma/src/lib']
 const DEFAULT_SEARCH_ROOTS = ['libs/api/custom/src', 'libs/api/core', 'apps/api/src']
 const SDL_PATH = 'api-schema.graphql'
 
-const PRISMA_SCALARS = new Set([
-  'String',
-  'Int',
-  'Float',
-  'Boolean',
-  'DateTime',
-  'Json',
-  'Decimal',
-  'BigInt',
-  'Bytes',
-])
+const PRISMA_SCALARS = new Set(['String', 'Int', 'Float', 'Boolean', 'DateTime', 'Json', 'Decimal', 'BigInt', 'Bytes'])
 
 const cwd = process.cwd()
 const argv = process.argv.slice(2)
 const asJson = argv.includes('--json')
 const warnNullable = argv.includes('--warn-nullable')
 const strictNested = argv.includes('--strict-nested')
-const roots = argv.filter(argument => !argument.startsWith('--'))
+const roots = argv.filter((argument) => !argument.startsWith('--'))
 const searchRoots = roots.length > 0 ? roots : DEFAULT_SEARCH_ROOTS
 
 // ── GraphQL SDL ──────────────────────────────────────────────────────────────
@@ -98,24 +87,21 @@ for (const match of sdl.matchAll(/^type (\w+) \{\n([\s\S]*?)^\}/gm)) {
 }
 
 // ── Prisma datamodel ─────────────────────────────────────────────────────────
-const schemaDirectory = SCHEMA_DIRECTORY_CANDIDATES.map(candidate => resolve(cwd, candidate)).find(
-  candidate =>
-    existsSync(candidate) && readdirSync(candidate).some(file => file.endsWith('.prisma')),
+const schemaDirectory = SCHEMA_DIRECTORY_CANDIDATES.map((candidate) => resolve(cwd, candidate)).find(
+  (candidate) => existsSync(candidate) && readdirSync(candidate).some((file) => file.endsWith('.prisma')),
 )
 if (!schemaDirectory) {
-  console.error(
-    `verify-select-coverage: no .prisma schema under ${SCHEMA_DIRECTORY_CANDIDATES.join(', ')}`,
-  )
+  console.error(`verify-select-coverage: no .prisma schema under ${SCHEMA_DIRECTORY_CANDIDATES.join(', ')}`)
   process.exit(2)
 }
 const datamodel = readdirSync(schemaDirectory)
-  .filter(file => file.endsWith('.prisma'))
+  .filter((file) => file.endsWith('.prisma'))
   .sort((left, right) => left.localeCompare(right))
-  .map(file => readFileSync(join(schemaDirectory, file), 'utf8'))
+  .map((file) => readFileSync(join(schemaDirectory, file), 'utf8'))
   .join('\n')
 
-const enumNames = new Set([...datamodel.matchAll(/^enum (\w+) \{/gm)].map(match => match[1]))
-const modelNames = new Set([...datamodel.matchAll(/^model (\w+) \{/gm)].map(match => match[1]))
+const enumNames = new Set([...datamodel.matchAll(/^enum (\w+) \{/gm)].map((match) => match[1]))
+const modelNames = new Set([...datamodel.matchAll(/^model (\w+) \{/gm)].map((match) => match[1]))
 
 /** model -> set of selectable scalar columns (relations excluded: they need their own select) */
 const prismaScalars = {}
@@ -141,7 +127,7 @@ for (const match of datamodel.matchAll(/^model (\w+) \{\n([\s\S]*?)^\}/gm)) {
 
 // ── select constants ─────────────────────────────────────────────────────────
 const selectFiles = []
-const walk = directory => {
+const walk = (directory) => {
   for (const entry of readdirSync(directory, { withFileTypes: true })) {
     const path = join(directory, entry.name)
     if (entry.isDirectory()) walk(path)
@@ -191,11 +177,9 @@ const declarationOf = (source, name) =>
  * a building block reached through a spread, not a select the API returns, and checking it directly
  * would report the base's deliberate partiality as a defect.
  */
-const exportedConstantNames = source => [
+const exportedConstantNames = (source) => [
   ...new Set(
-    [...source.matchAll(/\bexport\s+(?:const|let|var)\s+(\w+)\s*(?::[^=]+)?=\s*\{/g)].map(
-      match => match[1],
-    ),
+    [...source.matchAll(/\bexport\s+(?:const|let|var)\s+(\w+)\s*(?::[^=]+)?=\s*\{/g)].map((match) => match[1]),
   ),
 ]
 
@@ -220,19 +204,19 @@ const annotationFor = (source, name, tag) => {
   return found
     ? found[1]
         .split(',')
-        .map(value => value.trim())
+        .map((value) => value.trim())
         .filter(Boolean)
     : []
 }
 
-const pascalCase = value =>
+const pascalCase = (value) =>
   value
     .split(/[-_]/)
     .filter(Boolean)
-    .map(word => word[0].toUpperCase() + word.slice(1).toLowerCase())
+    .map((word) => word[0].toUpperCase() + word.slice(1).toLowerCase())
     .join('')
 
-const constantModelCandidates = name => {
+const constantModelCandidates = (name) => {
   const words = name
     .replace(/_?SELECT.*$/, '')
     .split('_')
@@ -280,7 +264,7 @@ const resolveSelect = (source, body, seen = new Set()) => {
       if (inlineOmit) {
         for (const field of inlineOmit[1]
           .split(',')
-          .map(value => value.trim())
+          .map((value) => value.trim())
           .filter(Boolean)) {
           omits.add(field)
         }
@@ -442,9 +426,7 @@ if (asJson) {
         console.log(`     ${entry.missing.length} non-nullable: ${entry.missing.join(', ')}\n`)
       }
     } else {
-      console.log(
-        `!  ${nestedProblems.length} nested select(s) omit ${fieldCount} non-nullable field(s).`,
-      )
+      console.log(`!  ${nestedProblems.length} nested select(s) omit ${fieldCount} non-nullable field(s).`)
       console.log("   Latent, not gated: widening a nested select can expose another user's row.")
       console.log('   The real fix is usually a purpose-built output type.')
       console.log('   Run with --strict-nested to list them.\n')
@@ -458,12 +440,13 @@ if (asJson) {
     }
   }
   if (selectFiles.length === 0) {
-    console.log('no reusable *.select.ts files discovered; nothing was checked\n')
+    nothingChecked = true
   } else if (problems.length === 0 && unresolved.length === 0) {
     console.log('every top-level select covers the non-nullable surface of its GraphQL type\n')
   }
 }
 
-const failed =
-  problems.length > 0 || unresolved.length > 0 || (strictNested && nestedProblems.length > 0)
-process.exit(failed ? 1 : 0)
+const failed = problems.length > 0 || unresolved.length > 0 || (strictNested && nestedProblems.length > 0)
+if (failed) process.exit(1)
+// Examining nothing is not the same as finding nothing wrong.
+process.exit(nothingChecked ? reportNothingChecked('verify-select-coverage') : 0)

--- a/doctor/src/verify-select-coverage.mjs
+++ b/doctor/src/verify-select-coverage.mjs
@@ -51,7 +51,6 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { join, relative, resolve } from 'node:path'
 import { reportNothingChecked } from './verify-selects.mjs'
 
-let nothingChecked = false
 
 const SCHEMA_DIRECTORY_CANDIDATES = ['libs/api/prisma/src/lib/schemas', 'prisma', 'libs/api/prisma/src/lib']
 const DEFAULT_SEARCH_ROOTS = ['libs/api/custom/src', 'libs/api/core', 'apps/api/src']
@@ -440,7 +439,7 @@ if (asJson) {
     }
   }
   if (selectFiles.length === 0) {
-    nothingChecked = true
+    // reported below, for both output modes
   } else if (problems.length === 0 && unresolved.length === 0) {
     console.log('every top-level select covers the non-nullable surface of its GraphQL type\n')
   }
@@ -448,5 +447,7 @@ if (asJson) {
 
 const failed = problems.length > 0 || unresolved.length > 0 || (strictNested && nestedProblems.length > 0)
 if (failed) process.exit(1)
-// Examining nothing is not the same as finding nothing wrong.
-process.exit(nothingChecked ? reportNothingChecked('verify-select-coverage') : 0)
+// Examining nothing is not the same as finding nothing wrong. Derived from the file count rather
+// than a flag set while rendering, so --json reaches the same verdict as the text output -- the
+// first cut set the flag inside the text-only branch, leaving --json to exit 0 on zero files.
+process.exit(selectFiles.length === 0 ? reportNothingChecked('verify-select-coverage') : 0)

--- a/doctor/src/verify-selects.mjs
+++ b/doctor/src/verify-selects.mjs
@@ -24,11 +24,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { basename, isAbsolute, join, relative, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
-export const SCHEMA_DIRECTORY_CANDIDATES = [
-  'libs/api/prisma/src/lib/schemas',
-  'prisma',
-  'libs/api/prisma/src/lib',
-]
+export const SCHEMA_DIRECTORY_CANDIDATES = ['libs/api/prisma/src/lib/schemas', 'prisma', 'libs/api/prisma/src/lib']
 
 export const DEFAULT_SEARCH_ROOTS = ['libs/api/custom/src', 'libs/api/core', 'apps/api/src']
 
@@ -67,14 +63,50 @@ export const readRepoConfig = (cwd = process.cwd()) => {
   if (
     !Array.isArray(declared) ||
     declared.length === 0 ||
-    declared.some(suffix => typeof suffix !== 'string' || !suffix)
+    declared.some((suffix) => typeof suffix !== 'string' || !suffix)
   ) {
-    throw new Error(
-      `${REPO_CONFIG_PATH}: selectFileSuffixes must be a non-empty array of non-empty strings`,
-    )
+    throw new Error(`${REPO_CONFIG_PATH}: selectFileSuffixes must be a non-empty array of non-empty strings`)
   }
 
-  return { selectFileSuffixes: declared }
+  // A repo may legitimately not use the select pattern at all -- 9 of the 11 repos in this fleet do
+  // not, both templates included. That is fine; what is not fine is a verifier reporting success
+  // for having examined nothing. Declaring it converts an invisible no-op into a recorded decision,
+  // and means a repo that DID have selects cannot lose them to a rename without the check noticing.
+  const absent = parsed?.noSelectFiles
+  if (absent !== undefined && (typeof absent !== 'string' || absent.trim() === '')) {
+    throw new Error(`${REPO_CONFIG_PATH}: noSelectFiles must be a non-empty string explaining why this repo has none`)
+  }
+
+  return { selectFileSuffixes: declared, noSelectFiles: absent }
+}
+
+/**
+ * What a verifier should do when it checked nothing.
+ *
+ * Exit 0 after examining zero files is the failure mode this whole enforcement effort keeps
+ * tripping over: the check stops looking and reports clean. A declaration makes the empty state
+ * deliberate and visible; its absence makes it a failure with a message naming both ways out.
+ */
+export const reportNothingChecked = (tool, cwd = process.cwd()) => {
+  let declared
+  try {
+    declared = readRepoConfig(cwd).noSelectFiles
+  } catch {
+    // A broken config is the config reader's error to report, not ours to swallow.
+    declared = undefined
+  }
+  if (declared) {
+    console.log(`\n${tool}: checked nothing, as declared in ${REPO_CONFIG_PATH} — ${declared}`)
+    return 0
+  }
+  console.error(
+    `\n${tool}: checked 0 files, so this run proves nothing.\n` +
+      `  If this repo uses the select pattern, the files moved or were renamed — set\n` +
+      `  selectFileSuffixes in ${REPO_CONFIG_PATH} to match.\n` +
+      `  If it genuinely has none, say so: "noSelectFiles": "<why>" in the same file.\n` +
+      `  Exiting non-zero because a check that examined nothing must not report success.`,
+  )
+  return 1
 }
 
 /**
@@ -104,50 +136,39 @@ const SKIPPED_STRUCTURAL_KEYS = new Set([
   '_max',
 ])
 
-const STRUCTURAL_KEYS = new Set([
-  'select',
-  'where',
-  'orderBy',
-  'take',
-  'skip',
-  'include',
-  'distinct',
-])
+const STRUCTURAL_KEYS = new Set(['select', 'where', 'orderBy', 'take', 'skip', 'include', 'distinct'])
 
 const alphabetical = (left, right) => left.localeCompare(right)
-const normalizePath = path => path.replaceAll('\\', '/')
+const normalizePath = (path) => path.replaceAll('\\', '/')
 
-const schemaDirectory = cwd =>
-  SCHEMA_DIRECTORY_CANDIDATES.map(candidate => resolve(cwd, candidate)).find(
-    candidate =>
-      existsSync(candidate) && readdirSync(candidate).some(file => file.endsWith('.prisma')),
+const schemaDirectory = (cwd) =>
+  SCHEMA_DIRECTORY_CANDIDATES.map((candidate) => resolve(cwd, candidate)).find(
+    (candidate) => existsSync(candidate) && readdirSync(candidate).some((file) => file.endsWith('.prisma')),
   )
 
-const readDatamodel = cwd => {
+const readDatamodel = (cwd) => {
   const directory = schemaDirectory(cwd)
   if (!directory) {
     throw new Error(`No .prisma schema found under: ${SCHEMA_DIRECTORY_CANDIDATES.join(', ')}`)
   }
 
   return readdirSync(directory)
-    .filter(file => file.endsWith('.prisma'))
+    .filter((file) => file.endsWith('.prisma'))
     .sort(alphabetical)
-    .map(file => readFileSync(join(directory, file), 'utf8'))
+    .map((file) => readFileSync(join(directory, file), 'utf8'))
     .join('\n')
 }
 
-const modelsFromDmmf = dmmf =>
+const modelsFromDmmf = (dmmf) =>
   Object.fromEntries(
-    dmmf.datamodel.models.map(model => [
+    dmmf.datamodel.models.map((model) => [
       model.name,
-      Object.fromEntries(
-        model.fields.map(field => [field.name, field.kind === 'object' ? field.type : null]),
-      ),
+      Object.fromEntries(model.fields.map((field) => [field.name, field.kind === 'object' ? field.type : null])),
     ]),
   )
 
 /** `name Type[]?` -> [name, relationTarget|null]. Null for scalars, comments and block attributes. */
-const parseFieldLine = line => {
+const parseFieldLine = (line) => {
   const trimmed = line.trim()
   if (!trimmed || trimmed.startsWith('//') || trimmed.startsWith('@@')) return null
 
@@ -162,7 +183,7 @@ const parseFieldLine = line => {
  * A capitalised type is only a relation if the model it names was actually parsed. Enums and
  * unresolvable types look identical to relations at this level, so they are demoted to scalars.
  */
-const pruneUnresolvedRelations = models => {
+const pruneUnresolvedRelations = (models) => {
   for (const fields of Object.values(models)) {
     for (const [field, relationTarget] of Object.entries(fields)) {
       if (relationTarget && !models[relationTarget]) fields[field] = null
@@ -171,7 +192,7 @@ const pruneUnresolvedRelations = models => {
   return models
 }
 
-export const parseDatamodelFallback = datamodel => {
+export const parseDatamodelFallback = (datamodel) => {
   const models = {}
   let modelName
   let fields
@@ -202,10 +223,7 @@ export const parseDatamodelFallback = datamodel => {
 
 const defaultInternalsLoader = () => import('@prisma/internals')
 
-export const loadModels = async ({
-  cwd = process.cwd(),
-  internalsLoader = defaultInternalsLoader,
-} = {}) => {
+export const loadModels = async ({ cwd = process.cwd(), internalsLoader = defaultInternalsLoader } = {}) => {
   const datamodel = readDatamodel(cwd)
   try {
     const internals = await internalsLoader()
@@ -229,7 +247,7 @@ export const findSelectFiles = ({
   selectFileSuffixes = readRepoConfig(cwd).selectFileSuffixes,
 } = {}) => {
   const files = []
-  const walk = directory => {
+  const walk = (directory) => {
     if (!existsSync(directory)) return
     for (const entry of readdirSync(directory)) {
       if (entry === 'node_modules') continue
@@ -237,7 +255,7 @@ export const findSelectFiles = ({
       const stat = statSync(path)
       if (stat.isDirectory()) walk(path)
       else {
-        const suffix = selectFileSuffixes.find(candidate => entry.endsWith(candidate))
+        const suffix = selectFileSuffixes.find((candidate) => entry.endsWith(candidate))
         if (suffix) {
           files.push({
             absolutePath: path,
@@ -286,9 +304,9 @@ const copyQuotedValue = (source, start) => {
   return index
 }
 
-const maskRange = source => source.replace(/[^\n]/g, ' ')
+const maskRange = (source) => source.replace(/[^\n]/g, ' ')
 
-const sanitizeSource = source => {
+const sanitizeSource = (source) => {
   let result = ''
   let index = 0
   while (index < source.length) {
@@ -366,9 +384,7 @@ const checkProperty = (source, index, context, problems) => {
     return close === -1 ? source.length : close + 1
   }
   if (FIELD_BEARING_KEYS.has(field) || STRUCTURAL_KEYS.has(field)) {
-    return source[valueStart] === '{'
-      ? checkBlock(source, valueStart + 1, context, problems)
-      : valueStart
+    return source[valueStart] === '{' ? checkBlock(source, valueStart + 1, context, problems) : valueStart
   }
   if (!context.models[context.model]) return valueStart
 
@@ -406,14 +422,14 @@ function checkBlock(source, start, context, problems) {
   return index
 }
 
-const pascalCase = value =>
+const pascalCase = (value) =>
   value
     .split(/[-_]/)
     .filter(Boolean)
-    .map(word => word[0].toUpperCase() + word.slice(1).toLowerCase())
+    .map((word) => word[0].toUpperCase() + word.slice(1).toLowerCase())
     .join('')
 
-const constantModelCandidates = constantName => {
+const constantModelCandidates = (constantName) => {
   const words = constantName
     .replace(/_?SELECT.*$/, '')
     .split('_')
@@ -433,12 +449,10 @@ const relationTargetForConstant = (models, constantName) => {
     .toLowerCase()
     .split('_')
     .filter(Boolean)
-  const relationName = words
-    .map((word, index) => (index === 0 ? word : word[0].toUpperCase() + word.slice(1)))
-    .join('')
+  const relationName = words.map((word, index) => (index === 0 ? word : word[0].toUpperCase() + word.slice(1))).join('')
   const targets = new Set(
     Object.values(models)
-      .map(fields => fields[relationName])
+      .map((fields) => fields[relationName])
       .filter(Boolean),
   )
   return targets.size === 1 ? [...targets][0] : null
@@ -506,12 +520,7 @@ const verifyFile = ({ absolutePath, file, conventionalNamesOnly = false }, model
       continue
     }
 
-    checkBlock(
-      source,
-      match.index + match[0].length,
-      { models, file, model, path: [match[1]] },
-      problems,
-    )
+    checkBlock(source, match.index + match[0].length, { models, file, model, path: [match[1]] }, problems)
   }
 
   return { problems, unresolved }
@@ -541,7 +550,7 @@ const usage = `Usage:
 
 Validates every *.select.ts constant under the configured roots against the Prisma schema.`
 
-const renderText = result => {
+const renderText = (result) => {
   const lines = [`verify-selects — ${result.files} file(s), schema via ${result.source}`, '']
   for (const problem of result.problems) {
     const reason =
@@ -551,10 +560,7 @@ const renderText = result => {
     lines.push(`  ${problem.file}`, `      ${problem.path}  — ${reason}`)
   }
   for (const unresolved of result.unresolved) {
-    lines.push(
-      `  ${unresolved.file}`,
-      `      ${unresolved.const}  — cannot resolve model; add /** @prisma-model X */`,
-    )
+    lines.push(`  ${unresolved.file}`, `      ${unresolved.const}  — cannot resolve model; add /** @prisma-model X */`)
   }
   lines.push(
     result.problems.length || result.unresolved.length
@@ -564,16 +570,16 @@ const renderText = result => {
   return lines.join('\n')
 }
 
-const parseArguments = arguments_ => {
+const parseArguments = (arguments_) => {
   const asJson = arguments_.includes('--json')
   const unknownOptions = arguments_.filter(
-    argument => argument.startsWith('--') && argument !== '--json' && argument !== '--',
+    (argument) => argument.startsWith('--') && argument !== '--json' && argument !== '--',
   )
   if (unknownOptions.length > 0) throw new Error(`Unknown option(s): ${unknownOptions.join(', ')}`)
-  return { asJson, roots: arguments_.filter(argument => !argument.startsWith('--')) }
+  return { asJson, roots: arguments_.filter((argument) => !argument.startsWith('--')) }
 }
 
-const errorMessage = error => {
+const errorMessage = (error) => {
   if (error instanceof Error) return error.message
   if (typeof error === 'string') return error
   return JSON.stringify(error) ?? 'Unknown verify-selects failure'
@@ -594,7 +600,8 @@ export const runCli = async (arguments_ = process.argv.slice(2), cwd = process.c
       roots: parsed.roots.length > 0 ? parsed.roots : DEFAULT_SEARCH_ROOTS,
     })
     console.log(asJson ? JSON.stringify(result, null, 2) : renderText(result))
-    return result.problems.length || result.unresolved.length ? 1 : 0
+    if (result.problems.length || result.unresolved.length) return 1
+    return result.files === 0 ? reportNothingChecked('verify-selects', cwd) : 0
   } catch (error) {
     const message = errorMessage(error)
     if (asJson) console.log(JSON.stringify({ error: message }, null, 2))

--- a/doctor/src/verify-selects.mjs
+++ b/doctor/src/verify-selects.mjs
@@ -91,12 +91,17 @@ export const reportNothingChecked = (tool, cwd = process.cwd()) => {
   let declared
   try {
     declared = readRepoConfig(cwd).noSelectFiles
-  } catch {
-    // A broken config is the config reader's error to report, not ours to swallow.
-    declared = undefined
+  } catch (error) {
+    // A malformed config is its own failure with its own fix. Swallowing it here would print the
+    // generic "checked 0 files" advice, which tells the reader to edit the very file that cannot
+    // be parsed -- and dressing a config error as a verification failure hides which one it is.
+    console.error(`\n${tool}: ${error.message}`)
+    return 2
   }
   if (declared) {
-    console.log(`\n${tool}: checked nothing, as declared in ${REPO_CONFIG_PATH} — ${declared}`)
+    // stderr, so --json callers can parse stdout: a human-readable line on stdout would corrupt
+    // the machine-readable output for exactly the automated callers this exit code is for.
+    console.error(`\n${tool}: checked nothing, as declared in ${REPO_CONFIG_PATH} — ${declared}`)
     return 0
   }
   console.error(

--- a/doctor/src/verify-selects.spec.mjs
+++ b/doctor/src/verify-selects.spec.mjs
@@ -472,14 +472,15 @@ describe('reportNothingChecked', () => {
       }),
     })
     const logs = []
-    const original = console.log
-    console.log = message => logs.push(message)
+    const original = console.error
+    console.error = message => logs.push(message)
     try {
       expect(reportNothingChecked('verify-selects', repo)).toBe(0)
     } finally {
-      console.log = original
+      console.error = original
     }
-    // Declared is not the same as hidden: the reason stays visible on every run.
+    // stderr, so --json stdout stays parseable. Declared is not the same as hidden: the reason
+    // stays visible on every run.
     expect(logs.join('\n')).toContain('as declared')
     expect(logs.join('\n')).toContain('generated CRUD')
   })
@@ -495,5 +496,27 @@ describe('reportNothingChecked', () => {
         }),
       ),
     ).toThrow(/noSelectFiles must be a non-empty string/)
+  })
+})
+
+describe('reportNothingChecked config errors', () => {
+  it('reports a malformed config as its own failure, not as a verification result', () => {
+    const repo = mkdtempSync(join(tmpdir(), 'verify-selects-badcfg-'))
+    mkdirSync(join(repo, '.nestled-updates'), { recursive: true })
+    writeFileSync(join(repo, '.nestled-updates/doctor.config.json'), '{ not json')
+    const errors = []
+    const original = console.error
+    console.error = message => errors.push(message)
+    let code
+    try {
+      code = reportNothingChecked('verify-selects', repo)
+    } finally {
+      console.error = original
+    }
+    // 2, not 1: a config that cannot be parsed is a different problem with a different fix, and
+    // the generic advice would tell the reader to edit the file that is already unreadable.
+    expect(code).toBe(2)
+    expect(errors.join('\n')).toContain('not valid JSON')
+    expect(errors.join('\n')).not.toContain('checked 0 files')
   })
 })

--- a/doctor/src/verify-selects.spec.mjs
+++ b/doctor/src/verify-selects.spec.mjs
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it } from 'vitest'
 import { loadModels, verifySelects,
+  reportNothingChecked,
   readRepoConfig,
   findSelectFiles,
 } from './verify-selects.mjs'
@@ -433,5 +434,66 @@ describe('repo layout config', () => {
 
     expect(byName['a.select.ts'].conventionalNamesOnly).toBe(false)
     expect(byName['b.resolver.ts'].conventionalNamesOnly).toBe(true)
+  })
+})
+
+describe('reportNothingChecked', () => {
+  const withRepo = files => {
+    const repo = mkdtempSync(join(tmpdir(), 'verify-selects-nothing-'))
+    for (const [relativePath, contents] of Object.entries(files)) {
+      const full = join(repo, relativePath)
+      mkdirSync(dirname(full), { recursive: true })
+      writeFileSync(full, contents)
+    }
+    return repo
+  }
+
+  it('fails when a verifier checked nothing and the repo never said why', () => {
+    const repo = withRepo({})
+    const errors = []
+    const original = console.error
+    console.error = message => errors.push(message)
+    try {
+      expect(reportNothingChecked('verify-selects', repo)).toBe(1)
+    } finally {
+      console.error = original
+    }
+    // The message has to name both exits, or the reader's only obvious move is to ignore it.
+    expect(errors.join('\n')).toContain('checked 0 files')
+    expect(errors.join('\n')).toContain('selectFileSuffixes')
+    expect(errors.join('\n')).toContain('noSelectFiles')
+  })
+
+  it('passes when the repo declares it has no select files, and says so out loud', () => {
+    const repo = withRepo({
+      '.nestled-updates/doctor.config.json': JSON.stringify({
+        selectFileSuffixes: ['.select.ts'],
+        noSelectFiles: 'Returns GraphQL via generated CRUD; no narrowed named selects exist.',
+      }),
+    })
+    const logs = []
+    const original = console.log
+    console.log = message => logs.push(message)
+    try {
+      expect(reportNothingChecked('verify-selects', repo)).toBe(0)
+    } finally {
+      console.log = original
+    }
+    // Declared is not the same as hidden: the reason stays visible on every run.
+    expect(logs.join('\n')).toContain('as declared')
+    expect(logs.join('\n')).toContain('generated CRUD')
+  })
+
+  it('rejects a declaration that says nothing', () => {
+    expect(() =>
+      readRepoConfig(
+        withRepo({
+          '.nestled-updates/doctor.config.json': JSON.stringify({
+            selectFileSuffixes: ['.select.ts'],
+            noSelectFiles: '   ',
+          }),
+        }),
+      ),
+    ).toThrow(/noSelectFiles must be a non-empty string/)
   })
 })


### PR DESCRIPTION
Two defects. The second is worse than the one this branch set out to fix.

## 1. `nestled-verify-selects` discarded its own exit code

```js
import('../src/verify-selects.mjs').then(({ runCli }) => runCli())
```

`runCli` returns 1 when it finds problems. The bin threw that away, so the command **exited 0 on every run**. Proved against a fixture whose select names a column the schema does not have:

```
before:  "userSelect.notAColumn — not a column on User"   →  exit 0
after:   same message                                     →  exit 1
```

Any repo gating CI on `pnpm run verify:selects` through this package has been gating on nothing — not merely skipping the repos with no select files, but **failing to report real problems in the two repos that have them** (silvermouselive 10, mi-core 32). `nestled-verify-fragments` had a milder version of the same shape (unawaited `void runCli()`).

## 2. Checking zero files passed silently

```
.select.ts files per repo
  nestled-template 0 · nestled-dev-template 0 · cashcast 0 · muzebook 0
  qalatra.com 0 · biztobiz 0 · flightdesk 0 · travel-outlook 0 · moceanic-ai 0
  silvermouselive 10 · mi-core 32
```

Nine of eleven, both templates included. `verify:fragments` already printed *"This is NOT fragment-coverage proof"* and then exited 0 — the contradiction stated in words and then contradicted by the exit code.

Zero-checked is now a **declared** state:

```json
{ "noSelectFiles": "Returns GraphQL via generated CRUD; no narrowed named selects exist." }
```

Declared → passes, and prints the reason on every run rather than staying silent. Undeclared → fails, with a message naming both ways out. A rename can no longer disable the check without anyone noticing.

## Verification

From a clean packed install (not `dist/` in the workspace):

| case | exit |
|---|---|
| real problem, files present | 1 ✓ |
| zero files, no declaration | 1 ✓ |
| zero files, declared | 0, reason printed ✓ |

172 tests pass.

## Expected fallout

**Nine repos will start failing `verify:selects` until each adds that one line**, both templates included. That is the intended cost of the change: it converts an invisible no-op into a recorded decision. Happy to split it into warn-now/fail-later if the one-time noise is not wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMc46HinkqtzyyvRVpcaV8