### PR TITLE
fix(doctor): 0.2.2 — stop crossing the ESM/CommonJS boundary at all

### DIFF
--- a/doctor/package.json
+++ b/doctor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestledjs/doctor",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/doctor/project.json
+++ b/doctor/project.json
@@ -26,6 +26,11 @@
             "input": "./doctor/bin",
             "glob": "**/*.js",
             "output": "./bin"
+          },
+          {
+            "input": "./doctor/src",
+            "glob": "doctor-repo-config.js",
+            "output": "./src"
           }
         ]
       }

--- a/doctor/project.json
+++ b/doctor/project.json
@@ -29,6 +29,11 @@
           },
           {
             "input": "./doctor/src",
+            "glob": "**/*.d.ts",
+            "output": "./src"
+          },
+          {
+            "input": "./doctor/src",
             "glob": "doctor-repo-config.js",
             "output": "./src"
           }

--- a/doctor/src/doctor-repo-config.d.ts
+++ b/doctor/src/doctor-repo-config.d.ts
@@ -1,0 +1,8 @@
+export declare const REPO_CONFIG_PATH: string
+export declare const DEFAULT_SELECT_FILE_SUFFIXES: string[]
+export declare const readRepoConfig: (cwd?: string) => {
+  selectFileSuffixes: string[]
+  noSelectFiles?: string
+}
+/** Exit code for a verifier that examined nothing: 0 if declared, 1 if not, 2 on a broken config. */
+export declare const reportNothingChecked: (tool: string, cwd?: string) => number

--- a/doctor/src/doctor-repo-config.js
+++ b/doctor/src/doctor-repo-config.js
@@ -1,0 +1,108 @@
+const { existsSync, readFileSync } = require('node:fs')
+const { resolve } = require('node:path')
+
+/**
+ * Repo layout config and the shared "checked nothing" verdict.
+ *
+ * This lives in a CommonJS module rather than beside the ESM verifiers for one blunt reason: the
+ * fragment verifier is compiled to CommonJS, and TypeScript downlevels a dynamic `import()` of an
+ * .mjs into `require()`, which cannot load ESM. Both a static and a dynamic import across that
+ * boundary shipped broken -- 0.2.0 died with ERR_REQUIRE_ASYNC_MODULE, 0.2.1 with a top-level-await
+ * transform error. Keeping the shared code on the CommonJS side removes the boundary instead of
+ * negotiating with it.
+ */
+
+const REPO_CONFIG_PATH = '.nestled-updates/doctor.config.json'
+
+const DEFAULT_SELECT_FILE_SUFFIXES = ['.select.ts']
+
+/**
+ * The few things about a repo's LAYOUT that enforcement cannot assume.
+ *
+ * Deliberately tiny, and deliberately not a general escape hatch: this declares where to look, never
+ * what to accept. A repo that keeps select constants beside the resolver that owns them is laid out
+ * differently, not held to a weaker rule.
+ *
+ * It exists because the alternative is editing the checker in place — which muzebook had to do, and
+ * which stops being possible at all once these tools ship as a package.
+ */
+const readRepoConfig = (
+  cwd = process.cwd(),
+) => {
+  const configPath = resolve(cwd, REPO_CONFIG_PATH)
+  if (!existsSync(configPath)) return { selectFileSuffixes: DEFAULT_SELECT_FILE_SUFFIXES }
+
+  let parsed
+  try {
+    parsed = JSON.parse(readFileSync(configPath, 'utf8'))
+  } catch {
+    // Fail loudly rather than silently scanning nothing: a malformed config that quietly reverted
+    // to the default would make this checker pass by verifying an empty set.
+    throw new Error(`${REPO_CONFIG_PATH} is not valid JSON`)
+  }
+
+  // A config file that exists is a statement of intent to configure. Silently defaulting on a typoed
+  // key — or accepting an empty list — would scan zero files and pass, in exactly the repos that
+  // wrote this file BECAUSE the default finds nothing for them. Absent file: default. Present file:
+  // say what you mean.
+  const declared = parsed?.selectFileSuffixes
+  if (
+    !Array.isArray(declared) ||
+    declared.length === 0 ||
+    declared.some((suffix) => typeof suffix !== 'string' || !suffix)
+  ) {
+    throw new Error(`${REPO_CONFIG_PATH}: selectFileSuffixes must be a non-empty array of non-empty strings`)
+  }
+
+  // A repo may legitimately not use the select pattern at all -- 9 of the 11 repos in this fleet do
+  // not, both templates included. That is fine; what is not fine is a verifier reporting success
+  // for having examined nothing. Declaring it converts an invisible no-op into a recorded decision,
+  // and means a repo that DID have selects cannot lose them to a rename without the check noticing.
+  const absent = parsed?.noSelectFiles
+  if (absent !== undefined && (typeof absent !== 'string' || absent.trim() === '')) {
+    throw new Error(`${REPO_CONFIG_PATH}: noSelectFiles must be a non-empty string explaining why this repo has none`)
+  }
+
+  return { selectFileSuffixes: declared, noSelectFiles: absent }
+}
+
+/**
+ * What a verifier should do when it checked nothing.
+ *
+ * Exit 0 after examining zero files is the failure mode this whole enforcement effort keeps
+ * tripping over: the check stops looking and reports clean. A declaration makes the empty state
+ * deliberate and visible; its absence makes it a failure with a message naming both ways out.
+ */
+const reportNothingChecked = (tool, cwd = process.cwd()) => {
+  let declared
+  try {
+    declared = readRepoConfig(cwd).noSelectFiles
+  } catch (error) {
+    // A malformed config is its own failure with its own fix. Swallowing it here would print the
+    // generic "checked 0 files" advice, which tells the reader to edit the very file that cannot
+    // be parsed -- and dressing a config error as a verification failure hides which one it is.
+    console.error(`\n${tool}: ${error.message}`)
+    return 2
+  }
+  if (declared) {
+    // stderr, so --json callers can parse stdout: a human-readable line on stdout would corrupt
+    // the machine-readable output for exactly the automated callers this exit code is for.
+    console.error(`\n${tool}: checked nothing, as declared in ${REPO_CONFIG_PATH} — ${declared}`)
+    return 0
+  }
+  console.error(
+    `\n${tool}: checked 0 files, so this run proves nothing.\n` +
+      `  If this repo uses the select pattern, the files moved or were renamed — set\n` +
+      `  selectFileSuffixes in ${REPO_CONFIG_PATH} to match.\n` +
+      `  If it genuinely has none, say so: "noSelectFiles": "<why>" in the same file.\n` +
+      `  Exiting non-zero because a check that examined nothing must not report success.`,
+  )
+  return 1
+}
+
+module.exports = {
+  REPO_CONFIG_PATH,
+  DEFAULT_SELECT_FILE_SUFFIXES,
+  readRepoConfig,
+  reportNothingChecked,
+}

--- a/doctor/src/verify-fragment-coverage.ts
+++ b/doctor/src/verify-fragment-coverage.ts
@@ -67,6 +67,7 @@ import {
   type GraphqlSource,
   type PrismaSelect,
 } from './doctor-sdk-contract-analysis'
+import { reportNothingChecked } from './doctor-repo-config'
 
 /**
  * Load DATABASE_MODELS from the consuming repo's TypeScript source.
@@ -108,8 +109,7 @@ const SELECT_FILE_SUFFIXES = ['.select.ts', '.resolver.ts', '.service.ts']
 //
 // The annotation excludes newlines deliberately. `[^=]+` would span lines and reintroduce the
 // backtracking that S8786 flagged here; a one-line annotation is the realistic case.
-const SELECT_CONSTANT =
-  /^[ \t]*(?:export\s+)?(?:const|let|var)\s+([A-Z][A-Z0-9_]*)\s*(?::[^=\n]+)?=\s*\{/gm
+const SELECT_CONSTANT = /^[ \t]*(?:export\s+)?(?:const|let|var)\s+([A-Z][A-Z0-9_]*)\s*(?::[^=\n]+)?=\s*\{/gm
 
 const alphabetical = (left: string, right: string): number => left.localeCompare(right)
 
@@ -280,7 +280,7 @@ const NAMED_IMPORT_PATTERN = /import\s+(?:type\s+)?\{([^}]*)\}\s*from\s*['"](\.[
 const resolveImportFile = (fromDir: string, spec: string): string | undefined => {
   const base = resolve(fromDir, spec)
   const candidates = [base, `${base}.ts`, `${base}.tsx`, join(base, 'index.ts')]
-  return candidates.find(candidate => {
+  return candidates.find((candidate) => {
     try {
       return statSync(candidate).isFile()
     } catch {
@@ -312,10 +312,7 @@ const readFileText = (file: string): { raw: string; sanitized: string } => {
   return text
 }
 
-const importedConstantSelect = (
-  ident: string,
-  context: SourceContext,
-): PrismaSelect | undefined => {
+const importedConstantSelect = (ident: string, context: SourceContext): PrismaSelect | undefined => {
   if (context.imported) return undefined
   // Import specifiers live inside string literals, which sanitize() blanks — so imports are read
   // from the raw file, not from the sanitized source the select parser works on. But raw text
@@ -329,12 +326,12 @@ const importedConstantSelect = (
     if (!sanitized.startsWith('import', match.index)) continue
     const binding = match[1]
       .split(',')
-      .map(name => name.trim())
-      .map(name => {
-        const [original, alias] = name.split(/\bas\b/).map(part => part.trim())
+      .map((name) => name.trim())
+      .map((name) => {
+        const [original, alias] = name.split(/\bas\b/).map((part) => part.trim())
         return { original, local: alias ?? original }
       })
-      .find(candidate => candidate.local === ident)
+      .find((candidate) => candidate.local === ident)
     if (!binding?.original) continue
 
     const importedFile = resolveImportFile(dirname(context.file), match[2])
@@ -394,9 +391,7 @@ export const toSelect = (
       continue
     }
     if (entry.kind !== 'object') continue
-    const inner = scanObject(source, entry.open).entries.find(
-      candidate => candidate.name === 'select',
-    )
+    const inner = scanObject(source, entry.open).entries.find((candidate) => candidate.name === 'select')
     if (inner?.kind === 'object') {
       select[entry.name] = { select: toSelect(source, inner.open, seen, context) }
       continue
@@ -489,9 +484,9 @@ const modelForConstant = (
   annotated: string | undefined,
   models: readonly DatabaseModelMetadata[],
 ): string | undefined => {
-  if (annotated) return models.find(model => model.modelName === annotated)?.modelName
+  if (annotated) return models.find((model) => model.modelName === annotated)?.modelName
   const stem = name.replace(/_(FIELDS|SELECT)$/, '').replaceAll('_', '')
-  return models.find(model => model.modelName.toUpperCase() === stem)?.modelName
+  return models.find((model) => model.modelName.toUpperCase() === stem)?.modelName
 }
 
 /** The `@prisma-model X` annotation attached to a constant, if the comment directly precedes it. */
@@ -507,27 +502,19 @@ const annotationBefore = (raw: string, offset: number, previousEnd: number): str
  * value runs to end of line; a closing comment marker on the same line is stripped so the
  * annotation can sit last in a one-line or block comment.
  */
-export const annotationListBefore = (
-  raw: string,
-  offset: number,
-  previousEnd: number,
-  tag: string,
-): string[] => {
+export const annotationListBefore = (raw: string, offset: number, previousEnd: number, tag: string): string[] => {
   const window = raw.slice(Math.max(previousEnd, 0), offset)
   return [...window.matchAll(new RegExp(String.raw`@${tag}[ \t]+([^\n]+)`, 'g'))]
-    .flatMap(match => match[1].replace(/\*\/.*$/, '').split(','))
-    .map(entry => entry.trim())
+    .flatMap((match) => match[1].replace(/\*\/.*$/, '').split(','))
+    .map((entry) => entry.trim())
     .filter(Boolean)
 }
 
-export const readSelectConstants = (
-  repo: string,
-  models: readonly DatabaseModelMetadata[],
-): SelectConstant[] => {
+export const readSelectConstants = (repo: string, models: readonly DatabaseModelMetadata[]): SelectConstant[] => {
   const constants: SelectConstant[] = []
 
   for (const root of SEARCH_ROOTS) {
-    const files = walk(join(repo, root), path => SELECT_FILE_SUFFIXES.some(s => path.endsWith(s)))
+    const files = walk(join(repo, root), (path) => SELECT_FILE_SUFFIXES.some((s) => path.endsWith(s)))
     for (const absolute of files) {
       if (absolute.includes('.spec.')) continue
       const raw = readFileSync(absolute, 'utf8')
@@ -550,9 +537,7 @@ export const readSelectConstants = (
         // sanitized source and is the stable anchor.
         const declaration = match.index + match[0].indexOf('const')
         const annotated = annotationBefore(raw, declaration, previousEnd)
-        const fragmentPartial = /@fragment-partial\b/.test(
-          raw.slice(Math.max(previousEnd, 0), declaration),
-        )
+        const fragmentPartial = /@fragment-partial\b/.test(raw.slice(Math.max(previousEnd, 0), declaration))
         const omits = annotationListBefore(raw, declaration, previousEnd, 'select-omits')
         const operations = annotationListBefore(raw, declaration, previousEnd, 'graphql-operations')
         previousEnd = matchingBrace(source, open)
@@ -574,7 +559,7 @@ export const readSelectConstants = (
       // before B has resolved its own spreads gives A only B's literal fields, and every field
       // reaching A through C would be reported MISSING even though it is selected. Recursing per
       // constant makes the result independent of declaration order.
-      for (const constant of constants.filter(entry => entry.file === file)) {
+      for (const constant of constants.filter((entry) => entry.file === file)) {
         constant.select = resolveSpreads(constant.name, inFile)
       }
     }
@@ -596,7 +581,7 @@ export const resolveFieldsByModel = (repo: string): Map<string, Set<string>> => 
   const served = new Map<string, Set<string>>()
 
   for (const root of SEARCH_ROOTS) {
-    for (const absolute of walk(join(repo, root), path => path.endsWith('.resolver.ts'))) {
+    for (const absolute of walk(join(repo, root), (path) => path.endsWith('.resolver.ts'))) {
       if (absolute.includes('.spec.')) continue
       const source = sanitize(readFileSync(absolute, 'utf8'))
 
@@ -605,14 +590,11 @@ export const resolveFieldsByModel = (repo: string): Map<string, Set<string>> => 
       for (let index = 0; index < classes.length; index++) {
         const modelName = classes[index][1]
         const start = classes[index].index ?? 0
-        const end =
-          index + 1 < classes.length ? (classes[index + 1].index ?? source.length) : source.length
+        const end = index + 1 < classes.length ? classes[index + 1].index ?? source.length : source.length
         const body = source.slice(start, end)
 
         const fields = served.get(modelName) ?? new Set<string>()
-        for (const match of body.matchAll(
-          /@ResolveField\(([\s\S]*?)\)[^\S\n]*\n\s*(?:async\s+)?(\w+)\s*\(/g,
-        )) {
+        for (const match of body.matchAll(/@ResolveField\(([\s\S]*?)\)[^\S\n]*\n\s*(?:async\s+)?(\w+)\s*\(/g)) {
           // `@ResolveField(() => X, { name: 'graphqlName' })` overrides the method name.
           const renamed = /name:\s*['"`]?(\w+)/.exec(match[1])
           fields.add(renamed ? renamed[1] : match[2])
@@ -630,9 +612,7 @@ export const relationTarget = (
   modelName: string,
   fieldName: string,
 ): string | undefined => {
-  const field = models
-    .find(model => model.modelName === modelName)
-    ?.fields?.find(entry => entry.name === fieldName)
+  const field = models.find((model) => model.modelName === modelName)?.fields?.find((entry) => entry.name === fieldName)
   return field?.kind === 'object' ? field.type : undefined
 }
 
@@ -697,7 +677,7 @@ export const flatten = (select: PrismaSelect, prefix = ''): string[] => {
 }
 
 const graphqlSources = (root: string): GraphqlSource[] =>
-  walk(root, path => path.endsWith('.graphql')).map(file => ({
+  walk(root, (path) => path.endsWith('.graphql')).map((file) => ({
     file,
     source: readFileSync(file, 'utf8'),
   }))
@@ -709,7 +689,7 @@ const main = async (): Promise<void> => {
     return
   }
   const verbose = args.includes('--verbose')
-  const repo = resolve(args.find(argument => !argument.startsWith('--')) ?? process.cwd())
+  const repo = resolve(args.find((argument) => !argument.startsWith('--')) ?? process.cwd())
 
   // database-models.ts is TypeScript SOURCE in the consuming repo, so it cannot be imported by a
   // plain node process — which is what this becomes once these checks ship as a package rather than
@@ -723,7 +703,7 @@ const main = async (): Promise<void> => {
   const schema = buildSchema(readFileSync(join(repo, 'api-schema.graphql'), 'utf8'))
 
   const constants = readSelectConstants(repo, DATABASE_MODELS)
-  const operationScoped = constants.filter(constant => constant.operations.length > 0)
+  const operationScoped = constants.filter((constant) => constant.operations.length > 0)
   const byModel = new Map<string, SelectConstant[]>()
   for (const constant of constants) {
     // An operation-scoped select answers for ITS documents, not for the model's whole
@@ -736,8 +716,8 @@ const main = async (): Promise<void> => {
   }
 
   const fragmentModels = new Set(
-    allSources.flatMap(source =>
-      [...source.source.matchAll(/^fragment\s+\w+\s+on\s+(\w+)/gm)].map(match => match[1]),
+    allSources.flatMap((source) =>
+      [...source.source.matchAll(/^fragment\s+\w+\s+on\s+(\w+)/gm)].map((match) => match[1]),
     ),
   )
 
@@ -752,10 +732,10 @@ const main = async (): Promise<void> => {
   let resolvedElsewhere = 0
 
   for (const modelName of [...fragmentModels].sort(alphabetical)) {
-    if (!DATABASE_MODELS.some(model => model.modelName === modelName)) continue
+    if (!DATABASE_MODELS.some((model) => model.modelName === modelName)) continue
     const selects = byModel.get(modelName)
     if (!selects || selects.length === 0) {
-      if (!operationScoped.some(constant => constant.model === modelName)) skipped.push(modelName)
+      if (!operationScoped.some((constant) => constant.model === modelName)) skipped.push(modelName)
       continue
     }
 
@@ -773,37 +753,28 @@ const main = async (): Promise<void> => {
     }
 
     checkedModels++
-    const { skipped: viaResolveField, wanted } = requiredPaths(
-      required,
-      modelName,
-      served,
-      DATABASE_MODELS,
-    )
+    const { skipped: viaResolveField, wanted } = requiredPaths(required, modelName, served, DATABASE_MODELS)
     resolvedElsewhere += viaResolveField.length
-    const provided = selects.map(select => new Set(flatten(select.select)))
+    const provided = selects.map((select) => new Set(flatten(select.select)))
 
     for (const path of wanted) {
-      const holders = provided.filter(set => set.has(path)).length
+      const holders = provided.filter((set) => set.has(path)).length
       if (holders === 0) {
-        missing.push(
-          `${modelName}.${path} — produced by none of ${selects.map(s => s.name).join(', ')}`,
-        )
+        missing.push(`${modelName}.${path} — produced by none of ${selects.map((s) => s.name).join(', ')}`)
       } else if (holders < selects.length) {
         const without = selects.filter((_, index) => !provided[index].has(path))
         const escalated = selects.filter(
           (select, index) =>
-            !provided[index].has(path) &&
-            !select.omits.includes(path) &&
-            parentProduced(provided[index], path),
+            !provided[index].has(path) && !select.omits.includes(path) && parentProduced(provided[index], path),
         )
         if (nonNullableAt(schema, modelName, path) && escalated.length > 0) {
           nonNullPartial.push(
-            `${modelName}.${path} — non-nullable, absent from ${escalated.map(s => s.name).join(', ')}: ` +
+            `${modelName}.${path} — non-nullable, absent from ${escalated.map((s) => s.name).join(', ')}: ` +
               `any document those selects serve that requests it fails the WHOLE query. ` +
               `Add the field, or acknowledge a deliberate deny with @select-omits ${path}.`,
           )
         } else {
-          partial.push(`${modelName}.${path} — absent from ${without.map(s => s.name).join(', ')}`)
+          partial.push(`${modelName}.${path} — absent from ${without.map((s) => s.name).join(', ')}`)
         }
       }
     }
@@ -869,16 +840,12 @@ const main = async (): Promise<void> => {
   )
 
   if (missing.length > 0) {
-    console.log(
-      `\nMISSING (${missing.length}) — a fragment asks for these and nothing produces them:`,
-    )
+    console.log(`\nMISSING (${missing.length}) — a fragment asks for these and nothing produces them:`)
     for (const entry of [...missing].sort(alphabetical)) console.log(`  ${entry}`)
   }
 
   if (nonNullPartial.length > 0) {
-    console.log(
-      `\nNON-NULLABLE PARTIAL (${nonNullPartial.length}) — these error the whole query, not a field:`,
-    )
+    console.log(`\nNON-NULLABLE PARTIAL (${nonNullPartial.length}) — these error the whole query, not a field:`)
     for (const entry of [...nonNullPartial].sort(alphabetical)) console.log(`  ${entry}`)
   }
 
@@ -890,20 +857,18 @@ const main = async (): Promise<void> => {
   }
 
   if (verbose && partial.length > 0) {
-    console.log(
-      `\nPARTIAL (${partial.length}) — advisory; thinner list selects are usually correct:`,
-    )
+    console.log(`\nPARTIAL (${partial.length}) — advisory; thinner list selects are usually correct:`)
     for (const entry of [...partial].sort(alphabetical)) console.log(`  ${entry}`)
   } else if (partial.length > 0) {
-    console.log(
-      `\nPARTIAL: ${partial.length} field(s) present in some selects but not others (--verbose to list).`,
-    )
+    console.log(`\nPARTIAL: ${partial.length} field(s) present in some selects but not others (--verbose to list).`)
   }
 
   if (skipped.length > 0) {
     console.log(
       `\nNOT CHECKED (${skipped.length}): no named select constant maps to these models — ` +
-        `generated CRUD or inline selects. ${verbose ? [...skipped].sort(alphabetical).join(', ') : '--verbose to list'}`,
+        `generated CRUD or inline selects. ${
+          verbose ? [...skipped].sort(alphabetical).join(', ') : '--verbose to list'
+        }`,
     )
   }
 
@@ -936,9 +901,6 @@ const main = async (): Promise<void> => {
     process.exitCode = 0
     return
   }
-  // Imported here, not at the top: this module is consumed as CommonJS, and a static import of an
-  // .mjs compiles to require(), which throws ERR_REQUIRE_ASYNC_MODULE before main() ever runs.
-  const { reportNothingChecked } = await import('./verify-selects.mjs')
   process.exitCode = reportNothingChecked('verify-fragments')
 }
 

--- a/doctor/src/verify-fragment-coverage.ts
+++ b/doctor/src/verify-fragment-coverage.ts
@@ -510,6 +510,68 @@ export const annotationListBefore = (raw: string, offset: number, previousEnd: n
     .filter(Boolean)
 }
 
+/**
+ * Every select constant declared in one file, with same-file spreads already resolved.
+ *
+ * Split out of readSelectConstants so the walk stays readable: the per-file work is a parser with
+ * its own offset rules, and nesting it three deep inside the root/file loops made the whole thing
+ * one 25-branch function.
+ */
+const readConstantsFromFile = (
+  repo: string,
+  absolute: string,
+  models: readonly DatabaseModelMetadata[],
+): SelectConstant[] => {
+  const raw = readFileSync(absolute, 'utf8')
+  const source = sanitize(raw)
+  const file = relative(repo, absolute)
+  const fileConstants: SelectConstant[] = []
+
+  const inFile = new Map<string, { select: PrismaSelect; spreads: string[] }>()
+  let previousEnd = 0
+  SELECT_CONSTANT.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = SELECT_CONSTANT.exec(source)) !== null) {
+    const open = source.indexOf('{', match.index + match[0].length - 1)
+    if (open === -1) continue
+    const select = toSelect(source, open, new Set(), { file: absolute })
+    const { spreads } = scanObject(source, open)
+    if (Object.keys(select).length === 0 && spreads.length === 0) continue
+    // The regex runs against sanitized source. A preceding JSDoc is whitespace there, so its
+    // leading `\s*` can move match.index to the top of the comment and put the annotation
+    // behind its own lookup window. The `const` keyword has the same offset in raw and
+    // sanitized source and is the stable anchor.
+    const declaration = match.index + match[0].indexOf('const')
+    const annotated = annotationBefore(raw, declaration, previousEnd)
+    const fragmentPartial = /@fragment-partial\b/.test(raw.slice(Math.max(previousEnd, 0), declaration))
+    const omits = annotationListBefore(raw, declaration, previousEnd, 'select-omits')
+    const operations = annotationListBefore(raw, declaration, previousEnd, 'graphql-operations')
+    previousEnd = matchingBrace(source, open)
+    inFile.set(match[1], { select, spreads })
+    if (fragmentPartial) continue
+    fileConstants.push({
+      file,
+      model: modelForConstant(match[1], annotated, models),
+      name: match[1],
+      omits,
+      operations,
+      select,
+    })
+  }
+
+  // Resolve `...SPREAD` against constants declared in the same file, following chains.
+  //
+  // A single pass would be order-dependent: if A spreads B and B spreads C, then resolving A
+  // before B has resolved its own spreads gives A only B's literal fields, and every field
+  // reaching A through C would be reported MISSING even though it is selected. Recursing per
+  // constant makes the result independent of declaration order.
+  for (const constant of fileConstants) {
+    constant.select = resolveSpreads(constant.name, inFile)
+  }
+
+  return fileConstants
+}
+
 export const readSelectConstants = (repo: string, models: readonly DatabaseModelMetadata[]): SelectConstant[] => {
   const constants: SelectConstant[] = []
 
@@ -517,51 +579,7 @@ export const readSelectConstants = (repo: string, models: readonly DatabaseModel
     const files = walk(join(repo, root), (path) => SELECT_FILE_SUFFIXES.some((s) => path.endsWith(s)))
     for (const absolute of files) {
       if (absolute.includes('.spec.')) continue
-      const raw = readFileSync(absolute, 'utf8')
-      const source = sanitize(raw)
-      const file = relative(repo, absolute)
-
-      const inFile = new Map<string, { select: PrismaSelect; spreads: string[] }>()
-      let previousEnd = 0
-      SELECT_CONSTANT.lastIndex = 0
-      let match: RegExpExecArray | null
-      while ((match = SELECT_CONSTANT.exec(source)) !== null) {
-        const open = source.indexOf('{', match.index + match[0].length - 1)
-        if (open === -1) continue
-        const select = toSelect(source, open, new Set(), { file: absolute })
-        const { spreads } = scanObject(source, open)
-        if (Object.keys(select).length === 0 && spreads.length === 0) continue
-        // The regex runs against sanitized source. A preceding JSDoc is whitespace there, so its
-        // leading `\s*` can move match.index to the top of the comment and put the annotation
-        // behind its own lookup window. The `const` keyword has the same offset in raw and
-        // sanitized source and is the stable anchor.
-        const declaration = match.index + match[0].indexOf('const')
-        const annotated = annotationBefore(raw, declaration, previousEnd)
-        const fragmentPartial = /@fragment-partial\b/.test(raw.slice(Math.max(previousEnd, 0), declaration))
-        const omits = annotationListBefore(raw, declaration, previousEnd, 'select-omits')
-        const operations = annotationListBefore(raw, declaration, previousEnd, 'graphql-operations')
-        previousEnd = matchingBrace(source, open)
-        inFile.set(match[1], { select, spreads })
-        if (fragmentPartial) continue
-        constants.push({
-          file,
-          model: modelForConstant(match[1], annotated, models),
-          name: match[1],
-          omits,
-          operations,
-          select,
-        })
-      }
-
-      // Resolve `...SPREAD` against constants declared in the same file, following chains.
-      //
-      // A single pass would be order-dependent: if A spreads B and B spreads C, then resolving A
-      // before B has resolved its own spreads gives A only B's literal fields, and every field
-      // reaching A through C would be reported MISSING even though it is selected. Recursing per
-      // constant makes the result independent of declaration order.
-      for (const constant of constants.filter((entry) => entry.file === file)) {
-        constant.select = resolveSpreads(constant.name, inFile)
-      }
+      constants.push(...readConstantsFromFile(repo, absolute, models))
     }
   }
 

--- a/doctor/src/verify-select-coverage.mjs
+++ b/doctor/src/verify-select-coverage.mjs
@@ -49,8 +49,7 @@
  */
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { join, relative, resolve } from 'node:path'
-import { reportNothingChecked } from './verify-selects.mjs'
-
+import { reportNothingChecked } from './doctor-repo-config.js'
 
 const SCHEMA_DIRECTORY_CANDIDATES = ['libs/api/prisma/src/lib/schemas', 'prisma', 'libs/api/prisma/src/lib']
 const DEFAULT_SEARCH_ROOTS = ['libs/api/custom/src', 'libs/api/core', 'apps/api/src']

--- a/doctor/src/verify-selects.mjs
+++ b/doctor/src/verify-selects.mjs
@@ -23,96 +23,23 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { basename, isAbsolute, join, relative, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
+import {
+  readRepoConfig as readRepoConfigInternal,
+  reportNothingChecked as reportNothingCheckedInternal,
+} from './doctor-repo-config.js'
 
 export const SCHEMA_DIRECTORY_CANDIDATES = ['libs/api/prisma/src/lib/schemas', 'prisma', 'libs/api/prisma/src/lib']
 
 export const DEFAULT_SEARCH_ROOTS = ['libs/api/custom/src', 'libs/api/core', 'apps/api/src']
 
-export const REPO_CONFIG_PATH = '.nestled-updates/doctor.config.json'
-
-export const DEFAULT_SELECT_FILE_SUFFIXES = ['.select.ts']
-
-/**
- * The few things about a repo's LAYOUT that enforcement cannot assume.
- *
- * Deliberately tiny, and deliberately not a general escape hatch: this declares where to look, never
- * what to accept. A repo that keeps select constants beside the resolver that owns them is laid out
- * differently, not held to a weaker rule.
- *
- * It exists because the alternative is editing the checker in place — which muzebook had to do, and
- * which stops being possible at all once these tools ship as a package.
- */
-export const readRepoConfig = (cwd = process.cwd()) => {
-  const configPath = resolve(cwd, REPO_CONFIG_PATH)
-  if (!existsSync(configPath)) return { selectFileSuffixes: DEFAULT_SELECT_FILE_SUFFIXES }
-
-  let parsed
-  try {
-    parsed = JSON.parse(readFileSync(configPath, 'utf8'))
-  } catch {
-    // Fail loudly rather than silently scanning nothing: a malformed config that quietly reverted
-    // to the default would make this checker pass by verifying an empty set.
-    throw new Error(`${REPO_CONFIG_PATH} is not valid JSON`)
-  }
-
-  // A config file that exists is a statement of intent to configure. Silently defaulting on a typoed
-  // key — or accepting an empty list — would scan zero files and pass, in exactly the repos that
-  // wrote this file BECAUSE the default finds nothing for them. Absent file: default. Present file:
-  // say what you mean.
-  const declared = parsed?.selectFileSuffixes
-  if (
-    !Array.isArray(declared) ||
-    declared.length === 0 ||
-    declared.some((suffix) => typeof suffix !== 'string' || !suffix)
-  ) {
-    throw new Error(`${REPO_CONFIG_PATH}: selectFileSuffixes must be a non-empty array of non-empty strings`)
-  }
-
-  // A repo may legitimately not use the select pattern at all -- 9 of the 11 repos in this fleet do
-  // not, both templates included. That is fine; what is not fine is a verifier reporting success
-  // for having examined nothing. Declaring it converts an invisible no-op into a recorded decision,
-  // and means a repo that DID have selects cannot lose them to a rename without the check noticing.
-  const absent = parsed?.noSelectFiles
-  if (absent !== undefined && (typeof absent !== 'string' || absent.trim() === '')) {
-    throw new Error(`${REPO_CONFIG_PATH}: noSelectFiles must be a non-empty string explaining why this repo has none`)
-  }
-
-  return { selectFileSuffixes: declared, noSelectFiles: absent }
-}
-
-/**
- * What a verifier should do when it checked nothing.
- *
- * Exit 0 after examining zero files is the failure mode this whole enforcement effort keeps
- * tripping over: the check stops looking and reports clean. A declaration makes the empty state
- * deliberate and visible; its absence makes it a failure with a message naming both ways out.
- */
-export const reportNothingChecked = (tool, cwd = process.cwd()) => {
-  let declared
-  try {
-    declared = readRepoConfig(cwd).noSelectFiles
-  } catch (error) {
-    // A malformed config is its own failure with its own fix. Swallowing it here would print the
-    // generic "checked 0 files" advice, which tells the reader to edit the very file that cannot
-    // be parsed -- and dressing a config error as a verification failure hides which one it is.
-    console.error(`\n${tool}: ${error.message}`)
-    return 2
-  }
-  if (declared) {
-    // stderr, so --json callers can parse stdout: a human-readable line on stdout would corrupt
-    // the machine-readable output for exactly the automated callers this exit code is for.
-    console.error(`\n${tool}: checked nothing, as declared in ${REPO_CONFIG_PATH} — ${declared}`)
-    return 0
-  }
-  console.error(
-    `\n${tool}: checked 0 files, so this run proves nothing.\n` +
-      `  If this repo uses the select pattern, the files moved or were renamed — set\n` +
-      `  selectFileSuffixes in ${REPO_CONFIG_PATH} to match.\n` +
-      `  If it genuinely has none, say so: "noSelectFiles": "<why>" in the same file.\n` +
-      `  Exiting non-zero because a check that examined nothing must not report success.`,
-  )
-  return 1
-}
+// Re-exported so existing callers and specs keep one import site. The definitions live in
+// doctor-repo-config.ts because the CommonJS fragment verifier cannot import an .mjs at all.
+export {
+  REPO_CONFIG_PATH,
+  DEFAULT_SELECT_FILE_SUFFIXES,
+  readRepoConfig,
+  reportNothingChecked,
+} from './doctor-repo-config.js'
 
 /**
  * Keys whose object value contains model FIELDS, so their contents are validated as columns.
@@ -249,7 +176,7 @@ const displayPath = (cwd, path) => {
 export const findSelectFiles = ({
   cwd = process.cwd(),
   roots = DEFAULT_SEARCH_ROOTS,
-  selectFileSuffixes = readRepoConfig(cwd).selectFileSuffixes,
+  selectFileSuffixes = readRepoConfigInternal(cwd).selectFileSuffixes,
 } = {}) => {
   const files = []
   const walk = (directory) => {
@@ -606,7 +533,7 @@ export const runCli = async (arguments_ = process.argv.slice(2), cwd = process.c
     })
     console.log(asJson ? JSON.stringify(result, null, 2) : renderText(result))
     if (result.problems.length || result.unresolved.length) return 1
-    return result.files === 0 ? reportNothingChecked('verify-selects', cwd) : 0
+    return result.files === 0 ? reportNothingCheckedInternal('verify-selects', cwd) : 0
   } catch (error) {
     const message = errorMessage(error)
     if (asJson) console.log(JSON.stringify({ error: message }, null, 2))

--- a/doctor/src/verify-selects.mjs
+++ b/doctor/src/verify-selects.mjs
@@ -33,7 +33,8 @@ export const SCHEMA_DIRECTORY_CANDIDATES = ['libs/api/prisma/src/lib/schemas', '
 export const DEFAULT_SEARCH_ROOTS = ['libs/api/custom/src', 'libs/api/core', 'apps/api/src']
 
 // Re-exported so existing callers and specs keep one import site. The definitions live in
-// doctor-repo-config.ts because the CommonJS fragment verifier cannot import an .mjs at all.
+// doctor-repo-config.js (typed by doctor-repo-config.d.ts) because the CommonJS fragment
+// verifier cannot import an .mjs at all.
 export {
   REPO_CONFIG_PATH,
   DEFAULT_SELECT_FILE_SUFFIXES,


### PR DESCRIPTION
**0.2.0 and 0.2.1 both shipped a broken `nestled-verify-fragments`.** Same seam, two mechanisms:

| release | what happened |
|---|---|
| 0.2.0 | static import of `.mjs` compiled to `require()` → `ERR_REQUIRE_ASYNC_MODULE`, bin could not start |
| 0.2.1 | dynamic `import()` — TypeScript downlevels that to `require()` too, pulling the `.mjs` into the CJS graph where its top-level `await` failed to transform |

The fragment verifier compiles to CommonJS; the config reader lived in an `.mjs`. Rather than negotiate with that boundary a third time, the shared config reader and the nothing-checked verdict move to a plain CommonJS module both sides load directly. `verify-selects` re-exports them so callers and specs keep one import site.

## Why 0.2.1 looked fine

The published 0.2.1 passes in muzebook, which has 65 select constants — it returns before reaching the new code. The break only appears on the **zero-checked path**, which is the path this whole change adds. Verified this time on exactly that path, from a clean packed install:

```
cashcast (0 select files, no declaration)      dev-template (0 files, declared)
  verify-selects          exit=1                 verify-selects          exit=0
  verify-select-coverage  exit=1                 verify-select-coverage  exit=0
  verify-fragments        exit=1                 verify-fragments        exit=0
  load errors: 0                                 load errors: 0
```

173 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMc46HinkqtzyyvRVpcaV8