### PR TITLE
fix: generated CRUD declares its permission without re-authenticating

### DIFF
--- a/doctor/package.json
+++ b/doctor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestledjs/doctor",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/doctor/src/doctor-access-policy-analysis.ts
+++ b/doctor/src/doctor-access-policy-analysis.ts
@@ -27,6 +27,9 @@ const policyDecorators = new Map<string, AccessPolicyScope>([
   ['RequireOrganizationPermission', 'organization'],
   ['RequireAllOrganizationPermissions', 'organization'],
   ['RequirePublicApiScopes', 'public-api'],
+  // Same policy, for a method whose class already authenticates -- generated CRUD. It declares a
+  // permission exactly as the composing variant does; only the guard wiring differs.
+  ['RequirePlatformPermissionUnderClassGuard', 'platform'],
 ])
 /** Exposed so doctor-auth-analysis can assert it recognizes the same decorators. */
 export const POLICY_DECORATOR_NAMES: readonly string[] = [...policyDecorators.keys()]

--- a/doctor/src/doctor-auth-analysis.ts
+++ b/doctor/src/doctor-auth-analysis.ts
@@ -29,6 +29,7 @@ const accessPolicyDecorators = new Set([
   'RequireOrganizationPermission',
   'RequireAllOrganizationPermissions',
   'RequirePublicApiScopes',
+  'RequirePlatformPermissionUnderClassGuard',
 ])
 /** Exposed so the spec can assert this stays in step with the access-policy map. */
 export const ACCESS_POLICY_DECORATOR_NAMES: readonly string[] = [...accessPolicyDecorators]

--- a/generators/package.json
+++ b/generators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestledjs/generators",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "generators": "./generators.json",
   "type": "commonjs",
   "main": "./src/index.js",

--- a/generators/src/crud/generator.spec.ts
+++ b/generators/src/crud/generator.spec.ts
@@ -173,14 +173,14 @@ describe('generate-crud generator', () => {
 
       expect(source).toContain("import { UseGuards } from '@nestjs/common'")
       expect(source).toContain(
-        "import { AdminOnly, GqlAuthAdminGuard, RequirePlatformPermission } from '@scope/api/utils'",
+        "import { AdminOnly, GqlAuthAdminGuard, RequirePlatformPermissionUnderClassGuard } from '@scope/api/utils'",
       )
       expect(source).toContain(
         '@Resolver(() => User)\n@UseGuards(GqlAuthAdminGuard)\n@AdminOnly()\nexport class GeneratedUserResolver',
       )
       expect(source.match(/@AdminOnly\(\)/g)).toHaveLength(1)
-      expect(source.match(/@RequirePlatformPermission\('platform\.data-browser\.read'\)/g)).toHaveLength(3)
-      expect(source.match(/@RequirePlatformPermission\('platform\.data-browser\.manage'\)/g)).toHaveLength(3)
+      expect(source.match(/@RequirePlatformPermissionUnderClassGuard\('platform\.data-browser\.read'\)/g)).toHaveLength(3)
+      expect(source.match(/@RequirePlatformPermissionUnderClassGuard\('platform\.data-browser\.manage'\)/g)).toHaveLength(3)
       expect(source).not.toContain('@Public()')
       expect(source).not.toContain('@Authenticated()')
       expect(source).not.toContain('GqlAuthGuard')
@@ -212,7 +212,7 @@ describe('generate-crud generator', () => {
       expect(source).toContain('@UseGuards(GqlAuthGuard)\n@Authenticated()')
       expect(source).not.toContain('AdminOnly')
       expect(source).not.toContain('GqlAuthAdminGuard')
-      expect(source).not.toContain('RequirePlatformPermission')
+      expect(source).not.toContain('RequirePlatformPermissionUnderClassGuard')
     })
 
     it('defaults to admin, quietly, when no posture file exists', async () => {

--- a/generators/src/crud/generator.ts
+++ b/generators/src/crud/generator.ts
@@ -91,12 +91,22 @@ export function generateResolverContent(
     posture === 'authenticated'
       ? { imports: 'Authenticated, GqlAuthGuard', guardClass: 'GqlAuthGuard', decorator: '@Authenticated()' }
       : {
-          imports: 'AdminOnly, GqlAuthAdminGuard, RequirePlatformPermission',
+          imports: 'AdminOnly, GqlAuthAdminGuard, RequirePlatformPermissionUnderClassGuard',
           guardClass: 'GqlAuthAdminGuard',
           decorator: '@AdminOnly()',
         }
-  const readPermission = posture === 'admin' ? "  @RequirePlatformPermission('platform.data-browser.read')\n" : ''
-  const managePermission = posture === 'admin' ? "  @RequirePlatformPermission('platform.data-browser.manage')\n" : ''
+  // The ...UnderClassGuard variant, not RequirePlatformPermission: the class already carries
+  // GqlAuthAdminGuard, and the composing decorator would add a second JWT verification plus an
+  // organization-context preload on every call, then override the class's @AdminOnly() with its own
+  // @Authenticated() -- leaving each root declaring a weaker level than the guard enforces.
+  const readPermission =
+    posture === 'admin'
+      ? "  @RequirePlatformPermissionUnderClassGuard('platform.data-browser.read')\n"
+      : ''
+  const managePermission =
+    posture === 'admin'
+      ? "  @RequirePlatformPermissionUnderClassGuard('platform.data-browser.manage')\n"
+      : ''
 
   return `import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, Query, Resolver, Info } from '@nestjs/graphql'


### PR DESCRIPTION
Found in review of dev-template#172, against a change **I** had described as adding metadata only. The lines were only that; what they did was not.

## The bug

```ts
RequirePlatformPermission = applyDecorators(
  Authenticated(),                          // ← sets AUTH_LEVEL_KEY = 'authenticated'
  SetMetadata(ACCESS_POLICY_KEY, policy),
  UseGuards(GqlAuthGuard, AccessPolicyGuard),
)
```

Correct on a bare resolver. Wrong on a generated one, whose class already carries `@UseGuards(GqlAuthAdminGuard)` + `@AdminOnly()`. Emitted there, across 138 roots in the template alone:

**A second JWT verification and an organization-context preload per call.** Both guards extend `AuthGuard('jwt')`, and `GqlAuthGuard.canActivate` calls `organizationContextService.attach(req)` — a database round trip, for platform-scoped admin work that has no organization to preload.

**And a downgraded declaration.** `GlobalAuthGuard` resolves the level with `getAllAndOverride([handler, controller])` — the handler wins. So the method's `Authenticated()` overrode the class's `AdminOnly()`, and every generated root *declared* `authenticated` while the class guard still *enforced* admin. Nothing became reachable that was not before, but the declaration was wrong — and it is the declaration the doctor's own auth-level analysis reads.

## The fix

`RequirePlatformPermissionUnderClassGuard` — same policy metadata, `AccessPolicyGuard` only, no auth level. That guard authenticates nothing (it throws when `request.user` is absent), so it is correct **only** under a class-level authenticating guard. Said plainly in the doc comment and the upgrade note, because the failure mode is a runtime 401 rather than a review comment.

The doctor recognizes it in both decorator lists; the sync spec keeps them together.

## Verified end to end

Regenerating the template with the built packages is a clean one-for-one swap:

```
138  @RequirePlatformPermissionUnderClassGuard(…)   added
138  @RequirePlatformPermission(…)                  removed
 23  import rewrites each way
161 insertions, 161 deletions — nothing else

access-policy 0 · auth-level 0 · api build passes
```

Two specs pin the distinction: the new decorator sets the same policy, and sets **no** auth level, so a class-level `AdminOnly()` survives.

## Release

`doctor 0.3.1`, `generators 3.2.1`. **3.2.0 should not be adopted** — it emits the composing decorator. 3.2.1 also requires the new decorator to exist in `api/utils`, so the template change lands first or regeneration produces code that does not compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMc46HinkqtzyyvRVpcaV8